### PR TITLE
BXC-3297 link to Box-C readme for instructions instead of old repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,13 @@ The project has only been tested in Mac and Linux environments
 
 ## Initial project setup
 When first setting up the project for development purposes, you will need to perform the following steps:
+
+* First, make a local clone of the box-c repo and build it
+>[Box-C Build Steps](https://github.com/UNC-Libraries/box-c#building-the-project)
+
+* Next, clone the migration utility and build it
 ```
-# First, make a local clone of the box-c and build it
-git clone git@github.com:UNC-Libraries/Carolina-Digital-Repository.git
-cd Carolina-Digital-Repository
-mvn clean install -DskipTests
-
-cd ..
-
-# Next, clone the migration utility and build it
+# in your home directory
 git clone git@github.com:UNC-Libraries/cdm-to-boxc-migration-util.git
 cd cdm-to-boxc-migration-util
 mvn clean install

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The project has only been tested in Mac and Linux environments
 When first setting up the project for development purposes, you will need to perform the following steps:
 
 * First, make a local clone of the box-c repo and build it
->[Box-C Build Steps](https://github.com/UNC-Libraries/box-c#building-the-project)
+>[Box-C Build Steps](https://github.com/UNC-Libraries/box-c#requirements)
 
 * Next, clone the migration utility and build it
 ```


### PR DESCRIPTION
This is a small update to the CDM to Box-C util readme which had outdated information for cloning the Box-C repository. Now it directly links to the new one (in case there are changes, so they won't have to be updated in two places).