### PR TITLE
BXC-3173 - Index of flat collections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <properties>
         <picocli.version>4.6.1</picocli.version>
         <wiremock.version>2.27.2</wiremock.version>
+        <sqlite-jdbc.version>3.36.0.1</sqlite-jdbc.version>
 
         <build-tools.path></build-tools.path>
     </properties>
@@ -129,6 +130,12 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>${jackson.version}</version>
+        </dependency>
+        <!-- Database -->
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>${sqlite-jdbc.version}</version>
         </dependency>
         <!-- Logging -->
         <dependency>

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
@@ -34,7 +34,8 @@ import picocli.CommandLine.Option;
 @Command(subcommands = {
         InitializeProjectCommand.class,
         CdmFieldsCommand.class,
-        CdmExportCommand.class
+        CdmExportCommand.class,
+        CdmIndexCommand.class
     })
 public class CLIMain implements Callable<Integer> {
     @Option(names = { "-w", "--work-dir" },

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommand.java
@@ -35,6 +35,7 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.CdmExportService;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
@@ -77,6 +78,8 @@ public class CdmExportCommand implements Callable<Integer> {
             Path currentPath = parentCommand.getWorkingDirectory();
             MigrationProject project = MigrationProjectFactory.loadMigrationProject(currentPath);
             exportService.exportAll(project);
+
+            ProjectPropertiesSerialization.write(project.getProjectPropertiesPath(), project.getProjectProperties());
 
             outputLogger.info("Exported project {} in {}s", project.getProjectName(),
                     (System.nanoTime() - start) / 1e9);

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommand.java
@@ -35,7 +35,6 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.CdmExportService;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
-import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
@@ -78,8 +77,6 @@ public class CdmExportCommand implements Callable<Integer> {
             Path currentPath = parentCommand.getWorkingDirectory();
             MigrationProject project = MigrationProjectFactory.loadMigrationProject(currentPath);
             exportService.exportAll(project);
-
-            ProjectPropertiesSerialization.write(project.getProjectPropertiesPath(), project.getProjectProperties());
 
             outputLogger.info("Exported project {} in {}s", project.getProjectName(),
                     (System.nanoTime() - start) / 1e9);

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmIndexCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmIndexCommand.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm;
+
+import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+import org.slf4j.Logger;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.StateAlreadyExistsException;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
+import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+/**
+ * @author bbpennel
+ */
+@Command(name = "index",
+        description = "Index the exported CDM records for this project. Must be run after a complete export.")
+public class CdmIndexCommand implements Callable<Integer> {
+    private static final Logger log = getLogger(CdmIndexCommand.class);
+    @ParentCommand
+    private CLIMain parentCommand;
+
+    @Option(names = { "-f", "--force"},
+            description = "Overwrite index if one already exists")
+    private boolean force;
+
+    private CdmFieldService fieldService;
+    private CdmIndexService indexService;
+    private MigrationProject project;
+
+    @Override
+    public Integer call() throws Exception {
+        long start = System.nanoTime();
+
+        try {
+            initialize();
+
+            indexService.createDatabase(force);
+            indexService.indexAll();
+            outputLogger.info("Indexed project {} in {}s", project.getProjectName(),
+                    (System.nanoTime() - start) / 1e9);
+            return 0;
+        } catch (StateAlreadyExistsException e) {
+            outputLogger.info("Cannot index project: {}", e.getMessage());
+            return 1;
+        } catch (Exception e) {
+            log.error("Failed to export project", e);
+            outputLogger.info("Failed to export project: {}", e.getMessage(), e);
+            indexService.removeIndex();
+            return 1;
+        }
+    }
+
+    private void initialize() throws IOException {
+        Path currentPath = parentCommand.getWorkingDirectory();
+        project = MigrationProjectFactory.loadMigrationProject(currentPath);
+        fieldService = new CdmFieldService();
+        indexService = new CdmIndexService();
+        indexService.setFieldService(fieldService);
+        indexService.setProject(project);
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/exceptions/StateAlreadyExistsException.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/exceptions/StateAlreadyExistsException.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.exceptions;
+
+/**
+ * Exception thrown when a project already contains files or state information
+ * @author bbpennel
+ */
+public class StateAlreadyExistsException extends MigrationException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @param message
+     */
+    public StateAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/CdmFieldInfo.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/CdmFieldInfo.java
@@ -17,7 +17,9 @@ package edu.unc.lib.boxc.migration.cdm.model;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -30,6 +32,8 @@ import org.apache.jena.ext.com.google.common.collect.Streams;
  */
 public class CdmFieldInfo {
     public static final String CDM_ID = "cdmid";
+    public static final Set<String> IGNORE_FIELDS = new HashSet<>(Arrays.asList(
+            "dmoclcno", "dmcreated", "dmmodified", "dmrecord"));
     public static final List<String> RESERVED_FIELDS = Arrays.asList(
             CDM_ID, "cdmcreated", "cdmmodified", "cdmfile", "cdmpath");
 
@@ -52,7 +56,7 @@ public class CdmFieldInfo {
      */
     public List<String> listExportFields() {
         Stream<String> exportFields = getFields().stream()
-                .filter(f -> !f.getSkipExport())
+                .filter(f -> !f.getSkipExport() && !IGNORE_FIELDS.contains(f.getExportAs()))
                 .map(CdmFieldEntry::getExportAs);
         return Streams.concat(exportFields, RESERVED_FIELDS.stream()).collect(Collectors.toList());
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/CdmFieldInfo.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/CdmFieldInfo.java
@@ -16,7 +16,12 @@
 package edu.unc.lib.boxc.migration.cdm.model;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.jena.ext.com.google.common.collect.Streams;
 
 /**
  * Information describing the fields present in a CDM collection
@@ -24,6 +29,10 @@ import java.util.List;
  * @author bbpennel
  */
 public class CdmFieldInfo {
+    public static final String CDM_ID = "cdmid";
+    public static final List<String> RESERVED_FIELDS = Arrays.asList(
+            CDM_ID, "cdmcreated", "cdmmodified", "cdmfile", "cdmpath");
+
     private List<CdmFieldEntry> fields;
 
     public CdmFieldInfo() {
@@ -36,6 +45,16 @@ public class CdmFieldInfo {
 
     public void setFields(List<CdmFieldEntry> fields) {
         this.fields = fields;
+    }
+
+    /**
+     * @return List of all the exported fields, including reserved CDM fields
+     */
+    public List<String> listExportFields() {
+        Stream<String> exportFields = getFields().stream()
+                .filter(f -> !f.getSkipExport())
+                .map(CdmFieldEntry::getExportAs);
+        return Streams.concat(exportFields, RESERVED_FIELDS.stream()).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
@@ -27,6 +27,7 @@ public class MigrationProject {
     public static final String DESCRIPTION_DIRNAME = "descriptions";
     public static final String EXPORT_DIRNAME = "exports";
     public static final String FIELD_NAMES_FILENAME = "cdm_fields.csv";
+    public static final String INDEX_FILENAME = "cdm_index.db";
 
     private Path projectPath;
     private MigrationProjectProperties properties;
@@ -79,6 +80,13 @@ public class MigrationProject {
      */
     public Path getDescriptionsPath() {
         return projectPath.resolve(DESCRIPTION_DIRNAME);
+    }
+
+    /**
+     * @return Path of the index containing exported CDM data
+     */
+    public Path getIndexPath() {
+        return projectPath.resolve(INDEX_FILENAME);
     }
 
     /**

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
@@ -27,6 +27,8 @@ public class MigrationProjectProperties {
     private String cdmCollectionId;
     private Instant createdDate;
     private String creator;
+    private Instant exportedDate;
+    private Instant indexedDate;
 
     public MigrationProjectProperties() {
     }
@@ -62,6 +64,28 @@ public class MigrationProjectProperties {
 
     public void setCreatedDate(Instant createdDate) {
         this.createdDate = createdDate;
+    }
+
+    /**
+     * @return timestamp of the last full successful CDM record export
+     */
+    public Instant getExportedDate() {
+        return exportedDate;
+    }
+
+    public void setExportedDate(Instant exportedDate) {
+        this.exportedDate = exportedDate;
+    }
+
+    /**
+     * @return timestamp of the last full successful CDM record indexing
+     */
+    public Instant getIndexedDate() {
+        return indexedDate;
+    }
+
+    public void setIndexedDate(Instant indexedDate) {
+        this.indexedDate = indexedDate;
     }
 
     /**

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
@@ -37,6 +37,7 @@ import edu.unc.lib.boxc.common.util.URIUtil;
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 
 /**
  * Service for exporting CDM item records
@@ -85,6 +86,7 @@ public class CdmExportService {
         downloadExport(project, exportFilePath);
 
         project.getProjectProperties().setExportedDate(Instant.now());
+        ProjectPropertiesSerialization.write(project);
     }
 
     private void initializeExportDir(MigrationProject project) throws IOException {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.time.Instant;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
@@ -82,6 +83,8 @@ public class CdmExportService {
         // Retrieve the export results
         Path exportFilePath = project.getExportPath().resolve("export_all.xml");
         downloadExport(project, exportFilePath);
+
+        project.getProjectProperties().setExportedDate(Instant.now());
     }
 
     private void initializeExportDir(MigrationProject project) throws IOException {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
@@ -42,6 +42,7 @@ import org.slf4j.Logger;
 import edu.unc.lib.boxc.common.xml.SecureXMLFactory;
 import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.exceptions.StateAlreadyExistsException;
 import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
@@ -81,13 +82,10 @@ public class CdmIndexService {
                 indexDocument(doc, conn, insertTemplate, exportFields);
             }
         } catch (IOException e) {
-            log.error("Failed to read export files", e);
             throw new MigrationException("Failed to read export files: " + e.getMessage());
         } catch (SQLException e) {
-            log.error("Failed to update database", e);
             throw new MigrationException("Failed to update database: " + e.getMessage());
         } catch (JDOMException e) {
-            log.error("Failed to parse export file", e);
             throw new MigrationException("Failed to parse export file: " + e.getMessage());
         } finally {
             closeDbConnection(conn);
@@ -173,7 +171,7 @@ public class CdmIndexService {
                     throw new MigrationException("Failed to overwrite index file", e);
                 }
             } else {
-                throw new InvalidProjectStateException("Cannot create index, an index file already exists."
+                throw new StateAlreadyExistsException("Cannot create index, an index file already exists."
                         + " Use the force flag to overwrite.");
             }
         }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
@@ -117,8 +117,13 @@ public class CdmIndexService {
             PreparedStatement stmt = conn.prepareStatement(insertTemplate);
             for (int i = 0; i < exportFields.size(); i++) {
                 String exportField = exportFields.get(i);
-                String value = recordEl.getChildTextTrim(exportField);
-                value = value == null? "" : value;
+                Element childEl = recordEl.getChild(exportField);
+                if (childEl == null) {
+                    throw new InvalidProjectStateException("Missing configured field " + exportField
+                            + " in export document, aborting indexing due to configuration mismatch");
+                }
+                String value = childEl.getTextTrim();
+                value = value == null ? "" : value;
                 stmt.setString(i + 1, value);
             }
             stmt.executeUpdate();

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
@@ -1,0 +1,224 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.services;
+
+import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.input.SAXBuilder;
+import org.slf4j.Logger;
+
+import edu.unc.lib.boxc.common.xml.SecureXMLFactory;
+import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+
+/**
+ * Service for populating and querying the index of exported CDM records for a migration project
+ * @author bbpennel
+ */
+public class CdmIndexService {
+    private static final Logger log = getLogger(CdmIndexService.class);
+    public static final String TB_NAME = "cdm_records";
+
+    private MigrationProject project;
+    private CdmFieldService fieldService;
+
+    /**
+     * Indexes all exported CDM records for this project
+     * @throws IOException
+     */
+    public void indexAll() throws IOException {
+        assertCollectionExported();
+
+        CdmFieldInfo fieldInfo = fieldService.loadFieldsFromProject(project);
+        List<String> exportFields = fieldInfo.listExportFields();
+        String insertTemplate = makeInsertTemplate(exportFields);
+
+        SAXBuilder builder = SecureXMLFactory.createSAXBuilder();
+        Connection conn = null;
+        try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(project.getExportPath(), "export*.xml")) {
+            conn = openDbConnection();
+
+            Iterator<Path> it = dirStream.iterator();
+            while (it.hasNext()) {
+                Path exportPath = it.next();
+                outputLogger.info("Indexing file: {}", exportPath.getFileName());
+                Document doc = builder.build(exportPath.toFile());
+                indexDocument(doc, conn, insertTemplate, exportFields);
+            }
+        } catch (IOException e) {
+            log.error("Failed to read export files", e);
+            throw new MigrationException("Failed to read export files: " + e.getMessage());
+        } catch (SQLException e) {
+            log.error("Failed to update database", e);
+            throw new MigrationException("Failed to update database: " + e.getMessage());
+        } catch (JDOMException e) {
+            log.error("Failed to parse export file", e);
+            throw new MigrationException("Failed to parse export file: " + e.getMessage());
+        } finally {
+            closeDbConnection(conn);
+        }
+
+        project.getProjectProperties().setIndexedDate(Instant.now());
+        ProjectPropertiesSerialization.write(project);
+    }
+
+    private void assertCollectionExported() {
+        if (project.getProjectProperties().getExportedDate() == null) {
+            throw new InvalidProjectStateException("Must complete an export of the collection prior to indexing");
+        }
+    }
+
+    private String makeInsertTemplate(List<String> exportFields) {
+        return "insert into " + TB_NAME + " values ("
+                + exportFields.stream().map(f -> "?").collect(Collectors.joining(","))
+                + ")";
+    }
+
+    private void indexDocument(Document doc, Connection conn, String insertTemplate, List<String> exportFields)
+            throws SQLException {
+        Element root = doc.getRootElement();
+        List<Element> recordEls = root.getChildren("record");
+        for (Element recordEl : recordEls) {
+            PreparedStatement stmt = conn.prepareStatement(insertTemplate);
+            for (int i = 0; i < exportFields.size(); i++) {
+                String exportField = exportFields.get(i);
+                String value = recordEl.getChildTextTrim(exportField);
+                value = value == null? "" : value;
+                stmt.setString(i + 1, value);
+            }
+            stmt.executeUpdate();
+            stmt.close();
+        }
+    }
+
+    public void createDatabase(boolean force) throws IOException {
+        ensureDatabaseState(force);
+
+        CdmFieldInfo fieldInfo = fieldService.loadFieldsFromProject(project);
+        List<String> exportFields = fieldInfo.listExportFields();
+        StringBuilder queryBuilder = new StringBuilder("CREATE TABLE " + TB_NAME + " (\n");
+        for (int i = 0; i < exportFields.size(); i++) {
+            String field = exportFields.get(i);
+            queryBuilder.append(field).append(' ');
+            if (CdmFieldInfo.CDM_ID.equals(field)) {
+                queryBuilder.append("INT PRIMARY KEY NOT NULL");
+            } else {
+                queryBuilder.append("TEXT");
+            }
+            if (i < exportFields.size() - 1) {
+                queryBuilder.append(',');
+            }
+        }
+        queryBuilder.append(')');
+        log.debug("Creating database with query: {}", queryBuilder);
+
+        Connection conn = null;
+        try {
+            conn = openDbConnection();
+            Statement stmt = conn.createStatement();
+            stmt.executeUpdate(queryBuilder.toString());
+        } catch (SQLException e) {
+            throw new MigrationException("Failed to create table: " + e.getMessage(), e);
+        } finally {
+            closeDbConnection(conn);
+        }
+    }
+
+    private void ensureDatabaseState(boolean force) {
+        if (Files.exists(project.getIndexPath())) {
+            if (force) {
+                try {
+                    Files.delete(project.getIndexPath());
+                } catch (IOException e) {
+                    throw new MigrationException("Failed to overwrite index file", e);
+                }
+            } else {
+                throw new InvalidProjectStateException("Cannot create index, an index file already exists."
+                        + " Use the force flag to overwrite.");
+            }
+        }
+    }
+
+    public void setFieldService(CdmFieldService fieldService) {
+        this.fieldService = fieldService;
+    }
+
+    public void setProject(MigrationProject project) {
+        this.project = project;
+    }
+
+    public Connection openDbConnection() throws SQLException {
+        try {
+            Class.forName("org.sqlite.JDBC");
+            return DriverManager.getConnection("jdbc:sqlite:" + project.getIndexPath());
+        } catch (ClassNotFoundException e) {
+            throw new MigrationException("Failed to open database connection to " + project.getIndexPath(), e);
+        }
+    }
+
+    public static void closeDbConnection(Connection conn) {
+        try {
+            if (conn != null) {
+                conn.close();
+            }
+        } catch (SQLException e) {
+            throw new MigrationException("Failed to close database connection: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Remove the index and related properties
+     */
+    public void removeIndex() {
+        try {
+            Files.delete(project.getIndexPath());
+        } catch (NoSuchFileException e) {
+            log.debug("Index file does not exist, skipping deletion");
+        } catch (IOException e) {
+            log.error("Failed to delete index", e);
+        }
+        // Clear indexed date property in case it was set
+        try {
+            project.getProjectProperties().setIndexedDate(null);
+            ProjectPropertiesSerialization.write(project);
+        } catch (IOException e) {
+            log.error("Failed to delete index", e);
+        }
+
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/util/ProjectPropertiesSerialization.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/util/ProjectPropertiesSerialization.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
 
 /**
@@ -63,5 +64,14 @@ public class ProjectPropertiesSerialization {
      */
     public static void write(Path path, MigrationProjectProperties properties) throws IOException {
         PROJECT_WRITER.writeValue(path.toFile(), properties);
+    }
+
+    /**
+     * Serializes the provided MigrationProject to the appropriate path
+     * @param project
+     * @throws IOException
+     */
+    public static void write(MigrationProject project) throws IOException {
+        write(project.getProjectPropertiesPath(), project.getProjectProperties());
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmIndexCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmIndexCommandIT.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.Instant;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+
+/**
+ * @author bbpennel
+ */
+public class CdmIndexCommandIT extends AbstractCommandIT {
+    private final static String COLLECTION_ID = "my_coll";
+
+    private MigrationProject project;
+
+    @Test
+    public void indexMultipleFilesTest() throws Exception {
+        project = MigrationProjectFactory.createMigrationProject(
+                baseDir, COLLECTION_ID, null, USERNAME);
+        Files.createDirectories(project.getExportPath());
+
+        Files.copy(Paths.get("src/test/resources/sample_exports/export_1.xml"),
+                project.getExportPath().resolve("export_1.xml"));
+        Files.copy(Paths.get("src/test/resources/sample_exports/export_2.xml"),
+                project.getExportPath().resolve("export_2.xml"));
+        Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
+        setExportedDate();
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "index"};
+        executeExpectSuccess(args);
+
+        assertTrue(Files.exists(project.getIndexPath()));
+        assertDateIndexedPresent();
+    }
+
+    @Test
+    public void indexAlreadyExistsTest() throws Exception {
+        project = MigrationProjectFactory.createMigrationProject(
+                baseDir, COLLECTION_ID, null, USERNAME);
+        Files.createDirectories(project.getExportPath());
+
+        Files.copy(Paths.get("src/test/resources/sample_exports/export_1.xml"),
+                project.getExportPath().resolve("export_1.xml"));
+        Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
+        setExportedDate();
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "index"};
+        executeExpectSuccess(args);
+        assertTrue(Files.exists(project.getIndexPath()));
+        long indexSize = Files.size(project.getIndexPath());
+
+        // Index a second time, should fail and index should be unchanged
+        executeExpectFailure(args);
+        assertTrue(output.contains("Cannot create index, an index file already exists"));
+        assertTrue(Files.exists(project.getIndexPath()));
+        assertEquals(indexSize, Files.size(project.getIndexPath()));
+        assertDateIndexedPresent();
+
+        // Add more data and index again with force flag
+        Files.copy(Paths.get("src/test/resources/sample_exports/export_2.xml"),
+                project.getExportPath().resolve("export_2.xml"));
+
+        String[] argsForce = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "index",
+                "-f"};
+        executeExpectSuccess(argsForce);
+        assertTrue(Files.exists(project.getIndexPath()));
+        assertNotEquals("Index should have changed size", indexSize, Files.size(project.getIndexPath()));
+        assertDateIndexedPresent();
+    }
+
+    @Test
+    public void indexingFailureTest() throws Exception {
+        project = MigrationProjectFactory.createMigrationProject(
+                baseDir, COLLECTION_ID, null, USERNAME);
+        Files.createDirectories(project.getExportPath());
+
+        Files.copy(Paths.get("src/test/resources/sample_exports/export_1.xml"),
+                project.getExportPath().resolve("export_1.xml"));
+        FileUtils.write(project.getExportPath().resolve("export_2.xml").toFile(), "uh oh", ISO_8859_1);
+        Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
+        setExportedDate();
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "index"};
+        executeExpectFailure(args);
+        assertTrue(output.contains("Failed to parse export file"));
+        assertDateIndexedNotPresent();
+        assertTrue("Index file should be cleaned up", Files.notExists(project.getIndexPath()));
+    }
+
+    private void setExportedDate() throws Exception {
+        project.getProjectProperties().setExportedDate(Instant.now());
+        ProjectPropertiesSerialization.write(project);
+    }
+
+    private void assertDateIndexedPresent() throws Exception {
+        MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
+        assertNotNull(props.getIndexedDate());
+    }
+
+    private void assertDateIndexedNotPresent() throws Exception {
+        MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
+        assertNull(props.getIndexedDate());
+    }
+}

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
@@ -41,6 +41,7 @@ import org.junit.rules.TemporaryFolder;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.exceptions.StateAlreadyExistsException;
 import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
@@ -196,7 +197,7 @@ public class CdmIndexServiceTest {
         try {
             service.createDatabase(false);
             fail();
-        } catch (InvalidProjectStateException e) {
+        } catch (StateAlreadyExistsException e) {
             assertTrue(e.getMessage().contains("Cannot create index, an index file already exists"));
             assertDateIndexedNotPresent();
         }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
@@ -1,0 +1,290 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.services;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import joptsimple.internal.Strings;
+
+/**
+ * @author bbpennel
+ */
+public class CdmIndexServiceTest {
+    private static final String PROJECT_NAME = "proj";
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private MigrationProject project;
+    private CdmFieldService fieldService;
+    private CdmIndexService service;
+
+    @Before
+    public void setup() throws Exception {
+        project = MigrationProjectFactory.createMigrationProject(
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user");
+
+        fieldService = new CdmFieldService();
+        service = new CdmIndexService();
+        service.setFieldService(fieldService);
+        service.setProject(project);
+    }
+
+    @Test
+    public void indexExportOneFileTest() throws Exception {
+        Files.createDirectories(project.getExportPath());
+        Files.copy(Paths.get("src/test/resources/sample_exports/export_1.xml"),
+                project.getExportPath().resolve("export_all.xml"));
+        Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
+        project.getProjectProperties().setExportedDate(Instant.now());
+        ProjectPropertiesSerialization.write(project);
+
+        service.createDatabase(false);
+        service.indexAll();
+
+        assertDateIndexedPresent();
+        assertRowCount(3);
+
+        CdmFieldInfo fieldInfo = fieldService.loadFieldsFromProject(project);
+        List<String> exportFields = fieldInfo.listExportFields();
+
+        Connection conn = service.openDbConnection();
+        try {
+            Statement stmt = conn.createStatement();
+            ResultSet rs = stmt.executeQuery("select " + Strings.join(exportFields, ",")
+                    + " from " + CdmIndexService.TB_NAME + " order by cdmid asc");
+            rs.next();
+            assertEquals(25, rs.getInt("cdmid"));
+            assertEquals("2005-11-23", rs.getString("cdmcreated"));
+            assertEquals("Redoubt C", rs.getString("title"));
+            assertEquals("Paper is discolored.", rs.getString("notes"));
+            assertEquals("276_182_E.tif", rs.getString("file"));
+            try {
+                rs.getString("search");
+                fail("Skipped field must not be indexed");
+            } catch (SQLException e) {
+            }
+
+            rs.next();
+            assertEquals(26, rs.getInt("cdmid"));
+            assertEquals("2005-11-23", rs.getString("cdmcreated"));
+            assertEquals("Plan of Battery McIntosh", rs.getString("title"));
+            assertEquals("Paper", rs.getString("medium"));
+            assertEquals("276_183_E.tif", rs.getString("file"));
+
+            rs.next();
+            assertEquals(27, rs.getInt("cdmid"));
+            assertEquals("2005-12-08", rs.getString("cdmcreated"));
+            assertEquals("Fort DeRussy on Red River, Louisiana", rs.getString("title"));
+            assertEquals("Bill Richards", rs.getString("creatb"));
+            assertEquals("276_203_E.tif", rs.getString("file"));
+
+        } finally {
+            CdmIndexService.closeDbConnection(conn);
+        }
+    }
+
+    @Test
+    public void indexExportMultiFileTest() throws Exception {
+        Files.createDirectories(project.getExportPath());
+        Files.copy(Paths.get("src/test/resources/sample_exports/export_1.xml"),
+                project.getExportPath().resolve("export_1.xml"));
+        Files.copy(Paths.get("src/test/resources/sample_exports/export_2.xml"),
+                project.getExportPath().resolve("export_2.xml"));
+        Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
+        project.getProjectProperties().setExportedDate(Instant.now());
+        ProjectPropertiesSerialization.write(project);
+
+        service.createDatabase(false);
+        service.indexAll();
+
+        assertDateIndexedPresent();
+        assertRowCount(5);
+
+        CdmFieldInfo fieldInfo = fieldService.loadFieldsFromProject(project);
+        List<String> exportFields = fieldInfo.listExportFields();
+
+        Connection conn = service.openDbConnection();
+        try {
+            Statement stmt = conn.createStatement();
+            ResultSet rs = stmt.executeQuery("select " + Strings.join(exportFields, ",")
+                    + " from " + CdmIndexService.TB_NAME + " order by cdmid asc");
+            rs.next();
+            assertEquals(25, rs.getInt("cdmid"));
+            assertEquals("Redoubt C", rs.getString("title"));
+
+            rs.next();
+            rs.next();
+
+            rs.next();
+            assertEquals(28, rs.getInt("cdmid"));
+            assertEquals("2005-12-08", rs.getString("cdmcreated"));
+            assertEquals("6337 x 9075", rs.getString("pixel"));
+            assertEquals("276_241_E.tif", rs.getString("file"));
+
+            rs.next();
+            assertEquals(29, rs.getInt("cdmid"));
+            assertEquals("2005-12-08", rs.getString("cdmcreated"));
+            assertEquals("United States--History--Civil War, 1861-1865.;", rs.getString("subjea"));
+            assertEquals("276_245a_E.tif", rs.getString("file"));
+        } finally {
+            CdmIndexService.closeDbConnection(conn);
+        }
+    }
+
+    @Test
+    public void exportIncompleteTest() throws Exception {
+        Files.createDirectories(project.getExportPath());
+        Files.copy(Paths.get("src/test/resources/sample_exports/export_1.xml"),
+                project.getExportPath().resolve("export_1.xml"));
+        Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
+
+        service.createDatabase(false);
+        try {
+            service.indexAll();
+            fail();
+        } catch (InvalidProjectStateException e) {
+            assertTrue(e.getMessage().contains("Must complete an export of the collection"));
+            assertDateIndexedNotPresent();
+        }
+    }
+
+    @Test
+    public void indexAlreadyExistsTest() throws Exception {
+        Files.createDirectories(project.getExportPath());
+        Files.copy(Paths.get("src/test/resources/sample_exports/export_1.xml"),
+                project.getExportPath().resolve("export_1.xml"));
+        Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
+        project.getProjectProperties().setExportedDate(Instant.now());
+        ProjectPropertiesSerialization.write(project);
+
+        service.createDatabase(false);
+        try {
+            service.createDatabase(false);
+            fail();
+        } catch (InvalidProjectStateException e) {
+            assertTrue(e.getMessage().contains("Cannot create index, an index file already exists"));
+            assertDateIndexedNotPresent();
+        }
+    }
+
+    @Test
+    public void indexAlreadyExistsForceFlagTest() throws Exception {
+        Files.createDirectories(project.getExportPath());
+        Files.copy(Paths.get("src/test/resources/sample_exports/export_1.xml"),
+                project.getExportPath().resolve("export_1.xml"));
+        Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
+        project.getProjectProperties().setExportedDate(Instant.now());
+        ProjectPropertiesSerialization.write(project);
+
+        service.createDatabase(false);
+        service.indexAll();
+        assertRowCount(3);
+
+        // Switch export files to one with fewer records and force a reindex
+        Files.copy(Paths.get("src/test/resources/sample_exports/export_2.xml"),
+                project.getExportPath().resolve("export_1.xml"), StandardCopyOption.REPLACE_EXISTING);
+        service.createDatabase(true);
+        service.indexAll();
+        assertRowCount(2);
+
+        assertDateIndexedPresent();
+    }
+
+    @Test
+    public void removeIndexTest() throws Exception {
+        Files.createDirectories(project.getExportPath());
+        Files.copy(Paths.get("src/test/resources/sample_exports/export_1.xml"),
+                project.getExportPath().resolve("export_1.xml"));
+        Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
+        project.getProjectProperties().setExportedDate(Instant.now());
+        ProjectPropertiesSerialization.write(project);
+
+        service.createDatabase(false);
+        service.indexAll();
+        assertRowCount(3);
+
+        service.removeIndex();
+
+        assertTrue(Files.notExists(project.getIndexPath()));
+        assertDateIndexedNotPresent();
+    }
+
+    @Test
+    public void invalidExportFileTest() throws Exception {
+        Files.createDirectories(project.getExportPath());
+        FileUtils.write(project.getExportPath().resolve("export_1.xml").toFile(), "uh oh", ISO_8859_1);
+        Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
+        project.getProjectProperties().setExportedDate(Instant.now());
+        ProjectPropertiesSerialization.write(project);
+
+        service.createDatabase(false);
+        try {
+            service.indexAll();
+            fail();
+        } catch (MigrationException e) {
+            assertTrue(e.getMessage().contains("Failed to parse export file"));
+        }
+    }
+
+    private void assertDateIndexedPresent() throws Exception {
+        MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
+        assertNotNull(props.getIndexedDate());
+    }
+
+    private void assertDateIndexedNotPresent() throws Exception {
+        MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
+        assertNull(props.getIndexedDate());
+    }
+
+    private void assertRowCount(int expected) throws Exception {
+        Connection conn = service.openDbConnection();
+        try {
+            Statement stmt = conn.createStatement();
+            ResultSet rs = stmt.executeQuery("select count(*) from " + CdmIndexService.TB_NAME);
+            rs.next();
+            assertEquals("Incorrect number of rows in database", expected, rs.getInt(1));
+        } finally {
+            CdmIndexService.closeDbConnection(conn);
+        }
+    }
+}

--- a/src/test/resources/gilmer_fields.csv
+++ b/src/test/resources/gilmer_fields.csv
@@ -1,0 +1,61 @@
+cdm_nick,export_as,description,skip_export
+title,title,Title,false
+altern,altern,Alternative Title,false
+creato,creato,Creator,false
+contri,contri,Contributor,false
+date,date,Creation Date,false
+data,data,Date,false
+search,search,Search by Decade,true
+descri,descri,Description,false
+subjec,subjec,Subject (tgm),false
+subjea,subjea,Subject Topical,false
+subjeb,subjeb,Subject Name,false
+subjed,subjed,Subject Geographic,false
+titla,titla,Title Note,false
+dcmi,dcmi,DCMI Type,false
+captio,captio,Caption,false
+contra,contra,Contributor Note,false
+notes,notes,Notes,false
+type,type,Original Form,false
+resour,resour,Resource Type,false
+covera,covera,Geographic Location,false
+langub,langub,Language Code,false
+langua,langua,Language,false
+format,format,Physical Description of Original,false
+medium,medium,Medium of Original,false
+source,source,Collection in Repository,false
+digitb,digitb,Digital Collection,false
+publis,publis,Repository,false
+host,host,Host,false
+educat,educat,N.C. Ed. Standard,false
+identi,identi,URL,false
+local,local,Local Identifier,false
+creata,creata,Creator Identifier,false
+sponso,sponso,Citation,false
+file,file,filename,false
+rights,rights,Copyright,false
+orderi,orderi,Usage Rights,false
+initia,initia,Raw Scan Filename,false
+digita,digita,Digital Scan Date Raw Scan,false
+digitc,digitc,Digital Scan Date filename,false
+creatb,creatb,Creator Raw Scan,false
+creatc,creatc,Creator filename,false
+hardwa,hardwa,Hardware Raw Scan,false
+hardwb,hardwb,Hardware filename,false
+softwa,softwa,Software Raw Scan,false
+softwb,softwb,Software filename,false
+pixel,pixel,Pixel Array Raw Scan,false
+pixea,pixea,Pixel Array filename,false
+bit,bit,Bit Depth Raw Scan,false
+bia,bia,Bit Depth filename,false
+color,color,Color Space Raw Scan,false
+coloa,coloa,Color Space filename,false
+fila,fila,File Format Raw Scan,false
+filb,filb,File Format filename,false
+full,full,path,false
+fullrs,fullrs,Full resolution,false
+dmoclcno,dmoclcno,OCLC number,false
+dmcreated,dmcreated,Date created,false
+dmmodified,dmmodified,Date modified,false
+dmrecord,dmrecord,CONTENTdm number,false
+find,find,CONTENTdm file name,false

--- a/src/test/resources/sample_exports/export_1.xml
+++ b/src/test/resources/sample_exports/export_1.xml
@@ -1,0 +1,206 @@
+<metadata>
+  <record>
+    <title>Redoubt C</title>
+    <altern></altern>
+    <creato>Gilmer, Jeremy Francis, 1818-1883.</creato>
+    <contri>Fitz, Newton.</contri>
+    <date>1861; 1862; 1863; 1864; 1865</date>
+    <data>undated</data>
+    <descri>A map of Redoubt C drawn under the direction of Lieutenant Colonel V. Sheliha, Chief Engineer, Department of the Gulf by Newton Fitz, assistant engineer (hand-drawn).</descri>
+    <subjec>Maps</subjec>
+    <subjea>United States--History--Civil War, 1861-1865.;</subjea>
+    <subjeb>Fitz, Newton.; Gilmer, Jeremy Francis, 1818-1883.;</subjeb>
+    <subjed>Alabama--History--Maps.; Confederate States of America--Maps.; United States--History--Civil War, 1861-1865--Maps.;</subjed>
+    <titla> on map.</titla>
+    <dcmi>Image</dcmi>
+    <captio></captio>
+    <contra>Map was drawn by Newton Fitz.</contra>
+    <notes>Paper is discolored.</notes>
+    <type>Maps</type>
+    <resour>Still Image</resour>
+    <covera>United States, Alabama</covera>
+    <langub>eng</langub>
+    <langua>English</langua>
+    <format>20-1/2&quot; H x 22-1/8&quot; W; scale on map.</format>
+    <medium>Paper</medium>
+    <source>Jeremy Francis Gilmer Papers; http://finding-aids.lib.unc.edu/00276/</source>
+    <digitb>Gilmer Maps</digitb>
+    <publis>University of North Carolina at Chapel Hill. Library. Southern Historical Collection.</publis>
+    <host>University of North Carolina at Chapel Hill</host>
+    <educat></educat>
+    <identi></identi>
+    <local>276/182</local>
+    <creata>Gilmer Map Number 7</creata>
+    <sponso>[Identification of item], in the Jeremy Francis Gilmer Papers #276, Southern Historical Collection, Wilson Library, University of North Carolina at Chapel Hill.</sponso>
+    <file>276_182_E.tif</file>
+    <rights>Public Domain</rights>
+    <orderi></orderi>
+    <initia>276_182.tif</initia>
+    <digita>2005-11-07</digita>
+    <digitc>2005-11-10</digitc>
+    <creatb>Bill Richards</creatb>
+    <creatc>Bill Richards</creatc>
+    <hardwa>Image was captured using a Horseman 4x5 studio camera with a Phase One PowerPhaseFX digital scanning camera back. Image was processed either with a Mac G4 or G5.</hardwa>
+    <hardwb>Image was processed either with a Mac G4 or G5.</hardwb>
+    <softwa>Image was processed with Photoshop CS2.</softwa>
+    <softwb>Image was processed with Photoshop CS2.</softwb>
+    <pixel>6524 x 6777</pixel>
+    <pixea>6524 x 6777</pixea>
+    <bit>8</bit>
+    <bia>8</bia>
+    <color>RGB</color>
+    <coloa>RGB</coloa>
+    <fila>TIFF</fila>
+    <filb>TIFF</filb>
+    <full>/shc/gilmer_maps/</full>
+    <find>http://localhost/cdm/ref/collection/gilmer/id/25</find>
+    <fullrs>1_276_182_E.tif</fullrs>
+    <fullResolution>1_276_182_E.tif</fullResolution>
+    <cdmid>25</cdmid>
+    <cdmaccess></cdmaccess>
+    <cdmcreated>2005-11-23</cdmcreated>
+    <cdmmodified>2015-09-14</cdmmodified>
+    <cdmoclc></cdmoclc>
+    <cdmfile>26.JP2</cdmfile>
+    <cdmpath>/gilmer/image/26.JP2</cdmpath>
+    <thumbnailURL>http://localhost/cgi-bin/thumbnail.exe?CISOROOT=/gilmer&amp;CISOPTR=25</thumbnailURL>
+    <viewerURL>http://localhost/cdm/ref/collection/gilmer/id/25</viewerURL>
+    <structure>http://localhost/cgi-bin/showfile.exe?CISOROOT=/gilmer&amp;CISOPTR=25</structure>
+  </record>
+  <record>
+    <title>Plan of Battery McIntosh</title>
+    <altern></altern>
+    <creato>Gilmer, Jeremy Francis, 1818-1883.</creato>
+    <contri>Fitz, Newton.</contri>
+    <date>1861; 1862; 1863; 1864; 1865</date>
+    <data>undated</data>
+    <descri>A map of the plan of Battery McIntosh, drawn under the direction of Brigadeer General D. Leadbetter (hand-drawn and colored).</descri>
+    <subjec>Maps</subjec>
+    <subjea>United States--History--Civil War, 1861-1865.;</subjea>
+    <subjeb>Fitz, Newton.; Gilmer, Jeremy Francis, 1818-1883.;</subjeb>
+    <subjed>Alabama--History--Maps.; Confederate States of America--Maps.; United States--History--Civil War, 1861-1865--Maps.;</subjed>
+    <titla> on map.</titla>
+    <dcmi>Image</dcmi>
+    <captio></captio>
+    <contra>Map is signed &quot;Newton Fitz, draughtsman&quot;.</contra>
+    <notes>Paper is torn at edges and bottom right-hand corner is missing.</notes>
+    <type>Maps</type>
+    <resour>Still Image</resour>
+    <covera>United States, Alabama</covera>
+    <langub>eng</langub>
+    <langua>English</langua>
+    <format>24-1/4&quot; H x 20&quot; W</format>
+    <medium>Paper</medium>
+    <source>Jeremy Francis Gilmer Papers; http://finding-aids.lib.unc.edu/00276/</source>
+    <digitb>Gilmer Maps</digitb>
+    <publis>University of North Carolina at Chapel Hill. Library. Southern Historical Collection.</publis>
+    <host>University of North Carolina at Chapel Hill</host>
+    <educat></educat>
+    <identi></identi>
+    <local>276/183</local>
+    <creata>Gilmer Map Number 8</creata>
+    <sponso>[Identification of item], in the Jeremy Francis Gilmer Papers #276, Southern Historical Collection, Wilson Library, University of North Carolina at Chapel Hill.</sponso>
+    <file>276_183_E.tif</file>
+    <rights>Public Domain</rights>
+    <orderi></orderi>
+    <initia>276_183.tif</initia>
+    <digita>2005-11-07</digita>
+    <digitc>2005-11-09</digitc>
+    <creatb>Bill Richards</creatb>
+    <creatc>Bill Richards</creatc>
+    <hardwa>Image was captured using a Horseman 4x5 studio camera with a Phase One PowerPhaseFX digital scanning camera back. Image was processed either with a Mac G4 or G5.</hardwa>
+    <hardwb>Image was processed either with a Mac G4 or G5.</hardwb>
+    <softwa>Image was processed with Photoshop CS2.</softwa>
+    <softwb>Image was processed with Photoshop CS2.</softwb>
+    <pixel>8156 x 8624</pixel>
+    <pixea>7389 x 8636</pixea>
+    <bit>8</bit>
+    <bia>8</bia>
+    <color>RGB</color>
+    <coloa>RGB</coloa>
+    <fila>TIFF</fila>
+    <filb>TIFF</filb>
+    <full>/shc/gilmer_maps/</full>
+    <find>http://localhost/cdm/ref/collection/gilmer/id/26</find>
+    <fullrs>276_183_E.tif</fullrs>
+    <fullResolution>276_183_E.tif</fullResolution>
+    <cdmid>26</cdmid>
+    <cdmaccess></cdmaccess>
+    <cdmcreated>2005-11-23</cdmcreated>
+    <cdmmodified>2015-09-14</cdmmodified>
+    <cdmoclc></cdmoclc>
+    <cdmfile>27.JP2</cdmfile>
+    <cdmpath>/gilmer/image/27.JP2</cdmpath>
+    <thumbnailURL>http://localhost/cgi-bin/thumbnail.exe?CISOROOT=/gilmer&amp;CISOPTR=26</thumbnailURL>
+    <viewerURL>http://localhost/cdm/ref/collection/gilmer/id/26</viewerURL>
+    <structure>http://localhost/cgi-bin/showfile.exe?CISOROOT=/gilmer&amp;CISOPTR=26</structure>
+  </record>
+  <record>
+    <title>Fort DeRussy on Red River, Louisiana</title>
+    <altern></altern>
+    <creato>Gilmer, Jeremy Francis, 1818-1883.</creato>
+    <contri></contri>
+    <date>1864</date>
+    <data>1864</data>
+    <descri>The plans of Fort DeRussy and obstructions of the Red River below Fort DeRussy, drawn under the direction of Captain R. M. Venable (hand-drawn).</descri>
+    <subjec>Maps</subjec>
+    <subjea>United States--History--Civil War, 1861-1865.;</subjea>
+    <subjeb>Gilmer, Jeremy Francis, 1818-1883.;</subjeb>
+    <subjed>Confederate States of America--Maps.; Louisiana--History--Maps.; United States--History--Civil War, 1861-1865--Maps.;</subjed>
+    <titla> on map.</titla>
+    <dcmi>Image</dcmi>
+    <captio></captio>
+    <contra></contra>
+    <notes>Paper is torn along center fold.</notes>
+    <type>Maps</type>
+    <resour>Still Image</resour>
+    <covera>United States, Louisiana</covera>
+    <langub>eng</langub>
+    <langua>English</langua>
+    <format>17-1/2&quot; H x 21-1/4&quot; W</format>
+    <medium>Paper</medium>
+    <source>Jeremy Francis Gilmer Papers; http://finding-aids.lib.unc.edu/00276/</source>
+    <digitb>Gilmer Maps</digitb>
+    <publis>University of North Carolina at Chapel Hill. Library. Southern Historical Collection.</publis>
+    <host>University of North Carolina at Chapel Hill</host>
+    <educat></educat>
+    <identi></identi>
+    <local>276/203</local>
+    <creata>Gilmer Map Number 196</creata>
+    <sponso>[Identification of item], in the Jeremy Francis Gilmer Papers #276, Southern Historical Collection, Wilson Library, University of North Carolina at Chapel Hill.</sponso>
+    <file>276_203_E.tif</file>
+    <rights>Public Domain</rights>
+    <orderi></orderi>
+    <initia>276_203.tif</initia>
+    <digita>2005-11-11</digita>
+    <digitc>2005-11-11</digitc>
+    <creatb>Bill Richards</creatb>
+    <creatc>Bill Richards</creatc>
+    <hardwa>Image was captured using a Horseman 4x5 studio camera with a Phase One PowerPhaseFX digital scanning camera back. Image was processed either with a Mac G4 or G5.</hardwa>
+    <hardwb>Image was processed either with a Mac G4 or G5.</hardwb>
+    <softwa>Image was processed with Photoshop CS2.</softwa>
+    <softwb>Image was processed with Photoshop CS2.</softwb>
+    <pixel>6330 x 5950</pixel>
+    <pixea>6330 x 5202</pixea>
+    <bit>8</bit>
+    <bia>8</bia>
+    <color>RGB</color>
+    <coloa>RGB</coloa>
+    <fila>TIFF</fila>
+    <filb>TIFF</filb>
+    <full>/shc/gilmer_maps/</full>
+    <find>http://localhost/cdm/ref/collection/gilmer/id/27</find>
+    <fullrs>276_203_E.tif</fullrs>
+    <fullResolution>276_203_E.tif</fullResolution>
+    <cdmid>27</cdmid>
+    <cdmaccess></cdmaccess>
+    <cdmcreated>2005-12-08</cdmcreated>
+    <cdmmodified>2015-09-14</cdmmodified>
+    <cdmoclc></cdmoclc>
+    <cdmfile>50.jp2</cdmfile>
+    <cdmpath>/gilmer/image/50.jp2</cdmpath>
+    <thumbnailURL>http://localhost/cgi-bin/thumbnail.exe?CISOROOT=/gilmer&amp;CISOPTR=27</thumbnailURL>
+    <viewerURL>http://localhost/cdm/ref/collection/gilmer/id/27</viewerURL>
+    <structure>http://localhost/cgi-bin/showfile.exe?CISOROOT=/gilmer&amp;CISOPTR=27</structure>
+  </record>
+</metadata>

--- a/src/test/resources/sample_exports/export_2.xml
+++ b/src/test/resources/sample_exports/export_2.xml
@@ -1,0 +1,138 @@
+<metadata>
+  <record>
+    <title>Map of the country adjacent to Smithville</title>
+    <altern></altern>
+    <creato>Gilmer, Jeremy Francis, 1818-1883.</creato>
+    <contri>Blackford, B. L. (Benjamin Lewis)</contri>
+    <date>1864</date>
+    <data>1864</data>
+    <descri>A map of the area adjacent to Smithville, made under the direction of Captain W. H. James by B. L. Blackford (hand-drawn and colored).</descri>
+    <subjec>Maps</subjec>
+    <subjea>United States--History--Civil War, 1861-1865.;</subjea>
+    <subjeb>Blackford, B. L. (Benjamin Lewis); Gilmer, Jeremy Francis, 1818-1883.;</subjeb>
+    <subjed>Confederate States of America--Maps.; North Carolina--History--Maps.; United States--History--Civil War, 1861-1865--Maps.;</subjed>
+    <titla>Title on map.</titla>
+    <dcmi>Image</dcmi>
+    <captio></captio>
+    <contra>Map was made by B. L. Blackford.</contra>
+    <notes>Paper is discolored.</notes>
+    <type>Maps</type>
+    <resour>Still Image</resour>
+    <covera>United States, North Carolina</covera>
+    <langub>eng</langub>
+    <langua>English</langua>
+    <format>17-3/4&quot; H x 29-3/4&quot; W; scale on map.</format>
+    <medium>Paper</medium>
+    <source>Jeremy Francis Gilmer Papers; http://finding-aids.lib.unc.edu/00276/</source>
+    <digitb>Gilmer Maps</digitb>
+    <publis>University of North Carolina at Chapel Hill. Library. Southern Historical Collection.</publis>
+    <host>University of North Carolina at Chapel Hill</host>
+    <educat></educat>
+    <identi></identi>
+    <local>276/241</local>
+    <creata>Gilmer Map Number 316</creata>
+    <sponso>[Identification of item], in the Jeremy Francis Gilmer Papers #276, Southern Historical Collection, Wilson Library, University of North Carolina at Chapel Hill.</sponso>
+    <file>276_241_E.tif</file>
+    <rights>Public Domain</rights>
+    <orderi></orderi>
+    <initia>276_241.tif</initia>
+    <digita>2005-10-21</digita>
+    <digitc>2005-11-10</digitc>
+    <creatb>Bill Richards</creatb>
+    <creatc>Bill Richards</creatc>
+    <hardwa>Image was captured using a Horseman 4x5 studio camera with a Phase One PowerPhaseFX digital scanning camera back. Image was processed either with a Mac G4 or G5.</hardwa>
+    <hardwb>Image was processed either with a Mac G4 or G5.</hardwb>
+    <softwa>Image was processed with Photoshop CS2.</softwa>
+    <softwb>Image was processed with Photoshop CS2.</softwb>
+    <pixel>6337 x 9075</pixel>
+    <pixea>6337 x 9075</pixea>
+    <bit>8</bit>
+    <bia>8</bia>
+    <color>RGB</color>
+    <coloa>RGB</coloa>
+    <fila>TIFF</fila>
+    <filb>TIFF</filb>
+    <full>/shc/gilmer_maps/</full>
+    <find>http://localhost/cdm/ref/collection/gilmer/id/28</find>
+    <fullrs>276_241_E.tif</fullrs>
+    <fullResolution>276_241_E.tif</fullResolution>
+    <cdmid>28</cdmid>
+    <cdmaccess></cdmaccess>
+    <cdmcreated>2005-12-08</cdmcreated>
+    <cdmmodified>2015-09-14</cdmmodified>
+    <cdmoclc></cdmoclc>
+    <cdmfile>74.jp2</cdmfile>
+    <cdmpath>/gilmer/image/74.jp2</cdmpath>
+    <thumbnailURL>http://localhost/cgi-bin/thumbnail.exe?CISOROOT=/gilmer&amp;CISOPTR=28</thumbnailURL>
+    <viewerURL>http://localhost/cdm/ref/collection/gilmer/id/28</viewerURL>
+    <structure>http://localhost/cgi-bin/showfile.exe?CISOROOT=/gilmer&amp;CISOPTR=28</structure>
+  </record>
+  <record>
+    <title>Fort Fisher and adjoining fortifications</title>
+    <altern></altern>
+    <creato>Gilmer, Jeremy Francis, 1818-1883.</creato>
+    <contri>Turner, L. C.</contri>
+    <date>1863</date>
+    <data>1863</data>
+    <descri>A map of Fort Fisher and adjoining fortifications, surveyed and mapped under the direction of W. H. James by L. C. Turner (hand-drawn).</descri>
+    <subjec>Maps</subjec>
+    <subjea>United States--History--Civil War, 1861-1865.;</subjea>
+    <subjeb>Gilmer, Jeremy Francis, 1818-1883.; Turner, L. C.</subjeb>
+    <subjed>Confederate States of America--Maps.; North Carolina--History--Maps.; United States--History--Civil War, 1861-1865--Maps.;</subjed>
+    <titla>Title on map.</titla>
+    <dcmi>Image</dcmi>
+    <captio></captio>
+    <contra>Map was surveyed and mapped by L. C. Turner.</contra>
+    <notes>Paper is torn along right and left edges.</notes>
+    <type>Maps</type>
+    <resour>Still Image</resour>
+    <covera>United States, North Carolina</covera>
+    <langub>eng</langub>
+    <langua>English</langua>
+    <format>20&quot; H x 28-1/8&quot; W; scale on map.</format>
+    <medium>Paper</medium>
+    <source>Jeremy Francis Gilmer Papers; http://finding-aids.lib.unc.edu/00276/</source>
+    <digitb>Gilmer Maps</digitb>
+    <publis>University of North Carolina at Chapel Hill. Library. Southern Historical Collection.</publis>
+    <host>University of North Carolina at Chapel Hill</host>
+    <educat></educat>
+    <identi></identi>
+    <local>276/245A</local>
+    <creata>Gilmer Map Number 320A</creata>
+    <sponso>[Identification of item], in the Jeremy Francis Gilmer Papers #276, Southern Historical Collection, Wilson Library, University of North Carolina at Chapel Hill.</sponso>
+    <file>276_245a_E.tif</file>
+    <rights>Public Domain</rights>
+    <orderi></orderi>
+    <initia>276_245a.tif</initia>
+    <digita>2005-10-27</digita>
+    <digitc>2005-11-10</digitc>
+    <creatb>Bill Richards</creatb>
+    <creatc>Bill Richards</creatc>
+    <hardwa>Image was captured using a Horseman 4x5 studio camera with a Phase One PowerPhaseFX digital scanning camera back. Image was processed either with a Mac G4 or G5.</hardwa>
+    <hardwb>Image was processed either with a Mac G4 or G5.</hardwb>
+    <softwa>Image was processed with Photoshop CS2.</softwa>
+    <softwb>Image was processed with Photoshop CS2.</softwb>
+    <pixel>6852 x 8625</pixel>
+    <pixea>6852 x 8625</pixea>
+    <bit>8</bit>
+    <bia>8</bia>
+    <color>RGB</color>
+    <coloa>RGB</coloa>
+    <fila>TIFF</fila>
+    <filb>TIFF</filb>
+    <full>/shc/gilmer_maps/</full>
+    <find>http://localhost/cdm/ref/collection/gilmer/id/29</find>
+    <fullrs>276_245a_E.tif</fullrs>
+    <fullResolution>276_245a_E.tif</fullResolution>
+    <cdmid>29</cdmid>
+    <cdmaccess></cdmaccess>
+    <cdmcreated>2005-12-08</cdmcreated>
+    <cdmmodified>2015-09-14</cdmmodified>
+    <cdmoclc></cdmoclc>
+    <cdmfile>71.jp2</cdmfile>
+    <cdmpath>/gilmer/image/71.jp2</cdmpath>
+    <thumbnailURL>http://localhost/cgi-bin/thumbnail.exe?CISOROOT=/gilmer&amp;CISOPTR=29</thumbnailURL>
+    <viewerURL>http://localhost/cdm/ref/collection/gilmer/id/29</viewerURL>
+    <structure>http://localhost/cgi-bin/showfile.exe?CISOROOT=/gilmer&amp;CISOPTR=29</structure>
+  </record>
+</metadata>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3173

* Adds a command and services to produce a sqlite database containing exported records from CDM, using the retrieved field information to produce the schema
* Adds properties to keep track of export and indexing state.