### PR TITLE
BXC-3175 - Generate source and access file mappings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,10 +98,6 @@
         </dependency>
         
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context-support</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/AccessFilesCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/AccessFilesCommand.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm;
+
+import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.options.SourceFileMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.services.AccessFileService;
+import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.ParentCommand;
+
+/**
+ * @author bbpennel
+ */
+@Command(name = "access_files",
+        description = "Commands related to access file mappings")
+public class AccessFilesCommand {
+    private static final Logger log = getLogger(AccessFilesCommand.class);
+
+    @ParentCommand
+    private CLIMain parentCommand;
+
+    private MigrationProject project;
+    private AccessFileService accessService;
+
+    @Command(name = "generate",
+            description = {
+                    "Generate the optional access copy mapping file for this project.",
+                    "See the source_files command for more details about usage"})
+    public int generate(@Mixin SourceFileMappingOptions options) throws Exception {
+        long start = System.nanoTime();
+
+        try {
+            validateOptions(options);
+            initialize();
+
+            accessService.generateMapping(options);
+            outputLogger.info("Access mapping generated for {} in {}s", project.getProjectName(),
+                    (System.nanoTime() - start) / 1e9);
+            return 0;
+        } catch (MigrationException | IllegalArgumentException e) {
+            outputLogger.info("Cannot generate access mapping: {}", e.getMessage());
+            return 1;
+        } catch (Exception e) {
+            log.error("Failed to map access files", e);
+            outputLogger.info("Failed to map access files: {}", e.getMessage(), e);
+            return 1;
+        }
+    }
+
+    private void validateOptions(SourceFileMappingOptions options) {
+        if (options.getBasePath() == null) {
+            throw new IllegalArgumentException("Must provide a base path");
+        }
+        if (StringUtils.isBlank(options.getExportField())) {
+            throw new IllegalArgumentException("Must provide an export field");
+        }
+    }
+
+    private void initialize() throws IOException {
+        Path currentPath = parentCommand.getWorkingDirectory();
+        project = MigrationProjectFactory.loadMigrationProject(currentPath);
+        CdmIndexService indexService = new CdmIndexService();
+        indexService.setProject(project);
+        accessService = new AccessFileService();
+        accessService.setIndexService(indexService);
+        accessService.setProject(project);
+    }
+
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
@@ -37,7 +37,8 @@ import picocli.CommandLine.Option;
         CdmExportCommand.class,
         CdmIndexCommand.class,
         DestinationsCommand.class,
-        SourceFilesCommand.class
+        SourceFilesCommand.class,
+        AccessFilesCommand.class
     })
 public class CLIMain implements Callable<Integer> {
     @Option(names = { "-w", "--work-dir" },

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
@@ -36,7 +36,8 @@ import picocli.CommandLine.Option;
         CdmFieldsCommand.class,
         CdmExportCommand.class,
         CdmIndexCommand.class,
-        DestinationsCommand.class
+        DestinationsCommand.class,
+        SourceFilesCommand.class
     })
 public class CLIMain implements Callable<Integer> {
     @Option(names = { "-w", "--work-dir" },

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommand.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm;
+
+import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.options.SourceFileMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.services.SourceFileService;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.ParentCommand;
+
+/**
+ * @author bbpennel
+ */
+@Command(name = "source_files",
+        description = "Commands related to source file mappings")
+public class SourceFilesCommand {
+    private static final Logger log = getLogger(SourceFilesCommand.class);
+
+    @ParentCommand
+    private CLIMain parentCommand;
+
+    private MigrationProject project;
+    private SourceFileService sourceService;
+
+    @Command(name = "generate",
+            description = {
+                    "Generate the source mapping file for this project.",
+                    "Mappings are produced by listing files from a directory using the --base-path option, "
+                    + "then searching for matches between those filenames and some filename field in the "
+                    + "exported CDM records.",
+                    "The filename field is set using the --field-name option.",
+                    "If the value of the filename field does not match the name of the source file, the filename "
+                    + " can be transformed using regular expressions via the --field-pattern"
+                    + " and --field-pattern options.",
+                    "The resulting will be written to the source_files.csv for this project, unless "
+                    + "the --dry-run flag is provided."})
+    public int generate(@Mixin SourceFileMappingOptions options) throws Exception {
+        long start = System.nanoTime();
+
+        try {
+            validateOptions(options);
+            initialize();
+
+            sourceService.generateMapping(options);
+            outputLogger.info("Source file mapping generated for {} in {}s", project.getProjectName(),
+                    (System.nanoTime() - start) / 1e9);
+            return 0;
+        } catch (MigrationException | IllegalArgumentException e) {
+            outputLogger.info("Cannot generate source mapping: {}", e.getMessage());
+            return 1;
+        } catch (Exception e) {
+            log.error("Failed to map source files", e);
+            outputLogger.info("Failed to map source files: {}", e.getMessage(), e);
+            return 1;
+        }
+    }
+
+    private void validateOptions(SourceFileMappingOptions options) {
+        if (options.getBasePath() == null) {
+            throw new IllegalArgumentException("Must provide a base path");
+        }
+        if (StringUtils.isBlank(options.getExportField())) {
+            throw new IllegalArgumentException("Must provide an export field");
+        }
+    }
+
+    private void initialize() throws IOException {
+        Path currentPath = parentCommand.getWorkingDirectory();
+        project = MigrationProjectFactory.loadMigrationProject(currentPath);
+        CdmIndexService indexService = new CdmIndexService();
+        indexService.setProject(project);
+        sourceService = new SourceFileService();
+        sourceService.setIndexService(indexService);
+        sourceService.setProject(project);
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
@@ -30,6 +30,7 @@ public class MigrationProject {
     public static final String INDEX_FILENAME = "cdm_index.db";
     public static final String DESTINATIONS_FILENAME = "destinations.csv";
     public static final String SOURCE_MAPPING_FILENAME = "source_files.csv";
+    public static final String ACCESS_MAPPING_FILENAME = "access_files.csv";
 
     private Path projectPath;
     private MigrationProjectProperties properties;
@@ -103,6 +104,13 @@ public class MigrationProject {
      */
     public Path getSourceFilesMappingPath() {
         return projectPath.resolve(SOURCE_MAPPING_FILENAME);
+    }
+
+    /**
+     * @return Path of the access files mapping file
+     */
+    public Path getAccessFilesMappingPath() {
+        return projectPath.resolve(ACCESS_MAPPING_FILENAME);
     }
 
     /**

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
@@ -29,6 +29,7 @@ public class MigrationProject {
     public static final String FIELD_NAMES_FILENAME = "cdm_fields.csv";
     public static final String INDEX_FILENAME = "cdm_index.db";
     public static final String DESTINATIONS_FILENAME = "destinations.csv";
+    public static final String SOURCE_MAPPING_FILENAME = "source_files.csv";
 
     private Path projectPath;
     private MigrationProjectProperties properties;
@@ -95,6 +96,13 @@ public class MigrationProject {
      */
     public Path getDestinationMappingsPath() {
         return projectPath.resolve(DESTINATIONS_FILENAME);
+    }
+
+    /**
+     * @return Path of the source files mapping file
+     */
+    public Path getSourceFilesMappingPath() {
+        return projectPath.resolve(SOURCE_MAPPING_FILENAME);
     }
 
     /**

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
@@ -31,6 +31,7 @@ public class MigrationProjectProperties {
     private Instant indexedDate;
     private Instant destinationsGeneratedDate;
     private Instant sourceFilesUpdatedDate;
+    private Instant accessFilesUpdatedDate;
 
     public MigrationProjectProperties() {
     }
@@ -121,5 +122,16 @@ public class MigrationProjectProperties {
 
     public void setSourceFilesUpdatedDate(Instant sourceFilesGeneratedDate) {
         this.sourceFilesUpdatedDate = sourceFilesGeneratedDate;
+    }
+
+    /**
+     * @return timestamp the access files mapping was last updated
+     */
+    public Instant getAccessFilesUpdatedDate() {
+        return accessFilesUpdatedDate;
+    }
+
+    public void setAccessFilesUpdatedDate(Instant accessFilesUpdatedDate) {
+        this.accessFilesUpdatedDate = accessFilesUpdatedDate;
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
@@ -30,6 +30,7 @@ public class MigrationProjectProperties {
     private Instant exportedDate;
     private Instant indexedDate;
     private Instant destinationsGeneratedDate;
+    private Instant sourceFilesUpdatedDate;
 
     public MigrationProjectProperties() {
     }
@@ -109,5 +110,16 @@ public class MigrationProjectProperties {
 
     public void setDestinationsGeneratedDate(Instant destinationsGeneratedDate) {
         this.destinationsGeneratedDate = destinationsGeneratedDate;
+    }
+
+    /**
+     * @return timestamp the source files mapping was last updated
+     */
+    public Instant getSourceFilesUpdatedDate() {
+        return sourceFilesUpdatedDate;
+    }
+
+    public void setSourceFilesUpdatedDate(Instant sourceFilesGeneratedDate) {
+        this.sourceFilesUpdatedDate = sourceFilesGeneratedDate;
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/SourceFilesInfo.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/SourceFilesInfo.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.model;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * @author bbpennel
+ */
+public class SourceFilesInfo {
+    private List<SourceFileMapping> mappings;
+
+    public SourceFilesInfo() {
+        mappings = new ArrayList<>();
+    }
+
+    /**
+     * @return Mappings of cdm objects to source files
+     */
+    public List<SourceFileMapping> getMappings() {
+        return mappings;
+    }
+
+    public void setMappings(List<SourceFileMapping> mappings) {
+        this.mappings = mappings;
+    }
+
+    public static class SourceFileMapping {
+        private String cdmId;
+        private String matchingValue;
+        private Path sourcePath;
+        private List<String> potentialMatches;
+
+        public String getCdmId() {
+            return cdmId;
+        }
+
+        public void setCdmId(String cdmId) {
+            this.cdmId = cdmId;
+        }
+
+        public String getMatchingValue() {
+            return matchingValue;
+        }
+
+        public void setMatchingValue(String matchingValue) {
+            this.matchingValue = matchingValue;
+        }
+
+        public Path getSourcePath() {
+            return sourcePath;
+        }
+
+        public void setSourcePath(String sourcePath) {
+            if (StringUtils.isBlank(sourcePath)) {
+                this.sourcePath = null;
+            } else {
+                this.sourcePath = Paths.get(sourcePath);
+            }
+        }
+
+        public List<String> getPotentialMatches() {
+            return potentialMatches;
+        }
+
+        public void setPotentialMatches(String potentialMatches) {
+            if (StringUtils.isBlank(potentialMatches)) {
+                this.potentialMatches = null;
+            } else {
+                this.potentialMatches = Arrays.asList(potentialMatches.split(","));
+            }
+        }
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/SourceFilesInfo.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/SourceFilesInfo.java
@@ -44,6 +44,14 @@ public class SourceFilesInfo {
         this.mappings = mappings;
     }
 
+    /**
+     * @param cdmId
+     * @return mapping with matching cdm id, or null if no match
+     */
+    public SourceFileMapping getMappingByCdmId(String cdmId) {
+        return this.mappings.stream().filter(m -> m.getCdmId().equals(cdmId)).findFirst().orElseGet(null);
+    }
+
     public static class SourceFileMapping {
         private String cdmId;
         private String matchingValue;
@@ -87,6 +95,18 @@ public class SourceFilesInfo {
                 this.potentialMatches = null;
             } else {
                 this.potentialMatches = Arrays.asList(potentialMatches.split(","));
+            }
+        }
+
+        public void setPotentialMatches(List<String> potentialMatches) {
+            this.potentialMatches = potentialMatches;
+        }
+
+        public String getPotentialMatchesString() {
+            if (potentialMatches == null) {
+                return null;
+            } else {
+                return String.join(",", potentialMatches);
             }
         }
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/SourceFileMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/SourceFileMappingOptions.java
@@ -28,7 +28,7 @@ public class SourceFileMappingOptions {
 
     @Option(names = {"-b", "--base-path"},
             description = {
-                    "Base file path to search in for source files to match with.",
+                    "Required. Base file path to search in for source files to match with.",
                     "By default, all files which are immediate children of base path will be used.",
                     "To change this behavior, use the -g option."})
     private Path basePath;
@@ -48,7 +48,8 @@ public class SourceFileMappingOptions {
     @Option(names = {"-n", "--field-name"},
             description = {
                     "Name of the CDM export field which will be transformed by the field matching pattern "
-                    + "to produce the source file filename for matching purposes."})
+                    + "to produce the source file filename for matching purposes."},
+            defaultValue = "file")
     private String exportField;
 
     @Option(names = {"-p", "--field-pattern"},
@@ -57,7 +58,8 @@ public class SourceFileMappingOptions {
                     + "for use in the filename template. Use matching groups for this.",
                     "Must match the entire value of the export field.",
                     "For example, to extract numeric portions of the value: 276_214_E.tif",
-                    "You could provide the pattern: (\\d+)\\_(\\d+)_E.tif"})
+                    "You could provide the pattern: (\\d+)\\_(\\d+)_E.tif"},
+            defaultValue = "(.+)")
     private String fieldMatchingPattern;
 
     @Option(names = {"-t", "--file-template"},
@@ -65,7 +67,8 @@ public class SourceFileMappingOptions {
                     "Template used to produce expected source file filenames.",
                     "It should be used with matching groups from --field-pattern.",
                     "Given the field pattern above, it could be templated out to: 00276_op0214_0001_e.tif",
-                    "With the template: 00$1_op0$2_0001_e.tif"})
+                    "With the template: 00$1_op0$2_0001_e.tif"},
+            defaultValue = "$1")
     private String filenameTemplate;
 
     @Option(names = {"-u", "--update"},
@@ -73,20 +76,24 @@ public class SourceFileMappingOptions {
                     "If provided, then any source file matches produced will be used to update an existing"
                     + " source file mapping file, instead of attempting to create a new one.",
                     "This can be used to build up the mapping in multiple passes"})
-    private Boolean update;
+    private boolean update;
 
     @Option(names = {"-d", "--dry-run"},
             description = {
                     "If provided, then the output of the matching will be displayed in the console rather "
                     + "than written to file"})
-    private Boolean dryRun;
+    private boolean dryRun;
+
+    @Option(names = { "-f", "--force"},
+            description = "Overwrite mapping file if one already exists")
+    private boolean force;
 
     public Path getBasePath() {
         return basePath;
     }
 
-    public void setBasePath(Path basePathPattern) {
-        this.basePath = basePathPattern;
+    public void setBasePath(Path basePath) {
+        this.basePath = basePath;
     }
 
     public String getPathPattern() {
@@ -121,19 +128,27 @@ public class SourceFileMappingOptions {
         this.filenameTemplate = filenameTemplate;
     }
 
-    public Boolean getUpdate() {
+    public boolean getUpdate() {
         return update;
     }
 
-    public void setUpdate(Boolean update) {
+    public void setUpdate(boolean update) {
         this.update = update;
     }
 
-    public Boolean getDryRun() {
+    public boolean getDryRun() {
         return dryRun;
     }
 
-    public void setDryRun(Boolean dryRun) {
+    public void setDryRun(boolean dryRun) {
         this.dryRun = dryRun;
+    }
+
+    public boolean isForce() {
+        return force;
+    }
+
+    public void setForce(boolean force) {
+        this.force = force;
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/SourceFileMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/SourceFileMappingOptions.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.options;
+
+import java.nio.file.Path;
+
+import picocli.CommandLine.Option;
+
+/**
+ * Options for generating source file mappings
+ *
+ * @author bbpennel
+ */
+public class SourceFileMappingOptions {
+
+    @Option(names = {"-b", "--base-path"},
+            description = {
+                    "Base file path to search in for source files to match with.",
+                    "By default, all files which are immediate children of base path will be used.",
+                    "To change this behavior, use the -g option."})
+    private Path basePath;
+
+    @Option(names = {"-g", "--glob-pattern"},
+            description = {
+                    "Optional pattern for adjusting which files within the base path to search.",
+                    "Must be relative to the base path. Follows glob pattern syntax.",
+                    "For example, to only match tiff files within the base path:",
+                    "    *.tiff",
+                    "To match any file within any directory at a depth of 2 subdirectories:",
+                    "    */*/*",
+                    "Or to match tiff files at any depth:",
+                    "    **/*.tiff"})
+    private String pathPattern;
+
+    @Option(names = {"-n", "--field-name"},
+            description = {
+                    "Name of the CDM export field which will be transformed by the field matching pattern "
+                    + "to produce the source file filename for matching purposes."})
+    private String exportField;
+
+    @Option(names = {"-p", "--field-pattern"},
+            description = {
+                    "Regular expression which will be used to extract portions of the export field value "
+                    + "for use in the filename template. Use matching groups for this.",
+                    "Must match the entire value of the export field.",
+                    "For example, to extract numeric portions of the value: 276_214_E.tif",
+                    "You could provide the pattern: (\\d+)\\_(\\d+)_E.tif"})
+    private String fieldMatchingPattern;
+
+    @Option(names = {"-t", "--file-template"},
+            description = {
+                    "Template used to produce expected source file filenames.",
+                    "It should be used with matching groups from --field-pattern.",
+                    "Given the field pattern above, it could be templated out to: 00276_op0214_0001_e.tif",
+                    "With the template: 00$1_op0$2_0001_e.tif"})
+    private String filenameTemplate;
+
+    @Option(names = {"-u", "--update"},
+            description = {
+                    "If provided, then any source file matches produced will be used to update an existing"
+                    + " source file mapping file, instead of attempting to create a new one.",
+                    "This can be used to build up the mapping in multiple passes"})
+    private Boolean update;
+
+    @Option(names = {"-d", "--dry-run"},
+            description = {
+                    "If provided, then the output of the matching will be displayed in the console rather "
+                    + "than written to file"})
+    private Boolean dryRun;
+
+    public Path getBasePath() {
+        return basePath;
+    }
+
+    public void setBasePath(Path basePathPattern) {
+        this.basePath = basePathPattern;
+    }
+
+    public String getPathPattern() {
+        return pathPattern;
+    }
+
+    public void setPathPattern(String pathPattern) {
+        this.pathPattern = pathPattern;
+    }
+
+    public String getExportField() {
+        return exportField;
+    }
+
+    public void setExportField(String exportField) {
+        this.exportField = exportField;
+    }
+
+    public String getFieldMatchingPattern() {
+        return fieldMatchingPattern;
+    }
+
+    public void setFieldMatchingPattern(String fieldMatchingPattern) {
+        this.fieldMatchingPattern = fieldMatchingPattern;
+    }
+
+    public String getFilenameTemplate() {
+        return filenameTemplate;
+    }
+
+    public void setFilenameTemplate(String filenameTemplate) {
+        this.filenameTemplate = filenameTemplate;
+    }
+
+    public Boolean getUpdate() {
+        return update;
+    }
+
+    public void setUpdate(Boolean update) {
+        this.update = update;
+    }
+
+    public Boolean getDryRun() {
+        return dryRun;
+    }
+
+    public void setDryRun(Boolean dryRun) {
+        this.dryRun = dryRun;
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/SourceFileMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/SourceFileMappingOptions.java
@@ -66,10 +66,16 @@ public class SourceFileMappingOptions {
             description = {
                     "Template used to produce expected source file filenames.",
                     "It should be used with matching groups from --field-pattern.",
+                    "NOTE: Use single quotes to wrap this value, or escape the $ characters as \\$.",
                     "Given the field pattern above, it could be templated out to: 00276_op0214_0001_e.tif",
                     "With the template: 00$1_op0$2_0001_e.tif"},
             defaultValue = "$1")
     private String filenameTemplate;
+
+    @Option(names = {"-l", "--lower-template"},
+            description = "Convert the filename produced from the --file-temp option to lowercase "
+                    + "prior to attempting to match against source files.")
+    private boolean lowercaseTemplate;
 
     @Option(names = {"-u", "--update"},
             description = {
@@ -126,6 +132,14 @@ public class SourceFileMappingOptions {
 
     public void setFilenameTemplate(String filenameTemplate) {
         this.filenameTemplate = filenameTemplate;
+    }
+
+    public boolean isLowercaseTemplate() {
+        return lowercaseTemplate;
+    }
+
+    public void setLowercaseTemplate(boolean lowercaseTemplate) {
+        this.lowercaseTemplate = lowercaseTemplate;
     }
 
     public boolean getUpdate() {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/AccessFileService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/AccessFileService.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.services;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+
+/**
+ * Service for interacting with access copy files
+ * @author bbpennel
+ */
+public class AccessFileService extends SourceFileService {
+
+    public AccessFileService() {
+    }
+
+    @Override
+    protected void setUpdatedDate(Instant timestamp) throws IOException {
+        project.getProjectProperties().setAccessFilesUpdatedDate(timestamp);
+        ProjectPropertiesSerialization.write(project);
+    }
+
+    @Override
+    protected Path getMappingPath() {
+        return project.getAccessFilesMappingPath();
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DestinationsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DestinationsService.java
@@ -129,7 +129,7 @@ public class DestinationsService {
 
     /**
      * @param project
-     * @return the destiantion mapping info for the provided project
+     * @return the destination mapping info for the provided project
      * @throws IOException
      */
     public static DestinationsInfo loadMappings(MigrationProject project) throws IOException {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileService.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.services;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.options.SourceFileMappingOptions;
+
+/**
+ * Service for interacting with source files
+ * @author bbpennel
+ */
+public class SourceFileService {
+    private static final Logger log = getLogger(SourceFileService.class);
+    private static final int FETCH_SIZE = 1000;
+    public static final String POTENTIAL_MATCHES_FIELD = "potential_matches";
+    public static final String SOURCE_FILE_FIELD = "source_file";
+    public static final String EXPORT_MATCHING_FIELD = "matching_value";
+    public static final String ID_FIELD = "id";
+    public static final String[] CSV_HEADERS = new String[] {
+            ID_FIELD, EXPORT_MATCHING_FIELD, SOURCE_FILE_FIELD, POTENTIAL_MATCHES_FIELD };
+
+    private MigrationProject project;
+    private CdmIndexService indexService;
+
+    public SourceFileService() {
+    }
+
+    /**
+     * Generate the source file mapping
+     * @param options
+     * @throws IOException
+     */
+    public void generateMapping(SourceFileMappingOptions options) throws IOException {
+        assertProjectStateValid();
+
+        // Gather listing of all potential source file paths to match against
+        Map<String, List<String>> candidatePaths = gatherCandidatePaths(options);
+
+        Pattern fieldMatchingPattern = Pattern.compile(options.getFieldMatchingPattern());
+
+        // Iterate through exported objects in this collection to match against
+        Connection conn = null;
+        try (
+            // Write to system.out if doing a dry run, otherwise write to mappings file
+            BufferedWriter writer = options.getDryRun() ?
+                    new BufferedWriter(new OutputStreamWriter(System.out)) :
+                    Files.newBufferedWriter(project.getSourceFilesMappingPath());
+            CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.withHeader(CSV_HEADERS));
+        ){
+            // Query for all values of the export field to be used for matching
+            conn = indexService.openDbConnection();
+            PreparedStatement stmt = conn.prepareStatement("select cdmid, ? from ?");
+            stmt.setString(1, options.getExportField());
+            stmt.setString(2, CdmIndexService.TB_NAME);
+            stmt.setFetchSize(FETCH_SIZE);
+            ResultSet rs = stmt.executeQuery();
+            while (rs.next()) {
+                String cdmId = rs.getString(1);
+                String dbFilename = rs.getString(2);
+
+                if (StringUtils.isBlank(dbFilename)) {
+                    log.debug("No matching field for object {}", cdmId);
+                    csvPrinter.printRecord(cdmId, null, null, null);
+                    continue;
+                }
+
+                Matcher fieldMatcher = fieldMatchingPattern.matcher(dbFilename);
+                if (fieldMatcher.matches()) {
+                    String transformed = fieldMatcher.replaceFirst(options.getFilenameTemplate());
+
+                    List<String> paths = candidatePaths.get(transformed);
+                    if (paths.size() > 1) {
+                        log.debug("Encountered multiple potential matches for {} from field {}", cdmId, dbFilename);
+                        csvPrinter.printRecord(cdmId, dbFilename, null, String.join(",", paths));
+                    } else if (paths.size() == 1) {
+                        log.debug("Found match for {} from field {}", cdmId, dbFilename);
+                        csvPrinter.printRecord(cdmId, dbFilename, paths.get(0), null);
+                    } else {
+                        throw new MigrationException("No paths returned for matching field value " + dbFilename);
+                    }
+                } else {
+                    log.debug("Field {} for object {} with field {} does not match the field value pattern",
+                            options.getExportField(), cdmId, dbFilename);
+                    csvPrinter.printRecord(cdmId, dbFilename, null, null);
+                }
+            }
+        } catch (SQLException e) {
+            throw new MigrationException("Error interacting with export index", e);
+        } finally {
+            CdmIndexService.closeDbConnection(conn);
+        }
+    }
+
+    private Map<String, List<String>> gatherCandidatePaths(SourceFileMappingOptions options) throws IOException {
+        Path basePath = options.getBasePath();
+        if (!Files.isDirectory(basePath)) {
+            throw new IllegalArgumentException("Base path must be a directory");
+        }
+
+        final String pathPattern;
+        if (StringUtils.isBlank(options.getPathPattern())) {
+            pathPattern = null;
+        } else {
+            if (Paths.get(options.getPathPattern()).isAbsolute()) {
+                throw new IllegalArgumentException("Path pattern must be relative");
+            }
+            pathPattern = options.getPathPattern();
+        }
+
+        // Mapping of filenames to relative paths versus the base path for those files
+        Map<String, List<String>> candidatePaths = new HashMap<>();
+        PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher(pathPattern);
+        Files.walkFileTree(basePath, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) throws IOException {
+                if (pathPattern == null || pathMatcher.matches(path)) {
+                    String filename = path.getFileName().toString();
+                    List<String> paths = candidatePaths.computeIfAbsent(filename, f -> new ArrayList<>());
+                    paths.add(basePath.relativize(path).toString());
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException exc)
+                    throws IOException {
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        return candidatePaths;
+    }
+
+    private void assertProjectStateValid() {
+        if (project.getProjectProperties().getIndexedDate() == null) {
+            throw new InvalidProjectStateException("Project must be indexed prior to generating source mappings");
+        }
+    }
+
+    public void setProject(MigrationProject project) {
+        this.project = project;
+    }
+
+    public void setIndexService(CdmIndexService indexService) {
+        this.indexService = indexService;
+    }
+}

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AccessFilesCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AccessFilesCommandIT.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+
+/**
+ * @author bbpennel
+ */
+public class AccessFilesCommandIT extends AbstractCommandIT {
+    private final static String COLLECTION_ID = "my_coll";
+
+    private MigrationProject project;
+    private Path basePath;
+
+    @Before
+    public void setup() throws Exception {
+        project = MigrationProjectFactory.createMigrationProject(
+                baseDir, COLLECTION_ID, null, USERNAME);
+        basePath = tmpFolder.newFolder().toPath();
+    }
+
+    @Test
+    public void generateNotIndexedTest() throws Exception {
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "access_files", "generate",
+                "-b", basePath.toString(),
+                "-n", "file"};
+        executeExpectFailure(args);
+
+        assertOutputContains("Project must be indexed");
+
+        assertUpdatedDateNotPresent();
+    }
+
+    @Test
+    public void generateNoExportFieldTest() throws Exception {
+        indexExportSamples();
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "access_files", "generate",
+                "-b", basePath.toString(),
+                "-n", ""};
+        executeExpectFailure(args);
+
+        assertOutputContains("Must provide an export field");
+
+        assertUpdatedDateNotPresent();
+    }
+
+    @Test
+    public void generateNoBasePathTest() throws Exception {
+        indexExportSamples();
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "access_files", "generate",
+                "-n", "file"};
+        executeExpectFailure(args);
+
+        assertOutputContains("Must provide a base path");
+
+        assertUpdatedDateNotPresent();
+    }
+
+    @Test
+    public void generateBasicMatchSucceedsTest() throws Exception {
+        indexExportSamples();
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "access_files", "generate",
+                "-b", basePath.toString(),
+                "-n", "file"};
+        executeExpectSuccess(args);
+
+        assertTrue(Files.exists(project.getAccessFilesMappingPath()));
+        assertFalse(Files.exists(project.getSourceFilesMappingPath()));
+
+        assertUpdatedDatePresent();
+    }
+
+    @Test
+    public void generateBasicMatchDryRunTest() throws Exception {
+        indexExportSamples();
+        Path srcPath1 = addSourceFile("276_182_E.tif");
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "access_files", "generate",
+                "--dry-run",
+                "-b", basePath.toString()};
+        executeExpectSuccess(args);
+
+        assertFalse(Files.exists(project.getAccessFilesMappingPath()));
+        assertTrue(output.contains("25,276_182_E.tif," + srcPath1.toString() + ","));
+        assertTrue(output.contains("26,276_183B_E.tif,,"));
+        assertTrue(output.contains("27,276_203_E.tif,,"));
+
+        assertUpdatedDateNotPresent();
+    }
+
+    @Test
+    public void generateNestedPatternMatchDryRunTest() throws Exception {
+        indexExportSamples();
+        Path srcPath1 = addSourceFile("path/to/00276_op0182_0001_e.tif");
+        Path srcPath3 = addSourceFile("00276_op0203_0001_e.tif");
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "access_files", "generate",
+                "--dry-run",
+                "-b", basePath.toString(),
+                "-p", "(\\d+)\\_(\\d+)_E.tif",
+                "-t", "00$1_op0$2_0001_e.tif" };
+        executeExpectSuccess(args);
+
+        assertFalse(Files.exists(project.getAccessFilesMappingPath()));
+        assertTrue(output.contains("25,276_182_E.tif," + srcPath1.toString() + ","));
+        assertTrue(output.contains("26,276_183B_E.tif,,"));
+        assertTrue(output.contains("27,276_203_E.tif," + srcPath3 + ","));
+
+        assertUpdatedDateNotPresent();
+    }
+
+    private void indexExportSamples() throws Exception {
+        Files.createDirectories(project.getExportPath());
+        Files.copy(Paths.get("src/test/resources/sample_exports/export_1.xml"),
+                project.getExportPath().resolve("export_all.xml"));
+        Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
+
+        project.getProjectProperties().setExportedDate(Instant.now());
+        ProjectPropertiesSerialization.write(project);
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "index"};
+        executeExpectSuccess(args);
+    }
+
+    private Path addSourceFile(String relPath) throws IOException {
+        Path srcPath = basePath.resolve(relPath);
+        // Create parent directories in case they don't exist
+        Files.createDirectories(srcPath.getParent());
+        Files.createFile(srcPath);
+        return srcPath;
+    }
+
+    private void assertUpdatedDatePresent() throws Exception {
+        MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
+        assertNotNull("Updated timestamp must be set", props.getAccessFilesUpdatedDate());
+        assertNull("Source mapping timestamp must not be set", props.getSourceFilesUpdatedDate());
+    }
+
+    private void assertUpdatedDateNotPresent() throws Exception {
+        MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
+        assertNull("Updated timestamp must not be set", props.getAccessFilesUpdatedDate());
+        assertNull("Source mapping timestamp must not be set", props.getSourceFilesUpdatedDate());
+    }
+}

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+
+/**
+ * @author bbpennel
+ */
+public class SourceFilesCommandIT extends AbstractCommandIT {
+    private final static String COLLECTION_ID = "my_coll";
+
+    private MigrationProject project;
+    private Path basePath;
+
+    @Before
+    public void setup() throws Exception {
+        project = MigrationProjectFactory.createMigrationProject(
+                baseDir, COLLECTION_ID, null, USERNAME);
+        basePath = tmpFolder.newFolder().toPath();
+    }
+
+    @Test
+    public void generateNotIndexedTest() throws Exception {
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "source_files", "generate",
+                "-b", basePath.toString(),
+                "-n", "file"};
+        executeExpectFailure(args);
+
+        assertOutputContains("Project must be indexed");
+    }
+
+    @Test
+    public void generateNoExportFieldTest() throws Exception {
+        indexExportSamples();
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "source_files", "generate",
+                "-b", basePath.toString(),
+                "-n", ""};
+        executeExpectFailure(args);
+
+        assertOutputContains("Must provide an export field");
+    }
+
+    @Test
+    public void generateNoBasePathTest() throws Exception {
+        indexExportSamples();
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "source_files", "generate",
+                "-n", "file"};
+        executeExpectFailure(args);
+
+        assertOutputContains("Must provide a base path");
+    }
+
+    @Test
+    public void generateBasicMatchSucceedsTest() throws Exception {
+        indexExportSamples();
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "source_files", "generate",
+                "-b", basePath.toString(),
+                "-n", "file"};
+        executeExpectSuccess(args);
+
+        assertTrue(Files.exists(project.getSourceFilesMappingPath()));
+    }
+
+    @Test
+    public void generateBasicMatchDryRunTest() throws Exception {
+        indexExportSamples();
+        Path srcPath1 = addSourceFile("276_182_E.tif");
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "source_files", "generate",
+                "--dry-run",
+                "-b", basePath.toString()};
+        executeExpectSuccess(args);
+
+        assertFalse(Files.exists(project.getSourceFilesMappingPath()));
+        assertTrue(output.contains("25,276_182_E.tif," + srcPath1.toString() + ","));
+        assertTrue(output.contains("26,276_183_E.tif,,"));
+        assertTrue(output.contains("27,276_203_E.tif,,"));
+    }
+
+    private void indexExportSamples() throws Exception {
+        Files.createDirectories(project.getExportPath());
+        Files.copy(Paths.get("src/test/resources/sample_exports/export_1.xml"),
+                project.getExportPath().resolve("export_all.xml"));
+        Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
+
+        project.getProjectProperties().setExportedDate(Instant.now());
+        ProjectPropertiesSerialization.write(project);
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "index"};
+        executeExpectSuccess(args);
+    }
+
+    private Path addSourceFile(String relPath) throws IOException {
+        Path srcPath = basePath.resolve(relPath);
+        // Create parent directories in case they don't exist
+        Files.createDirectories(srcPath.getParent());
+        Files.createFile(srcPath);
+        return srcPath;
+    }
+}

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
@@ -110,9 +110,9 @@ public class SourceFilesCommandIT extends AbstractCommandIT {
         executeExpectSuccess(args);
 
         assertFalse(Files.exists(project.getSourceFilesMappingPath()));
-        assertTrue(output.contains("25,276_182_E.tif," + srcPath1.toString() + ","));
-        assertTrue(output.contains("26,276_183B_E.tif,,"));
-        assertTrue(output.contains("27,276_203_E.tif,,"));
+        assertOutputContains("25,276_182_E.tif," + srcPath1.toString() + ",");
+        assertOutputContains("26,276_183B_E.tif,,");
+        assertOutputContains("27,276_203_E.tif,,");
     }
 
     @Test
@@ -131,9 +131,34 @@ public class SourceFilesCommandIT extends AbstractCommandIT {
         executeExpectSuccess(args);
 
         assertFalse(Files.exists(project.getSourceFilesMappingPath()));
-        assertTrue(output.contains("25,276_182_E.tif," + srcPath1.toString() + ","));
-        assertTrue(output.contains("26,276_183B_E.tif,,"));
-        assertTrue(output.contains("27,276_203_E.tif," + srcPath3 + ","));
+        assertOutputContains("25,276_182_E.tif," + srcPath1.toString() + ",");
+        assertOutputContains("26,276_183B_E.tif,,");
+        assertOutputContains("27,276_203_E.tif," + srcPath3 + ",");
+    }
+
+    @Test
+    public void generateUpdateAddSourceFileDryRunTest() throws Exception {
+        indexExportSamples();
+        Path srcPath1 = addSourceFile("276_182_E.tif");
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "source_files", "generate",
+                "-b", basePath.toString()};
+        executeExpectSuccess(args);
+
+        Path srcPath2 = addSourceFile("276_183B_E.tif");
+        String[] args2 = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "source_files", "generate",
+                "-u",
+                "--dry-run",
+                "-b", basePath.toString()};
+        executeExpectSuccess(args2);
+
+        assertOutputContains("25,276_182_E.tif," + srcPath1.toString() + ",");
+        assertOutputContains("26,276_183B_E.tif," + srcPath2.toString() + ",");
+        assertOutputContains("27,276_203_E.tif,,");
     }
 
     private void indexExportSamples() throws Exception {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
@@ -111,8 +111,29 @@ public class SourceFilesCommandIT extends AbstractCommandIT {
 
         assertFalse(Files.exists(project.getSourceFilesMappingPath()));
         assertTrue(output.contains("25,276_182_E.tif," + srcPath1.toString() + ","));
-        assertTrue(output.contains("26,276_183_E.tif,,"));
+        assertTrue(output.contains("26,276_183B_E.tif,,"));
         assertTrue(output.contains("27,276_203_E.tif,,"));
+    }
+
+    @Test
+    public void generateNestedPatternMatchDryRunTest() throws Exception {
+        indexExportSamples();
+        Path srcPath1 = addSourceFile("path/to/00276_op0182_0001_e.tif");
+        Path srcPath3 = addSourceFile("00276_op0203_0001_e.tif");
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "source_files", "generate",
+                "--dry-run",
+                "-b", basePath.toString(),
+                "-p", "(\\d+)\\_(\\d+)_E.tif",
+                "-t", "00$1_op0$2_0001_e.tif" };
+        executeExpectSuccess(args);
+
+        assertFalse(Files.exists(project.getSourceFilesMappingPath()));
+        assertTrue(output.contains("25,276_182_E.tif," + srcPath1.toString() + ","));
+        assertTrue(output.contains("26,276_183B_E.tif,,"));
+        assertTrue(output.contains("27,276_203_E.tif," + srcPath3 + ","));
     }
 
     private void indexExportSamples() throws Exception {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
@@ -110,7 +110,7 @@ public class CdmIndexServiceTest {
             assertEquals("2005-11-23", rs.getString("cdmcreated"));
             assertEquals("Plan of Battery McIntosh", rs.getString("title"));
             assertEquals("Paper", rs.getString("medium"));
-            assertEquals("276_183_E.tif", rs.getString("file"));
+            assertEquals("276_183B_E.tif", rs.getString("file"));
 
             rs.next();
             assertEquals(27, rs.getInt("cdmid"));

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
@@ -126,7 +126,7 @@ public class SourceFileServiceTest {
         SourceFileMappingOptions options = makeDefaultOptions();
         service.generateMapping(options);
 
-        SourceFilesInfo info = SourceFileService.loadMappings(project);
+        SourceFilesInfo info = service.loadMappings();
         assertMappingPresent(info, "25", "276_182_E.tif", null);
         assertMappingPresent(info, "26", "276_183B_E.tif", null);
         assertMappingPresent(info, "27", "276_203_E.tif", null);
@@ -142,7 +142,7 @@ public class SourceFileServiceTest {
 
         service.generateMapping(options);
 
-        SourceFilesInfo info = SourceFileService.loadMappings(project);
+        SourceFilesInfo info = service.loadMappings();
         assertMappingPresent(info, "25", "276_182_E.tif", srcPath1);
         assertMappingPresent(info, "26", "276_183B_E.tif", null);
         assertMappingPresent(info, "27", "276_203_E.tif", null);
@@ -161,7 +161,7 @@ public class SourceFileServiceTest {
 
         service.generateMapping(options);
 
-        SourceFilesInfo info = SourceFileService.loadMappings(project);
+        SourceFilesInfo info = service.loadMappings();
         assertMappingPresent(info, "25", "276_182_E.tif", srcPath1);
         assertMappingPresent(info, "26", "276_183B_E.tif", null);
         assertMappingPresent(info, "27", "276_203_E.tif", srcPath3);
@@ -179,7 +179,7 @@ public class SourceFileServiceTest {
 
         service.generateMapping(options);
 
-        SourceFilesInfo info = SourceFileService.loadMappings(project);
+        SourceFilesInfo info = service.loadMappings();
         assertMappingPresent(info, "25", "276_182_E.tif", srcPath1);
         assertMappingPresent(info, "26", "276_183B_E.tif", srcPath2);
         assertMappingPresent(info, "27", "276_203_E.tif", null);
@@ -199,7 +199,7 @@ public class SourceFileServiceTest {
 
         service.generateMapping(options);
 
-        SourceFilesInfo info = SourceFileService.loadMappings(project);
+        SourceFilesInfo info = service.loadMappings();
         assertMappingPresent(info, "25", "276_182_E.tif", srcPath1);
         assertMappingPresent(info, "26", "276_183B_E.tif", null);
         assertMappingPresent(info, "27", "276_203_E.tif", null);
@@ -218,7 +218,7 @@ public class SourceFileServiceTest {
 
         service.generateMapping(options);
 
-        SourceFilesInfo info = SourceFileService.loadMappings(project);
+        SourceFilesInfo info = service.loadMappings();
         assertMappingPresent(info, "25", "276_182_E.tif", null, srcPath1, srcPath1Dupe);
         assertMappingPresent(info, "26", "276_183B_E.tif", srcPath2);
         assertMappingPresent(info, "27", "276_203_E.tif", null);
@@ -248,7 +248,7 @@ public class SourceFileServiceTest {
 
         service.generateMapping(options);
 
-        SourceFilesInfo info = SourceFileService.loadMappings(project);
+        SourceFilesInfo info = service.loadMappings();
         assertMappingPresent(info, "25", "276_182_E.tif", srcPath1);
         assertMappingPresent(info, "26", "276_183B_E.tif", null);
         assertMappingPresent(info, "27", "276_203_E.tif", null);
@@ -259,10 +259,10 @@ public class SourceFileServiceTest {
             service.generateMapping(options);
             fail();
         } catch (MigrationException e) {
-            assertTrue(e.getMessage().contains("Cannot create source mapping, a file already exists"));
+            assertTrue(e.getMessage().contains("Cannot create mapping, a file already exists"));
         }
 
-        SourceFilesInfo info2 = SourceFileService.loadMappings(project);
+        SourceFilesInfo info2 = service.loadMappings();
         assertMappingPresent(info2, "25", "276_182_E.tif", srcPath1);
         assertMappingPresent(info2, "26", "276_183B_E.tif", null);
         assertMappingPresent(info2, "27", "276_203_E.tif", null);
@@ -271,7 +271,7 @@ public class SourceFileServiceTest {
         options.setForce(true);
         service.generateMapping(options);
 
-        SourceFilesInfo info3 = SourceFileService.loadMappings(project);
+        SourceFilesInfo info3 = service.loadMappings();
         assertMappingPresent(info3, "25", "276_182_E.tif", srcPath1);
         assertMappingPresent(info3, "26", "276_183B_E.tif", srcPath2);
         assertMappingPresent(info3, "27", "276_203_E.tif", null);
@@ -289,7 +289,7 @@ public class SourceFileServiceTest {
 
         service.generateMapping(options);
 
-        SourceFilesInfo info = SourceFileService.loadMappings(project);
+        SourceFilesInfo info = service.loadMappings();
         assertMappingPresent(info, "25", "276_182_E.tif", srcPath1);
         assertMappingPresent(info, "26", "276_183B_E.tif", srcPath2);
         assertMappingPresent(info, "27", "276_203_E.tif", null);

--- a/src/test/resources/sample_exports/export_1.xml
+++ b/src/test/resources/sample_exports/export_1.xml
@@ -100,7 +100,7 @@
     <local>276/183</local>
     <creata>Gilmer Map Number 8</creata>
     <sponso>[Identification of item], in the Jeremy Francis Gilmer Papers #276, Southern Historical Collection, Wilson Library, University of North Carolina at Chapel Hill.</sponso>
-    <file>276_183_E.tif</file>
+    <file>276_183B_E.tif</file>
     <rights>Public Domain</rights>
     <orderi></orderi>
     <initia>276_183.tif</initia>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3175

* Add command for generating source file mappings
    * supports matching files from a base directory against a field from the CDM export, using regular expressions to transform the value of the field to match the expected filename
    * Produces a CSV document with the mappings
    * Allows for the CSV document to be update based on the result of subsequent generation commands
* Add command for generating access file mappings, which works the same as source file mappings