### PR TITLE
BXC-3171 - Unpaged record exports

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
@@ -33,7 +33,8 @@ import picocli.CommandLine.Option;
  */
 @Command(subcommands = {
         InitializeProjectCommand.class,
-        CdmFieldsCommand.class
+        CdmFieldsCommand.class,
+        CdmExportCommand.class
     })
 public class CLIMain implements Callable<Integer> {
     @Option(names = { "-w", "--work-dir" },

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommand.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm;
+
+import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.services.CdmExportService;
+import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+/**
+ * @author bbpennel
+ */
+@Command(name = "export",
+        description = "Export records for a collection from CDM")
+public class CdmExportCommand implements Callable<Integer> {
+    @ParentCommand
+    private CLIMain parentCommand;
+
+    @Option(names = { "--cdm-url" },
+            description = {"Base URL to the CDM web service API. Falls back to CDM_BASE_URL env variable.",
+                    "Default: ${DEFAULT-VALUE}"},
+            defaultValue = "${env:CDM_BASE_URL:-http://localhost:82/}")
+    private String cdmBaseUri;
+    @Option(names = { "-u", "--cdm-user"},
+            description = {"User name for CDM requests.",
+                    "Defaults to current user: ${DEFAULT-VALUE}"},
+            defaultValue = "${sys:user.name}")
+    private String cdmUsername;
+    @Option(names = {"-p", "--cdm-password"},
+            description = "Password for CDM requests. Required.",
+            arity = "0..1",
+            interactive = true)
+    private String cdmPassword;
+
+    private CdmFieldService fieldService;
+    private CdmExportService exportService;
+
+    @Override
+    public Integer call() throws Exception {
+        long start = System.nanoTime();
+
+        try {
+            initializeServices();
+
+            Path currentPath = parentCommand.getWorkingDirectory();
+            MigrationProject project = MigrationProjectFactory.loadMigrationProject(currentPath);
+            exportService.exportAll(project);
+
+            outputLogger.info("Exported project {} in {}s", project.getProjectName(),
+                    (System.nanoTime() - start) / 1e9);
+            return 0;
+        } catch (MigrationException e) {
+            outputLogger.info("Failed to export project: {}", e.getMessage());
+            return 1;
+        }
+    }
+
+    public void initializeServices() {
+        fieldService = new CdmFieldService();
+        exportService = new CdmExportService();
+        exportService.setCdmBaseUri(cdmBaseUri);
+        exportService.setCdmFieldService(fieldService);
+        initializeAuthenticatedCdmClient();
+
+    }
+
+    private void initializeAuthenticatedCdmClient() {
+        if (StringUtils.isBlank(cdmUsername)) {
+            throw new MigrationException("Must provided a CDM username");
+        }
+        if (StringUtils.isBlank(cdmPassword)) {
+            throw new MigrationException("Must provided a CDM password for user " + cdmUsername);
+        }
+
+        CredentialsProvider credsProvider = new BasicCredentialsProvider();
+        outputLogger.info("Initializing connection to {}", URI.create(cdmBaseUri).getHost());
+        AuthScope scope = new AuthScope(new HttpHost(URI.create(cdmBaseUri).getHost()));
+        credsProvider.setCredentials(scope, new UsernamePasswordCredentials(cdmUsername, cdmPassword));
+
+        CloseableHttpClient httpClient = HttpClients.custom()
+                .setDefaultCredentialsProvider(credsProvider)
+                .useSystemProperties()
+                .build();
+
+        exportService.setHttpClient(httpClient);
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommand.java
@@ -45,8 +45,9 @@ public class InitializeProjectCommand implements Callable<Integer> {
     private CLIMain parentCommand;
 
     @Option(names = { "--cdm-url" },
-            description = "Base URL to the CDM web service API",
-            defaultValue = "http://localhost:82/")
+            description = "Base URL to the CDM web service API. Falls back to CDM_BASE_URL env variable. "
+                    + "Default: ${DEFAULT-VALUE}",
+            defaultValue = "${env:CDM_BASE_URL:-http://localhost:82/}")
     private String cdmBaseUri;
     @Option(names = { "-c", "--cdm-coll-id" },
             description = "Identifier of the CDM collection to migrate. Use if the name of the project directory"
@@ -66,7 +67,6 @@ public class InitializeProjectCommand implements Callable<Integer> {
         httpClient = HttpClients.createMinimal();
         fieldService = new CdmFieldService();
         fieldService.setHttpClient(httpClient);
-        fieldService.setCdmBaseUri(cdmBaseUri);
     }
 
     @Override

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 public class MigrationProject {
     public static final String PROJECT_PROPERTIES_FILENAME = "project.json";
     public static final String DESCRIPTION_DIRNAME = "descriptions";
+    public static final String EXPORT_DIRNAME = "exports";
     public static final String FIELD_NAMES_FILENAME = "cdm_fields.csv";
 
     private Path projectPath;
@@ -56,6 +57,13 @@ public class MigrationProject {
     }
 
     /**
+     * @return Path to directory where CDM Record exports should be stored
+     */
+    public Path getExportPath() {
+        return projectPath.resolve(EXPORT_DIRNAME);
+    }
+
+    /**
      * @return Properties describing this project
      */
     public MigrationProjectProperties getProjectProperties() {
@@ -71,5 +79,12 @@ public class MigrationProject {
      */
     public Path getDescriptionsPath() {
         return projectPath.resolve(DESCRIPTION_DIRNAME);
+    }
+
+    /**
+     * @return Name of the project
+     */
+    public String getProjectName() {
+        return properties.getName();
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.services;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.slf4j.Logger;
+
+import edu.unc.lib.boxc.common.util.URIUtil;
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+
+/**
+ * Service for exporting CDM item records
+ * @author bbpennel
+ */
+public class CdmExportService {
+    private static final Logger log = getLogger(CdmExportService.class);
+
+    private CloseableHttpClient httpClient;
+    private String cdmBaseUri;
+    private CdmFieldService cdmFieldService;
+
+    public CdmExportService() {
+    }
+
+    /**
+     * Export all records from CDM for the provided project
+     * @param project
+     * @throws IOException
+     */
+    public void exportAll(MigrationProject project) throws IOException {
+        // Generate body of export request using the list of fields configure for export
+        cdmFieldService.validateFieldsFile(project);
+        CdmFieldInfo fieldInfo = cdmFieldService.loadFieldsFromProject(project);
+        String fieldParams = fieldInfo.getFields().stream()
+                .filter(f -> !f.getSkipExport())
+                .map(f -> f.getNickName() + "=" + f.getExportAs())
+                .collect(Collectors.joining("&"));
+        String bodyParams = "CISODB=%2F" + project.getProjectProperties().getCdmCollectionId()
+                + "&CISOTYPE=standard&CISOPAGE=1&" + fieldParams;
+
+        // Trigger the export
+        String exportReqUrl = URIUtil.join(cdmBaseUri, "cgi-bin/admin/exportxml.exe");
+        log.debug("Requesting export from {}", exportReqUrl);
+        HttpPost postMethod = new HttpPost(exportReqUrl);
+        postMethod.setEntity(new StringEntity(bodyParams, ISO_8859_1));
+        try (CloseableHttpResponse resp = httpClient.execute(postMethod)) {
+            if (resp.getStatusLine().getStatusCode() != 200) {
+                throw new MigrationException("Failed to request export (" + resp.getStatusLine().getStatusCode()
+                        + "): " + IOUtils.toString(resp.getEntity().getContent(), ISO_8859_1));
+            }
+        }
+
+        // Retrieve the export results
+        Path exportFilePath = project.getExportPath().resolve("export_all.xml");
+        downloadExport(project, exportFilePath);
+    }
+
+    private void initializeExportDir(MigrationProject project) throws IOException {
+        Files.createDirectories(project.getExportPath());
+    }
+
+    private void downloadExport(MigrationProject project, Path exportFilePath) throws IOException {
+        String uri = URIUtil.join(cdmBaseUri, "cgi-bin/admin/getfile.exe?")
+                + "CISOMODE=1&CISOFILE=/" + project.getProjectProperties().getCdmCollectionId()
+                + "/index/description/export.xml";
+        log.debug("Downloading export from {}", uri);
+        HttpGet getMethod = new HttpGet(uri);
+        try (CloseableHttpResponse resp = httpClient.execute(getMethod)) {
+            if (resp.getStatusLine().getStatusCode() >= 400) {
+                throw new MigrationException("Failed to download export (" + resp.getStatusLine().getStatusCode()
+                        + "): " + IOUtils.toString(resp.getEntity().getContent(), ISO_8859_1));
+            }
+            initializeExportDir(project);
+            Files.copy(resp.getEntity().getContent(), exportFilePath, StandardCopyOption.REPLACE_EXISTING);
+            log.debug("Downloaded export to file {}", exportFilePath);
+        }
+    }
+
+    public void setHttpClient(CloseableHttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    public void setCdmBaseUri(String cdmBaseUri) {
+        this.cdmBaseUri = cdmBaseUri;
+    }
+
+    public void setCdmFieldService(CdmFieldService cdmFieldService) {
+        this.cdmFieldService = cdmFieldService;
+    }
+}

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractCommandIT.java
@@ -73,6 +73,8 @@ public class AbstractCommandIT {
         if (result != 0) {
             System.setOut(originalOut);
             log.error(output);
+            // Can't see the output from the command without this
+            System.out.println(output);
             fail("Expected command to result in success: " + String.join(" ", args));
         }
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
+import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo.CdmFieldEntry;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+
+/**
+ * @author bbpennel
+ */
+public class CdmExportCommandIT extends AbstractCommandIT {
+
+    private final static String COLLECTION_ID = "my_coll";
+    private final static String PASSWORD = "supersecret";
+    private final static String BODY_RESP = "<xml>record</xml>";
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
+
+    private CdmFieldService fieldService;
+    private String cdmBaseUrl;
+
+    @Before
+    public void setUp() throws Exception {
+        fieldService = new CdmFieldService();
+        cdmBaseUrl = "http://localhost:" + wireMockRule.port();
+
+        stubFor(post(urlEqualTo("/cgi-bin/admin/exportxml.exe"))
+                .willReturn(aResponse()
+                        .withStatus(200)));
+        stubFor(get(urlEqualTo("/cgi-bin/admin/getfile.exe?CISOMODE=1&CISOFILE=/my_coll/index/description/export.xml"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/octet-stream")
+                        .withBody(BODY_RESP)));
+    }
+
+    @Test
+    public void exportValidProjectTest() throws Exception {
+        Path projPath = createProject();
+
+        String[] args = new String[] {
+                "-w", projPath.toString(),
+                "export",
+                "--cdm-url", cdmBaseUrl,
+                "-p", PASSWORD };
+        executeExpectSuccess(args);
+
+        MigrationProject project = MigrationProjectFactory.loadMigrationProject(projPath);
+
+        assertTrue("Export folder not created", Files.exists(project.getExportPath()));
+        assertEquals(BODY_RESP, FileUtils.readFileToString(
+                project.getExportPath().resolve("export_all.xml").toFile(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void noUsernameTest() throws Exception {
+        System.clearProperty("user.name");
+        Path projPath = createProject();
+
+        String[] args = new String[] {
+                "-w", projPath.toString(),
+                "export",
+                "--cdm-url", cdmBaseUrl,
+                "-p", PASSWORD };
+        executeExpectFailure(args);
+
+        MigrationProject project = MigrationProjectFactory.loadMigrationProject(projPath);
+        assertFalse("Description folder should not be created", Files.exists(project.getExportPath()));
+        assertTrue(output.contains("Must provided a CDM username"));
+    }
+
+    @Test
+    public void noPasswordTest() throws Exception {
+        Path projPath = createProject();
+
+        String[] args = new String[] {
+                "-w", projPath.toString(),
+                "export",
+                "--cdm-url", cdmBaseUrl };
+        executeExpectFailure(args);
+
+        MigrationProject project = MigrationProjectFactory.loadMigrationProject(projPath);
+        assertFalse("Description folder should not be created", Files.exists(project.getExportPath()));
+        assertTrue(output.contains("Must provided a CDM password"));
+    }
+
+    @Test
+    public void errorResponseTest() throws Exception {
+        stubFor(post(urlEqualTo("/cgi-bin/admin/exportxml.exe"))
+                .willReturn(aResponse()
+                        .withStatus(400)));
+
+        Path projPath = createProject();
+
+        String[] args = new String[] {
+                "-w", projPath.toString(),
+                "export",
+                "--cdm-url", cdmBaseUrl,
+                "-p", PASSWORD };
+        executeExpectFailure(args);
+
+        MigrationProject project = MigrationProjectFactory.loadMigrationProject(projPath);
+
+        assertFalse("Description folder should not be created", Files.exists(project.getExportPath()));
+        assertTrue(output.contains("Failed to request export"));
+    }
+
+    private Path createProject() throws Exception {
+        MigrationProject project = MigrationProjectFactory.createMigrationProject(
+                baseDir, COLLECTION_ID, null, USERNAME);
+        CdmFieldInfo fieldInfo = new CdmFieldInfo();
+        CdmFieldEntry fieldEntry = new CdmFieldEntry();
+        fieldEntry.setNickName("title");
+        fieldEntry.setExportAs("titla");
+        fieldEntry.setDescription("Title");
+        fieldInfo.getFields().add(fieldEntry);
+        CdmFieldEntry fieldEntry2 = new CdmFieldEntry();
+        fieldEntry2.setNickName("title2");
+        fieldEntry2.setExportAs("titlb");
+        fieldEntry2.setDescription("Another Title");
+        fieldInfo.getFields().add(fieldEntry2);
+        fieldService.persistFieldsToProject(project, fieldInfo);
+        return project.getProjectPath();
+    }
+}

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
@@ -1,0 +1,215 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.services;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.ByteArrayInputStream;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
+import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo.CdmFieldEntry;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+
+/**
+ * @author bbpennel
+ */
+public class CdmExportServiceTest {
+    private static final String CDM_BASE_URL = "http://example.com:88/";
+    private static final String PROJECT_NAME = "proj";
+    private static final String EXPORT_BODY = "<xml><rec>1</rec></xml>";
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private MigrationProject project;
+    private CdmFieldService fieldService;
+    private CdmExportService service;
+    @Mock
+    private CloseableHttpClient httpClient;
+    @Mock
+    private CloseableHttpResponse getResp;
+    @Mock
+    private StatusLine getStatus;
+    @Mock
+    private CloseableHttpResponse postResp;
+    @Mock
+    private StatusLine postStatus;
+    @Mock
+    private HttpEntity postEntity;
+    @Mock
+    private HttpEntity getEntity;
+    @Captor
+    private ArgumentCaptor<HttpUriRequest> requestCaptor;
+
+    @Before
+    public void setup() throws Exception {
+        initMocks(this);
+        tmpFolder.create();
+        project = MigrationProjectFactory.createMigrationProject(
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user");
+        fieldService = new CdmFieldService();
+
+        service = new CdmExportService();
+        service.setHttpClient(httpClient);
+        service.setCdmBaseUri(CDM_BASE_URL);
+        service.setCdmFieldService(fieldService);
+
+        // Mockito any matcher not differentiating between the different HttpPost/HttpGet params
+        when(httpClient.execute(any())).thenReturn(postResp).thenReturn(getResp);
+        when(getResp.getStatusLine()).thenReturn(getStatus);
+        when(postResp.getStatusLine()).thenReturn(postStatus);
+        when(postResp.getEntity()).thenReturn(postEntity);
+        when(getResp.getEntity()).thenReturn(getEntity);
+        when(getEntity.getContent()).thenReturn(new ByteArrayInputStream(EXPORT_BODY.getBytes()));
+    }
+
+    @Test
+    public void exportAllValidProjectTest() throws Exception {
+        CdmFieldInfo fieldInfo = populateFieldInfo();
+        fieldService.persistFieldsToProject(project, fieldInfo);
+
+        when(postStatus.getStatusCode()).thenReturn(200);
+        when(getStatus.getStatusCode()).thenReturn(200);
+
+        service.exportAll(project);
+
+        verify(httpClient, times(2)).execute(requestCaptor.capture());
+        List<HttpUriRequest> requests = requestCaptor.getAllValues();
+        HttpPost httpPost = (HttpPost) requests.get(0);
+        String postBody = IOUtils.toString(httpPost.getEntity().getContent(), ISO_8859_1);
+        Map<String, String> submittedParams = Arrays.stream(postBody.split("&"))
+            .collect(Collectors.toMap(f -> f.split("=")[0], f -> f.split("=")[1]));
+        assertEquals("1", submittedParams.get("CISOPAGE"));
+        assertEquals("standard", submittedParams.get("CISOTYPE"));
+        assertEquals("%2F" + PROJECT_NAME, submittedParams.get("CISODB"));
+        assertEquals("title", submittedParams.get("title"));
+        assertEquals("description", submittedParams.get("desc"));
+
+        assertTrue("Export folder not created", Files.exists(project.getExportPath()));
+        assertEquals(EXPORT_BODY, FileUtils.readFileToString(
+                project.getExportPath().resolve("export_all.xml").toFile(), ISO_8859_1));
+    }
+
+    @Test
+    public void exportAllExportFailureTest() throws Exception {
+        CdmFieldInfo fieldInfo = populateFieldInfo();
+        fieldService.persistFieldsToProject(project, fieldInfo);
+
+        when(postStatus.getStatusCode()).thenReturn(400);
+        when(postEntity.getContent()).thenReturn(new ByteArrayInputStream("bad".getBytes()));
+        when(getStatus.getStatusCode()).thenReturn(200);
+
+        try {
+            service.exportAll(project);
+            fail();
+        } catch (MigrationException e) {
+            // Should only have made one call
+            verify(httpClient).execute(any());
+            assertFalse("Export folder should not exist", Files.exists(project.getExportPath()));
+        }
+    }
+
+    @Test
+    public void exportAllDownloadFailureTest() throws Exception {
+        CdmFieldInfo fieldInfo = populateFieldInfo();
+        fieldService.persistFieldsToProject(project, fieldInfo);
+
+        when(postStatus.getStatusCode()).thenReturn(200);
+        when(getStatus.getStatusCode()).thenReturn(400);
+
+        try {
+            service.exportAll(project);
+            fail();
+        } catch (MigrationException e) {
+            verify(httpClient, times(2)).execute(any());
+            assertFalse("Export folder should not exist", Files.exists(project.getExportPath()));
+        }
+    }
+
+    @Test
+    public void exportAllSkipFieldTest() throws Exception {
+        CdmFieldInfo fieldInfo = populateFieldInfo();
+        fieldInfo.getFields().get(1).setSkipExport(true);
+        fieldService.persistFieldsToProject(project, fieldInfo);
+
+        when(postStatus.getStatusCode()).thenReturn(200);
+        when(getStatus.getStatusCode()).thenReturn(200);
+
+        service.exportAll(project);
+
+        verify(httpClient, times(2)).execute(requestCaptor.capture());
+        List<HttpUriRequest> requests = requestCaptor.getAllValues();
+        HttpPost httpPost = (HttpPost) requests.get(0);
+        String postBody = IOUtils.toString(httpPost.getEntity().getContent(), ISO_8859_1);
+        Map<String, String> submittedParams = Arrays.stream(postBody.split("&"))
+            .collect(Collectors.toMap(f -> f.split("=")[0], f -> f.split("=")[1]));
+        assertEquals("1", submittedParams.get("CISOPAGE"));
+        assertEquals("standard", submittedParams.get("CISOTYPE"));
+        assertEquals("%2F" + PROJECT_NAME, submittedParams.get("CISODB"));
+        assertEquals("title", submittedParams.get("title"));
+        assertFalse("Must not include skipped field", submittedParams.containsKey("desc"));
+
+        assertTrue("Export folder not created", Files.exists(project.getExportPath()));
+        assertEquals(EXPORT_BODY, FileUtils.readFileToString(
+                project.getExportPath().resolve("export_all.xml").toFile(), ISO_8859_1));
+    }
+
+    private CdmFieldInfo populateFieldInfo() {
+        CdmFieldInfo fieldInfo = new CdmFieldInfo();
+        List<CdmFieldEntry> fields = fieldInfo.getFields();
+        CdmFieldEntry field1 = new CdmFieldEntry();
+        field1.setNickName("title");
+        field1.setExportAs("title");
+        field1.setDescription("Title");
+        fields.add(field1);
+        CdmFieldEntry field2 = new CdmFieldEntry();
+        field2.setNickName("desc");
+        field2.setExportAs("description");
+        field2.setDescription("Abstract");
+        fields.add(field2);
+        return fieldInfo;
+    }
+}


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3171
* Adds command and service for exporting CDM records as XML based on field config for small collections that don't requiring exporting in pages