### PR TITLE
Bxc 3177 mapping csvs

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
@@ -35,6 +35,7 @@ public class MigrationProject {
     public static final String ACCESS_MAPPING_FILENAME = "access_files.csv";
     public static final String GROUP_MAPPING_FILENAME = "group_mappings.csv";
     public static final String SIPS_DIRNAME = "sips";
+    public static final String REDIRECT_MAPPING_FILENAME = "redirect_mappings.csv";
 
     private Path projectPath;
     private MigrationProjectProperties properties;
@@ -150,5 +151,12 @@ public class MigrationProject {
      */
     public String getProjectName() {
         return properties.getName();
+    }
+
+    /**
+     * @return Path of the redirect mapping file
+     */
+    public Path getRedirectMappingPath() {
+        return projectPath.resolve(REDIRECT_MAPPING_FILENAME);
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingService.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.services;
+
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+
+/**
+ * @author snluong
+ */
+public class RedirectMappingService {
+    private MigrationProject project;
+
+    public RedirectMappingService(MigrationProject project) {
+        this.project = project;
+    }
+
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingService.java
@@ -15,16 +15,69 @@
  */
 package edu.unc.lib.boxc.migration.cdm.services;
 
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.GroupMappingInfo;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.file.Files;
 
 /**
+ * Service for generating a redirect mapping csv with the following information:
+ * CDM Collection ID, CDM Object ID, Box-c Work ID, Box-c File ID
+ *
  * @author snluong
  */
 public class RedirectMappingService {
     private MigrationProject project;
+    private CSVPrinter csvPrinter;
+    public static final String[] CSV_HEADERS = new String[] {
+            "cdm_collection_id", "cdm_object_id", "boxc_work_id", "boxc_file_id" };
 
     public RedirectMappingService(MigrationProject project) {
         this.project = project;
     }
 
+    /**
+     * Opens RedirectMapping CSV and sets its path
+     */
+    public void init() {
+        try {
+            BufferedWriter writer = Files.newBufferedWriter(project.getRedirectMappingPath());
+            csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.withHeader(CSV_HEADERS));
+        } catch (IOException e) {
+            throw new MigrationException("Error creating redirect mapping CSV", e);
+        }
+
+    }
+
+    /**
+     * Closes RedirectMapping CSV
+     */
+    public void closeCsv() {
+        try {
+            csvPrinter.close();
+        } catch (IOException e) {
+            throw new MigrationException("Error closing redirect mapping CSV", e);
+        }
+    }
+
+    /**
+     * Adds row to Redirect Mapping CSV in the correct order
+     * @param cdmObjectId
+     * @param boxcWorkId
+     * @param boxcFileId
+     */
+    public void addRow(String cdmObjectId, String boxcWorkId, String boxcFileId) {
+        String cdmCollectionId = project.getProjectProperties().getCdmCollectionId();
+        try {
+            csvPrinter.printRecord(cdmCollectionId, cdmObjectId, boxcWorkId, boxcFileId);
+        } catch (IOException e) {
+            throw new MigrationException("Error adding row to redirect mapping CSV", e);
+        }
+    }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingService.java
@@ -16,14 +16,12 @@
 package edu.unc.lib.boxc.migration.cdm.services;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
-import edu.unc.lib.boxc.migration.cdm.model.GroupMappingInfo;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.nio.file.Files;
 
 /**

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
@@ -383,6 +383,9 @@ public class SipService {
                 }
             }
 
+            // add redirect mapping for this file
+            redirectMappingService.addRow(cdmId, workPid.getId(), fileObjPid.getId());
+
             return fileObjPid;
         }
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
@@ -253,7 +253,6 @@ public class SipService {
 
                 SourceFileMapping sourceMapping = getSourceFileMapping(cdmId);
                 PID filePid = addFileObject(cdmId, cdmCreated, sourceMapping);
-                redirectMappingService.addRow(cdmId, workPid.getId(), filePid.getId());
 
                 childPids.add(filePid);
             }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -15,35 +15,6 @@
  */
 package edu.unc.lib.boxc.migration.cdm.services;
 
-import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.AUTHENTICATED_PRINC;
-import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.PUBLIC_PRINC;
-import static java.nio.file.StandardOpenOption.APPEND;
-import static org.junit.Assert.*;
-
-import java.io.BufferedWriter;
-import java.io.Reader;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVRecord;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.jena.rdf.model.Bag;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.vocabulary.RDF;
-import org.jdom2.Document;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
 import edu.unc.lib.boxc.common.xml.SecureXMLFactory;
 import edu.unc.lib.boxc.deposit.impl.model.DepositDirectoryManager;
 import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
@@ -56,6 +27,37 @@ import edu.unc.lib.boxc.model.api.rdf.Cdr;
 import edu.unc.lib.boxc.model.api.rdf.CdrAcl;
 import edu.unc.lib.boxc.model.api.rdf.CdrDeposit;
 import edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.rdf.model.Bag;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDF;
+import org.jdom2.Document;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedWriter;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.AUTHENTICATED_PRINC;
+import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.PUBLIC_PRINC;
+import static java.nio.file.StandardOpenOption.APPEND;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author bbpennel

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -610,9 +610,8 @@ public class SipServiceTest {
         }
     }
 
-    // TODO generating sips twice should overwrite redirect mappings csv
     @Test
-    public void generateSipsTwiceWithRedirectMapping() throws Exception {
+    public void generateSipsTwiceOverwritesRedirectMapping() throws Exception {
         testHelper.indexExportData("export_1.xml");
         testHelper.generateDefaultDestinationsMapping(DEST_UUID, null);
         testHelper.populateDescriptions("gilmer_mods1.xml");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -31,6 +31,7 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
@@ -610,6 +611,25 @@ public class SipServiceTest {
     }
 
     // TODO generating sips twice should overwrite redirect mappings csv
+    @Test
+    public void generateSipsTwiceWithRedirectMapping() throws Exception {
+        testHelper.indexExportData("export_1.xml");
+        testHelper.generateDefaultDestinationsMapping(DEST_UUID, null);
+        testHelper.populateDescriptions("gilmer_mods1.xml");
+        testHelper.populateSourceFiles("276_182_E.tif", "276_183B_E.tif", "276_203_E.tif");
+
+        service.generateSips(makeOptions());
+        String redirectFile = FileUtils.readFileToString(project.getRedirectMappingPath().toFile(), StandardCharsets.UTF_8);
+
+        service = testHelper.createSipsService();
+        service.generateSips(makeOptions());
+        String secondRedirectFile = FileUtils.readFileToString(project.getRedirectMappingPath().toFile(), StandardCharsets.UTF_8);
+
+
+        assertTrue(Files.exists(project.getRedirectMappingPath()));
+        // make sure that sequential sips generation work/file ID changes are reflected in the redirect mapping csv
+        assertNotEquals(redirectFile, secondRedirectFile);
+    }
 
     private  SipGenerationOptions makeOptions() {
         return makeOptions(false);


### PR DESCRIPTION
This PR adds a redirect mapping service that generates a CSV with the following pieces of information in each row:
- CDM collection ID
- CDM object ID
- Box-c work ID
- Box-c file ID

The RedirectMappingService gets initialized (CSV is opened) at the beginning of the `generateSips` method and closed in its `finally` block. Every time a fileObject is generated, a row gets added to the CSV.

Lastly, there are four new SipsService tests for the new service.
https://jira.lib.unc.edu/browse/BXC-3177