### PR TITLE
Catch output to prevent intellij test failures

### DIFF
--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Paths;
@@ -33,6 +35,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import edu.unc.lib.boxc.migration.cdm.test.OutputHelper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -116,17 +119,19 @@ public class GroupMappingServiceTest {
 
     @Test
     public void generateDryRunTest() throws Exception {
-        indexExportSamples();
-        GroupMappingOptions options = makeDefaultOptions();
-        options.setDryRun(true);
-        service.generateMapping(options);
+        OutputHelper.captureOutput(() -> {
+            try {
+                indexExportSamples();
+                GroupMappingOptions options = makeDefaultOptions();
+                options.setDryRun(true);
+                service.generateMapping(options);
 
-        try {
-            service.loadMappings();
-            fail();
-        } catch (NoSuchFileException e) {
-            // expected
-        }
+                service.loadMappings();
+                fail();
+            } catch (NoSuchFileException e) {
+                // expected
+            }
+        });
 
         assertMappedDateNotPresent();
     }
@@ -160,26 +165,25 @@ public class GroupMappingServiceTest {
 
     @Test
     public void generateSecondDryRunTest() throws Exception {
-        indexExportSamples();
-        GroupMappingOptions options = makeDefaultOptions();
-        service.generateMapping(options);
+        OutputHelper.captureOutput(() -> {
+            indexExportSamples();
+            GroupMappingOptions options = makeDefaultOptions();
+            service.generateMapping(options);
+            options.setDryRun(true);
 
-        options.setDryRun(true);
-
-        service.generateMapping(options);
-
-        // mapping state should be unchanged
-        GroupMappingInfo info = service.loadMappings();
-        String group1Key = info.getGroupKeyByMatchedValue("groupa:group1");
-        String group2Key = info.getGroupKeyByMatchedValue("groupa:group2");
-        assertMappingPresent(info, "25", "groupa:group1", group1Key);
-        assertMappingPresent(info, "26", "groupa:group1", group1Key);
-        assertMappingPresent(info, "27", "groupa:group2", group2Key);
-        assertMappingPresent(info, "28", null, null);
-        assertMappingPresent(info, "29", null, null);
-        assertEquals(5, info.getMappings().size());
-
-        assertMappedDatePresent();
+            service.generateMapping(options);
+            // mapping state should be unchanged
+            GroupMappingInfo info = service.loadMappings();
+            String group1Key = info.getGroupKeyByMatchedValue("groupa:group1");
+            String group2Key = info.getGroupKeyByMatchedValue("groupa:group2");
+            assertMappingPresent(info, "25", "groupa:group1", group1Key);
+            assertMappingPresent(info, "26", "groupa:group1", group1Key);
+            assertMappingPresent(info, "27", "groupa:group2", group2Key);
+            assertMappingPresent(info, "28", null, null);
+            assertMappingPresent(info, "29", null, null);
+            assertEquals(5, info.getMappings().size());
+            assertMappedDatePresent();
+        });
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
@@ -29,6 +29,7 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.List;
 
+import edu.unc.lib.boxc.migration.cdm.test.OutputHelper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -228,16 +229,18 @@ public class SourceFileServiceTest {
 
     @Test
     public void generateDryRunTest() throws Exception {
-        indexExportSamples();
-        SourceFileMappingOptions options = makeDefaultOptions();
-        options.setDryRun(true);
-        addSourceFile("276_182_E.tif");
+        OutputHelper.captureOutput(() -> {
+            indexExportSamples();
+            SourceFileMappingOptions options = makeDefaultOptions();
+            options.setDryRun(true);
+            addSourceFile("276_182_E.tif");
 
-        service.generateMapping(options);
+            service.generateMapping(options);
 
-        assertFalse(Files.exists(project.getSourceFilesMappingPath()));
+            assertFalse(Files.exists(project.getSourceFilesMappingPath()));
 
-        assertMappedDateNotPresent();
+            assertMappedDateNotPresent();
+        });
     }
 
     @Test
@@ -503,16 +506,18 @@ public class SourceFileServiceTest {
 
         service.generateMapping(options);
 
-        addSourceFile("276_183B_E.tif");
-        options.setUpdate(true);
-        options.setDryRun(true);
-        service.generateMapping(options);
+        OutputHelper.captureOutput(() -> {
+            addSourceFile("276_183B_E.tif");
+            options.setUpdate(true);
+            options.setDryRun(true);
+            service.generateMapping(options);
 
-        SourceFilesInfo info2 = service.loadMappings();
-        assertMappingPresent(info2, "25", "276_182_E.tif", srcPath1);
-        // Mapping should be unchanged
-        assertMappingPresent(info2, "26", "276_183B_E.tif", null);
-        assertMappingPresent(info2, "27", "276_203_E.tif", null);
+            SourceFilesInfo info2 = service.loadMappings();
+            assertMappingPresent(info2, "25", "276_182_E.tif", srcPath1);
+            // Mapping should be unchanged
+            assertMappingPresent(info2, "26", "276_183B_E.tif", null);
+            assertMappingPresent(info2, "27", "276_203_E.tif", null);
+        });
     }
 
     private void assertMappingPresent(SourceFilesInfo info, String cdmid, String matchingVal, Path sourcePath,

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/OutputHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/OutputHelper.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+/**
+ * @author bbpennel
+ */
+public class OutputHelper {
+
+    @FunctionalInterface
+    public interface CheckedRunnable {
+        void run() throws Exception;
+    }
+
+    /**
+     * Capture the output of the provided code block
+     * @param runnable
+     * @return
+     */
+    public static String captureOutput(CheckedRunnable runnable) {
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        try {
+            runnable.run();
+        } catch (Exception e) {
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            }
+            throw new RuntimeException(e);
+        } finally {
+            System.setOut(originalOut);
+        }
+        return out.toString();
+    }
+}


### PR DESCRIPTION
Add helper for consuming output from tests, use it for some of the dry run tests since otherwise intellij can't run them