### PR TITLE
BXC-3228 - Compound object support

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/CdmFieldInfo.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/CdmFieldInfo.java
@@ -39,6 +39,8 @@ public class CdmFieldInfo {
             CDM_ID, CDM_CREATED, "cdmmodified", "cdmfile", "cdmpath");
 
     private List<CdmFieldEntry> fields;
+    private List<String> exportFields;
+    private List<String> configuredFields;
 
     public CdmFieldInfo() {
         fields = new ArrayList<>();
@@ -53,13 +55,30 @@ public class CdmFieldInfo {
     }
 
     /**
+     * @return List of all the configured export fields. Does not include reserved CDM fields.
+     */
+    public List<String> listConfiguredFields() {
+        if (configuredFields == null) {
+            configuredFields = streamConfiguredFields().collect(Collectors.toList());
+        }
+        return configuredFields;
+    }
+
+    /**
      * @return List of all the exported fields, including reserved CDM fields
      */
-    public List<String> listExportFields() {
-        Stream<String> exportFields = getFields().stream()
+    public List<String> listAllExportFields() {
+        if (exportFields == null) {
+            exportFields = Streams.concat(streamConfiguredFields(), RESERVED_FIELDS.stream())
+                    .collect(Collectors.toList());
+        }
+        return exportFields;
+    }
+
+    private Stream<String> streamConfiguredFields() {
+        return getFields().stream()
                 .filter(f -> !f.getSkipExport() && !IGNORE_FIELDS.contains(f.getExportAs()))
                 .map(CdmFieldEntry::getExportAs);
-        return Streams.concat(exportFields, RESERVED_FIELDS.stream()).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
@@ -184,10 +184,10 @@ public class CdmIndexService {
 
         // Add in migration generated fields
         for (int j = 0; j < migrationFieldValues.length; j++) {
-            if (migrationFieldValues == null) {
-                stmt.setNull(i + j, Types.LONGVARCHAR);
+            if (migrationFieldValues[j] == null) {
+                stmt.setNull(i + j + 1, Types.LONGVARCHAR);
             } else {
-                stmt.setString(i + j, migrationFieldValues[j]);
+                stmt.setString(i + j + 1, migrationFieldValues[j]);
             }
         }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
@@ -173,6 +173,16 @@ public class CdmIndexService {
                 }).collect(Collectors.toList());
     }
 
+    /**
+     * Indexes the metadata of an object provided via exportFieldValues and migrationFieldValues
+     * @param conn
+     * @param exportFieldValues Values of all configured and reserved fields which belong to the object being indexed.
+     *                          Must be ordered with configured fields first, followed by reserved fields
+     *                          as defined in CdmFieldInfo.RESERVED_FIELDS
+     * @param migrationFieldValues Array of migration specific fields, in the order defined in
+     *                             CdmIndexService.MIGRATION_FIELDS
+     * @throws SQLException
+     */
     private void indexObject(Connection conn, List<String> exportFieldValues, String... migrationFieldValues)
             throws SQLException {
         PreparedStatement stmt = conn.prepareStatement(recordInsertSqlTemplate);

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
@@ -60,10 +60,14 @@ public class CdmIndexService {
     public static final String PARENT_ID_FIELD = "cdm2bxc_parent_id";
     public static final String ENTRY_TYPE_FIELD = "cdm2bxc_entry_type";
     public static final String ENTRY_TYPE_GROUPED_WORK = "grouped_work";
+    public static final String ENTRY_TYPE_COMPOUND_OBJECT = "cpd_object";
+    public static final String ENTRY_TYPE_COMPOUND_CHILD = "cpd_child";
     public static final List<String> MIGRATION_FIELDS = Arrays.asList(PARENT_ID_FIELD, ENTRY_TYPE_FIELD);
 
     private MigrationProject project;
     private CdmFieldService fieldService;
+
+    private String recordInsertSqlTemplate;
 
     /**
      * Indexes all exported CDM records for this project
@@ -73,10 +77,10 @@ public class CdmIndexService {
         assertCollectionExported();
 
         CdmFieldInfo fieldInfo = fieldService.loadFieldsFromProject(project);
-        List<String> exportFields = fieldInfo.listExportFields();
+        List<String> exportFields = fieldInfo.listAllExportFields();
         List<String> allFields = new ArrayList<>(exportFields);
         allFields.addAll(MIGRATION_FIELDS);
-        String insertTemplate = makeInsertTemplate(allFields);
+        recordInsertSqlTemplate = makeInsertTemplate(allFields);
 
         SAXBuilder builder = SecureXMLFactory.createSAXBuilder();
         Connection conn = null;
@@ -88,7 +92,7 @@ public class CdmIndexService {
                 Path exportPath = it.next();
                 outputLogger.info("Indexing file: {}", exportPath.getFileName());
                 Document doc = builder.build(exportPath.toFile());
-                indexDocument(doc, conn, insertTemplate, exportFields);
+                indexDocument(doc, conn, fieldInfo);
             }
         } catch (IOException e) {
             throw new MigrationException("Failed to read export files: " + e.getMessage());
@@ -116,38 +120,86 @@ public class CdmIndexService {
                 + ")";
     }
 
-    private void indexDocument(Document doc, Connection conn, String insertTemplate, List<String> exportFields)
+    private void indexDocument(Document doc, Connection conn, CdmFieldInfo fieldInfo)
             throws SQLException {
         Element root = doc.getRootElement();
         List<Element> recordEls = root.getChildren("record");
         for (Element recordEl : recordEls) {
-            PreparedStatement stmt = conn.prepareStatement(insertTemplate);
-            int i = 0;
-            for (; i < exportFields.size(); i++) {
-                String exportField = exportFields.get(i);
-                Element childEl = recordEl.getChild(exportField);
-                if (childEl == null) {
-                    throw new InvalidProjectStateException("Missing configured field " + exportField
-                            + " in export document, aborting indexing due to configuration mismatch");
+            Element structEl = recordEl.getChild("structure");
+            List<Element> pageEls = structEl.getChildren("page");
+            String objType = pageEls.size() > 0 ? ENTRY_TYPE_COMPOUND_OBJECT : null;
+
+            List<String> values = listFieldValues(recordEl, fieldInfo.listConfiguredFields());
+            List<String> reserved = listFieldValues(recordEl, CdmFieldInfo.RESERVED_FIELDS);
+            values.addAll(reserved);
+            indexObject(conn, values, null, objType);
+
+            if (!pageEls.isEmpty()) {
+                for (Element pageEl : pageEls) {
+                    indexCompoundChild(pageEl, conn, fieldInfo, reserved);
                 }
-                String value = childEl.getTextTrim();
-                value = value == null ? "" : value;
-                stmt.setString(i + 1, value);
             }
-            // Add in migration generated fields
-            for (int j = 0; j < MIGRATION_FIELDS.size(); j++) {
-                stmt.setNull(i + j, Types.LONGVARCHAR);
-            }
-            stmt.executeUpdate();
-            stmt.close();
         }
+    }
+
+    private void indexCompoundChild(Element childEl, Connection conn, CdmFieldInfo fieldInfo,
+                                    List<String> parentReservedValues) throws SQLException {
+        Element metadataEl = childEl.getChild("pagemetadata");
+        String pageId = childEl.getChildText("pageptr");
+        String parentCdmId = parentReservedValues.get(0);
+
+        List<String> values = listFieldValues(metadataEl, fieldInfo.listConfiguredFields());
+        // Use the page id as the child's cdm id
+        values.add(pageId);
+        // Compound child record doesn't timestamp fields, so use parents
+        values.add(parentReservedValues.get(1));
+        values.add(parentReservedValues.get(2));
+        // Clear the cdmfile and cdmpath values for the child
+        values.add(null);
+        values.add(null);
+        indexObject(conn, values, parentCdmId, ENTRY_TYPE_COMPOUND_CHILD);
+    }
+
+    private List<String> listFieldValues(Element objEl, List<String> exportFields) {
+        return exportFields.stream()
+                .map(exportField -> {
+                    Element childEl = objEl.getChild(exportField);
+                    if (childEl == null) {
+                        throw new InvalidProjectStateException("Missing configured field " + exportField
+                                + " in export document, aborting indexing due to configuration mismatch");
+                    }
+                    String value = childEl.getTextTrim();
+                    return value == null ? "" : value;
+                }).collect(Collectors.toList());
+    }
+
+    private void indexObject(Connection conn, List<String> exportFieldValues, String... migrationFieldValues)
+            throws SQLException {
+        PreparedStatement stmt = conn.prepareStatement(recordInsertSqlTemplate);
+        int i = 0;
+        for (; i < exportFieldValues.size(); i++) {
+            String value = exportFieldValues.get(i);
+            stmt.setString(i + 1, value);
+        }
+
+        // Add in migration generated fields
+        for (int j = 0; j < migrationFieldValues.length; j++) {
+            if (migrationFieldValues == null) {
+                stmt.setNull(i + j, Types.LONGVARCHAR);
+            } else {
+                stmt.setString(i + j, migrationFieldValues[j]);
+            }
+        }
+
+        stmt.executeUpdate();
+        stmt.close();
     }
 
     public void createDatabase(boolean force) throws IOException {
         ensureDatabaseState(force);
 
         CdmFieldInfo fieldInfo = fieldService.loadFieldsFromProject(project);
-        List<String> exportFields = new ArrayList<>(fieldInfo.listExportFields());
+        List<String> exportFields = new ArrayList<>(fieldInfo.listAllExportFields());
         exportFields.addAll(MIGRATION_FIELDS);
         StringBuilder queryBuilder = new StringBuilder("CREATE TABLE " + TB_NAME + " (\n");
         for (int i = 0; i < exportFields.size(); i++) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsService.java
@@ -16,6 +16,8 @@
 package edu.unc.lib.boxc.migration.cdm.services;
 
 import static edu.unc.lib.boxc.common.xml.SecureXMLFactory.createXMLInputFactory;
+import static edu.unc.lib.boxc.migration.cdm.services.CdmIndexService.ENTRY_TYPE_FIELD;
+import static edu.unc.lib.boxc.migration.cdm.services.CdmIndexService.ENTRY_TYPE_GROUPED_WORK;
 import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.MODS_V3_NS;
 
 import java.io.ByteArrayInputStream;
@@ -269,7 +271,9 @@ public class DescriptionsService {
             doc.setRootElement(collEl);
             Statement stmt = conn.createStatement();
             ResultSet rs = stmt.executeQuery("select " + CdmFieldInfo.CDM_ID + ", title from "
-                    + CdmIndexService.TB_NAME);
+                    + CdmIndexService.TB_NAME
+                    + " where " + ENTRY_TYPE_FIELD + " != '" + ENTRY_TYPE_GROUPED_WORK + "'"
+                            + " or " + ENTRY_TYPE_FIELD + " is null");
             while (rs.next()) {
                 String cdmId = rs.getString(1);
                 String title = rs.getString(2);

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingService.java
@@ -291,7 +291,7 @@ public class GroupMappingService {
         }
 
         CdmFieldInfo fieldInfo = fieldService.loadFieldsFromProject(project);
-        List<String> exportFields = new ArrayList<>(fieldInfo.listExportFields());
+        List<String> exportFields = new ArrayList<>(fieldInfo.listAllExportFields());
         exportFields.remove(CdmFieldInfo.CDM_ID);
 
         Connection conn = null;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
@@ -209,6 +209,13 @@ public class SipService {
      */
     private class MultiFileWorkGenerator extends WorkGenerator {
         @Override
+        protected void generateWork() throws IOException {
+            super.generateWork();
+            // Add redirect mapping for compound object
+            redirectMappingService.addRow(cdmId, workPid.getId(), null);
+        }
+
+        @Override
         protected List<PID> addChildObjects() throws IOException {
             try {
                 Statement stmt = conn.createStatement();

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
@@ -183,6 +183,8 @@ public class SipService {
             WorkGenerator gen;
             if (CdmIndexService.ENTRY_TYPE_GROUPED_WORK.equals(entryType)) {
                 gen = new GroupedWorkGenerator();
+            } else if (CdmIndexService.ENTRY_TYPE_COMPOUND_OBJECT.equals(entryType)) {
+                gen = new MultiFileWorkGenerator();
             } else {
                 gen = new WorkGenerator();
             }
@@ -198,10 +200,40 @@ public class SipService {
     }
 
     /**
+     * WorkGenerator for works containing multiple files
+     * @author bbpennel
+     */
+    private class MultiFileWorkGenerator extends WorkGenerator {
+        @Override
+        protected List<PID> addChildObjects() throws IOException {
+            try {
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery("select " + CdmFieldInfo.CDM_ID + "," + CdmFieldInfo.CDM_CREATED
+                        + " from " + CdmIndexService.TB_NAME
+                        + " where " + CdmIndexService.PARENT_ID_FIELD + " = '" + cdmId + "'");
+
+                List<PID> childPids = new ArrayList<>();
+                while (rs.next()) {
+                    String cdmId = rs.getString(1);
+                    String cdmCreated = rs.getString(2) + "T00:00:00.000Z";
+
+                    SourceFileMapping sourceMapping = getSourceFileMapping(cdmId);
+                    PID filePid = addFileObject(cdmId, cdmCreated, sourceMapping);
+
+                    childPids.add(filePid);
+                }
+                return childPids;
+            } catch (SQLException e) {
+                throw new MigrationException(e);
+            }
+        }
+    }
+
+    /**
      * WorkGenerator for works created via grouping together CDM objects
      * @author bbpennel
      */
-    private class GroupedWorkGenerator extends WorkGenerator {
+    private class GroupedWorkGenerator extends MultiFileWorkGenerator {
         @Override
         protected void generateWork() throws IOException {
             try {
@@ -234,25 +266,6 @@ public class SipService {
                 return rs.getString(1);
             }
             return null;
-        }
-
-        private List<PID> addChildObjects() throws SQLException, IOException {
-            Statement stmt = conn.createStatement();
-            ResultSet rs = stmt.executeQuery("select " + CdmFieldInfo.CDM_ID + "," + CdmFieldInfo.CDM_CREATED
-                + " from " + CdmIndexService.TB_NAME
-                + " where " + CdmIndexService.PARENT_ID_FIELD + " = '" + cdmId + "'");
-
-            List<PID> childPids = new ArrayList<>();
-            while (rs.next()) {
-                String cdmId = rs.getString(1);
-                String cdmCreated = rs.getString(2) + "T00:00:00.000Z";
-
-                SourceFileMapping sourceMapping = getSourceFileMapping(cdmId);
-                PID filePid = addFileObject(cdmId, cdmCreated, sourceMapping);
-
-                childPids.add(filePid);
-            }
-            return childPids;
         }
     }
 
@@ -296,7 +309,7 @@ public class SipService {
         protected void generateWork() throws IOException {
             Path expDescPath = getDescriptionPath(cdmId, false);
 
-            SourceFileMapping sourceMapping = getSourceFileMapping(cdmId);
+
             log.info("Transforming CDM object {} to box-c work {}", cdmId, workPid.getId());
             workBag = model.createBag(workPid.getRepositoryPath());
             workBag.addProperty(RDF.type, Cdr.Work);
@@ -305,7 +318,12 @@ public class SipService {
             // Copy description to SIP
             copyDescriptionToSip(workPid, expDescPath);
 
-            fileObjPids = Collections.singletonList(addFileObject(cdmId, cdmCreated, sourceMapping));
+            fileObjPids = addChildObjects();
+        }
+
+        protected List<PID> addChildObjects() throws IOException {
+            SourceFileMapping sourceMapping = getSourceFileMapping(cdmId);
+            return Collections.singletonList(addFileObject(cdmId, cdmCreated, sourceMapping));
         }
 
         protected void copyDescriptionToSip(PID pid, Path descPath) throws IOException {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileService.java
@@ -116,10 +116,12 @@ public class SourceFileService {
             conn = indexService.openDbConnection();
             Statement stmt = conn.createStatement();
             stmt.setFetchSize(FETCH_SIZE);
+            // Query for all non-compound objects. If the entry type is null, the object is a individual cdm object
             ResultSet rs = stmt.executeQuery("select cdmid, " + options.getExportField()
                     + " from " + CdmIndexService.TB_NAME
                     + " where " + ENTRY_TYPE_FIELD + " = '" + ENTRY_TYPE_COMPOUND_CHILD + "'"
                         + " or " + ENTRY_TYPE_FIELD + " is null");
+            // Generate source file mapping entry for each returned object
             while (rs.next()) {
                 String cdmId = rs.getString(1);
                 String dbFilename = rs.getString(2);

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileService.java
@@ -15,6 +15,8 @@
  */
 package edu.unc.lib.boxc.migration.cdm.services;
 
+import static edu.unc.lib.boxc.migration.cdm.services.CdmIndexService.ENTRY_TYPE_FIELD;
+import static edu.unc.lib.boxc.migration.cdm.services.CdmIndexService.ENTRY_TYPE_COMPOUND_CHILD;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.BufferedWriter;
@@ -115,7 +117,9 @@ public class SourceFileService {
             Statement stmt = conn.createStatement();
             stmt.setFetchSize(FETCH_SIZE);
             ResultSet rs = stmt.executeQuery("select cdmid, " + options.getExportField()
-                + " from " + CdmIndexService.TB_NAME);
+                    + " from " + CdmIndexService.TB_NAME
+                    + " where " + ENTRY_TYPE_FIELD + " = '" + ENTRY_TYPE_COMPOUND_CHILD + "'"
+                        + " or " + ENTRY_TYPE_FIELD + " is null");
             while (rs.next()) {
                 String cdmId = rs.getString(1);
                 String dbFilename = rs.getString(2);

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/ProjectStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/ProjectStatusService.java
@@ -19,6 +19,7 @@ import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Map;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
@@ -28,6 +29,7 @@ import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
 import edu.unc.lib.boxc.migration.cdm.services.DescriptionsService;
 import edu.unc.lib.boxc.migration.cdm.services.SipService;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Service which displays overall the status of a migration project
@@ -80,6 +82,14 @@ public class ProjectStatusService extends AbstractStatusService {
         }
         int totalObjects = getQueryService().countIndexedObjects();
         showField("Total Objects", totalObjects);
+        Map<String, Integer> typeCounts = getQueryService().countObjectsByType();
+        typeCounts.forEach((type, count) -> {
+            if (StringUtils.isBlank(type)) {
+                showFieldWithPercent("Single Objects", count, totalObjects);
+            } else {
+                showFieldWithPercent(type, count, totalObjects);
+            }
+        });
         sectionDivider();
 
         outputLogger.info("Destination Mappings");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
@@ -306,24 +306,24 @@ public class CdmIndexServiceTest {
 
             rs.next();
             assertEquals(602, rs.getInt("cdmid"));
-            assertEquals("2014-01-17", rs.getString("cdmcreated"));
-            assertEquals("2014-01-17", rs.getString("cdmmodified"));
+            assertEquals("2014-01-20", rs.getString("cdmcreated"));
+            assertEquals("2014-01-20", rs.getString("cdmmodified"));
             assertEquals("World War II ration book", rs.getString("title"));
             assertEquals(CdmIndexService.ENTRY_TYPE_COMPOUND_CHILD, rs.getString(CdmIndexService.ENTRY_TYPE_FIELD));
             assertEquals("604", rs.getString(CdmIndexService.PARENT_ID_FIELD));
 
             rs.next();
             assertEquals(603, rs.getInt("cdmid"));
-            assertEquals("2014-01-17", rs.getString("cdmcreated"));
-            assertEquals("2014-01-17", rs.getString("cdmmodified"));
+            assertEquals("2014-01-20", rs.getString("cdmcreated"));
+            assertEquals("2014-01-20", rs.getString("cdmmodified"));
             assertEquals("World War II ration book (instructions)", rs.getString("title"));
             assertEquals(CdmIndexService.ENTRY_TYPE_COMPOUND_CHILD, rs.getString(CdmIndexService.ENTRY_TYPE_FIELD));
             assertEquals("604", rs.getString(CdmIndexService.PARENT_ID_FIELD));
 
             rs.next();
             assertEquals(604, rs.getInt("cdmid"));
-            assertEquals("2014-01-17", rs.getString("cdmcreated"));
-            assertEquals("2014-01-17", rs.getString("cdmmodified"));
+            assertEquals("2014-01-20", rs.getString("cdmcreated"));
+            assertEquals("2014-01-20", rs.getString("cdmmodified"));
             assertEquals("World War II ration book, 1943", rs.getString("title"));
             assertEquals(CdmIndexService.ENTRY_TYPE_COMPOUND_OBJECT, rs.getString(CdmIndexService.ENTRY_TYPE_FIELD));
             assertNull(rs.getString(CdmIndexService.PARENT_ID_FIELD));

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
@@ -86,7 +86,7 @@ public class CdmIndexServiceTest {
         assertRowCount(3);
 
         CdmFieldInfo fieldInfo = fieldService.loadFieldsFromProject(project);
-        List<String> exportFields = fieldInfo.listExportFields();
+        List<String> exportFields = fieldInfo.listAllExportFields();
 
         Connection conn = service.openDbConnection();
         try {
@@ -140,7 +140,7 @@ public class CdmIndexServiceTest {
         assertRowCount(5);
 
         CdmFieldInfo fieldInfo = fieldService.loadFieldsFromProject(project);
-        List<String> exportFields = fieldInfo.listExportFields();
+        List<String> exportFields = fieldInfo.listAllExportFields();
 
         Connection conn = service.openDbConnection();
         try {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
@@ -15,6 +15,7 @@
  */
 package edu.unc.lib.boxc.migration.cdm.test;
 
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -26,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -246,10 +248,14 @@ public class SipServiceHelper {
     }
 
     public void indexExportData(String... filenames) throws Exception {
-        Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
+        indexExportData(Paths.get("src/test/resources/gilmer_fields.csv"), filenames);
+    }
+
+    public void indexExportData(Path fieldsPath, String... filenames) throws Exception {
+        Files.copy(fieldsPath, project.getFieldsPath(), REPLACE_EXISTING);
         for (String filename : filenames) {
             Files.copy(Paths.get("src/test/resources/sample_exports/" + filename),
-                    project.getExportPath().resolve(filename));
+                    project.getExportPath().resolve(filename), REPLACE_EXISTING);
         }
         project.getProjectProperties().setExportedDate(Instant.now());
         indexService.createDatabase(true);

--- a/src/test/resources/keepsakes_fields.csv
+++ b/src/test/resources/keepsakes_fields.csv
@@ -1,0 +1,37 @@
+cdm_nick,export_as,description,skip_export
+title,title,Title,false
+descri,descri,Description,false
+creato,creato,Creator,false
+creati,creati,Creation Date,false
+date,date,Date,false
+search,search,Search by Decade,false
+inscri,inscri,Transcription,false
+captio,captio,Caption,false
+subjec,subjec,Subject (tgm),false
+subjea,subjea,Subject Name,false
+subjeb,subjeb,Subject Topical,false
+usage,usage,Usage Statement,false
+releva,releva,Relevance,false
+subjed,subjed,Subject Geographic,false
+notes,notes,Notes,false
+titla,titla,Title Note,false
+origin,origin,Form,false
+resour,resour,Resource Type,false
+physic,physic,Physical Description,false
+publis,publis,Publisher,false
+collec,collec,Collection in Repository,false
+digita,digita,Digital Collection,false
+reposi,reposi,Repository,false
+host,host,Host,false
+local,local,Local Identifier,false
+citati,citati,Citation,false
+langua,langua,Language,false
+condit,condit,Condition,false
+additi,additi,Additional display,false
+filena,filena,filename,false
+fullrs,fullrs,Archival file,false
+dmoclcno,dmoclcno,OCLC number,false
+dmcreated,dmcreated,Date created,false
+dmmodified,dmmodified,Date modified,false
+dmrecord,dmrecord,CONTENTdm number,false
+find,find,CONTENTdm file name,false

--- a/src/test/resources/keepsakes_fields.csv
+++ b/src/test/resources/keepsakes_fields.csv
@@ -28,7 +28,7 @@ citati,citati,Citation,false
 langua,langua,Language,false
 condit,condit,Condition,false
 additi,additi,Additional display,false
-filena,filena,filename,false
+file,file,filename,false
 fullrs,fullrs,Archival file,false
 dmoclcno,dmoclcno,OCLC number,false
 dmcreated,dmcreated,Date created,false

--- a/src/test/resources/sample_exports/export_compounds.xml
+++ b/src/test/resources/sample_exports/export_compounds.xml
@@ -1,0 +1,343 @@
+<metadata>
+  <record>
+    <title>Playmakers, circa 1974</title>
+    <descri>Document designating UNC's PlayMaker's Theatre a National Historic Landmark, ca.1974.  Document states that it &quot;...possesses national significance in commemorating the History of the United States of America&quot;.  Document bears the logos of the U.S. Dept. of Interior and the National Park Service and is signed by Ronald D. Walker, director of the National Park Service, and Rogers C. B. Morton, Secretary of the Interior.  Dimensions: 35.5 x 27.9 cm.</descri>
+    <creato></creato>
+    <creati></creati>
+    <date>circa 1974</date>
+    <search>1970-1979</search>
+    <inscri></inscri>
+    <captio></captio>
+    <subjec>Certificates</subjec>
+    <subjea>University of North Carolina at Chapel Hill.; United States. National Park Service.; United States. Dept. of the Interior.</subjea>
+    <subjeb></subjeb>
+    <usage>This item is presented courtesy of the North Carolina Collection at the University of North Carolina at Chapel Hill for research and educational purposes. Prior permission from the North Carolina Collection is required for any commercial use.</usage>
+    <releva>UNC campus</releva>
+    <subjed>Chapel Hill (N.C.)</subjed>
+    <notes></notes>
+    <titla></titla>
+    <origin>Certificates</origin>
+    <resour>Image</resour>
+    <physic></physic>
+    <publis></publis>
+    <collec></collec>
+    <digita>Carolina Keepsakes</digita>
+    <reposi>North Carolina Collection, Wilson Library, University of North Carolina at Chapel Hill</reposi>
+    <host>University of North Carolina at Chapel Hill</host>
+    <local></local>
+    <citati>North Carolina Collection, Wilson Library Special Collections, University of North Carolina at Chapel Hill</citati>
+    <langua>English</langua>
+    <condit></condit>
+    <additi></additi>
+    <filena>nccg_ck_09.tif</filena>
+    <find>http://dc.lib.unc.edu:80/cdm/ref/collection/keepsakes/id/216</find>
+    <fullrs>Volume1/nccg_ck_09.tif</fullrs>
+    <fullResolution>Volume1/nccg_ck_09.tif</fullResolution>
+    <cdmid>216</cdmid>
+    <cdmaccess></cdmaccess>
+    <cdmcreated>2012-05-18</cdmcreated>
+    <cdmmodified>2014-01-17</cdmmodified>
+    <cdmoclc></cdmoclc>
+    <cdmfile>229.jp2</cdmfile>
+    <cdmpath>/keepsakes/image/229.jp2</cdmpath>
+    <thumbnailURL>http://dc.lib.unc.edu:82/cgi-bin/thumbnail.exe?CISOROOT=/keepsakes&amp;CISOPTR=216</thumbnailURL>
+    <viewerURL>http://dc.lib.unc.edu:80/cdm/ref/collection/keepsakes/id/216</viewerURL>
+    <structure>http://dc.lib.unc.edu:82/cgi-bin/showfile.exe?CISOROOT=/keepsakes&amp;CISOPTR=216</structure>
+  </record>
+  <record>
+    <title>World War II ration book, 1943</title>
+    <descri>World War II ration book.  Consists of a square, green papered booklet with two pockets on the front.  At bottom right corner of book is gold-colored text reading, &quot;DELL'S JEWEL BOX / 167 E. FRANKLIN ST. / CHAPEL HILL, NORTH CAROLINA&quot; with a small golden image of a diamond above the writing.  The front pocket contains six small cards; the first is manila and at top reads  &quot;'A' Basic Gasoline Ration&quot; in black lettering with the number &quot;895626&quot; in red to the right, the rest of the card has blue inked script identifying the owner as Mr. Albert Coates, including his address and the details of his vehicle.  Other cards are light blue, read &quot;'B' Supplemental Mileage Ration&quot; in green and contain information concerning Mr. Albert Coates.  The last card is manila, reads &quot;Mileage Ration Identification Folder,&quot;  has the same information about Coates, and opens up to instructions written in black concerning the rations.  The main pocket contains four manila ration cards and one Certificate of Registrar.  Each ration book contains several small blue stamps redeemable for various items.  Dimensions:  Booklet is 6.25&quot; (16cm) in width and 4.5&quot; (11.5cm) in length.</descri>
+    <creato></creato>
+    <creati>1943</creati>
+    <date>1943</date>
+    <search>1940-1949</search>
+    <inscri></inscri>
+    <captio></captio>
+    <subjec>Cards; Books; Consumer rationing; Coupons</subjec>
+    <subjea></subjea>
+    <subjeb></subjeb>
+    <usage>This item is presented courtesy of the North Carolina Collection at the University of North Carolina at Chapel Hill for research and educational purposes. Prior permission from the North Carolina Collection is required for any commercial use.</usage>
+    <releva></releva>
+    <subjed></subjed>
+    <notes></notes>
+    <titla></titla>
+    <origin>Cards; Books</origin>
+    <resour>Image</resour>
+    <physic></physic>
+    <publis></publis>
+    <collec></collec>
+    <digita>Carolina Keepsakes</digita>
+    <reposi>North Carolina Collection, Wilson Library, University of North Carolina at Chapel Hill</reposi>
+    <host>University of North Carolina at Chapel Hill</host>
+    <local></local>
+    <citati>North Carolina Collection, Wilson Library Special Collections, University of North Carolina at Chapel Hill</citati>
+    <langua>English</langua>
+    <condit></condit>
+    <additi></additi>
+    <filena></filena>
+    <find>http://dc.lib.unc.edu:80/cdm/ref/collection/keepsakes/id/604</find>
+    <fullrs></fullrs>
+    <fullResolution></fullResolution>
+    <cdmid>604</cdmid>
+    <cdmaccess></cdmaccess>
+    <cdmcreated>2014-01-17</cdmcreated>
+    <cdmmodified>2014-01-17</cdmmodified>
+    <cdmoclc></cdmoclc>
+    <cdmfile>617.cpd</cdmfile>
+    <cdmpath>/keepsakes/image/617.cpd</cdmpath>
+    <thumbnailURL>http://dc.lib.unc.edu:82/cgi-bin/thumbnail.exe?CISOROOT=/keepsakes&amp;CISOPTR=604</thumbnailURL>
+    <viewerURL>http://dc.lib.unc.edu:80/cdm/ref/collection/keepsakes/id/604</viewerURL>
+    <structure>
+        <page>
+            <pagetitle>World War II ration book</pagetitle>
+            <pageptr>602</pageptr>
+            <pagefile>
+                <pagefiletype>thumbnail</pagefiletype>
+                <pagefilelocation>http://dc.lib.unc.edu:82/cgi-bin/thumbnail.exe?CISOROOT=/keepsakes&amp;CISOPTR=602</pagefilelocation>
+            </pagefile>
+            <pagefile>
+                <pagefiletype>access</pagefiletype>
+                <pagefilelocation>http://dc.lib.unc.edu:82/cgi-bin/showfile.exe?CISOROOT=/keepsakes&amp;CISOPTR=602</pagefilelocation>
+            </pagefile>
+            <pagefile>
+                <pagefiletype>master</pagefiletype>
+                <pagefilelocation>Volume2/nccg_ck_1042-22_v1.TIF</pagefilelocation>
+            </pagefile>
+            <pagetext>        </pagetext>
+            <pagemetadata>
+                <title>World War II ration book</title>
+                <descri></descri>
+                <creato></creato>
+                <creati></creati>
+                <date></date>
+                <search></search>
+                <inscri></inscri>
+                <captio></captio>
+                <subjec></subjec>
+                <subjea></subjea>
+                <subjeb></subjeb>
+                <usage>This item is presented courtesy of the North Carolina Collection at the University of North Carolina at Chapel Hill for research and educational purposes. Prior permission from the North Carolina Collection is required for any commercial use.</usage>
+                <releva></releva>
+                <subjed></subjed>
+                <notes></notes>
+                <titla></titla>
+                <origin></origin>
+                <resour>Image</resour>
+                <physic></physic>
+                <publis></publis>
+                <collec></collec>
+                <digita></digita>
+                <reposi></reposi>
+                <host></host>
+                <local></local>
+                <citati></citati>
+                <langua></langua>
+                <condit></condit>
+                <additi></additi>
+                <filena>nccg_ck_1042-22_v1.tif</filena>
+                <find>615.jp2</find>
+                <fullrs>Volume2/nccg_ck_1042-22_v1.TIF</fullrs>
+            </pagemetadata>
+        </page>
+        <page>
+            <pagetitle>World War II ration book (instructions)</pagetitle>
+            <pageptr>603</pageptr>
+            <pagefile>
+                <pagefiletype>thumbnail</pagefiletype>
+                <pagefilelocation>http://dc.lib.unc.edu:82/cgi-bin/thumbnail.exe?CISOROOT=/keepsakes&amp;CISOPTR=603</pagefilelocation>
+            </pagefile>
+            <pagefile>
+                <pagefiletype>access</pagefiletype>
+                <pagefilelocation>http://dc.lib.unc.edu:82/cgi-bin/showfile.exe?CISOROOT=/keepsakes&amp;CISOPTR=603</pagefilelocation>
+            </pagefile>
+            <pagefile>
+                <pagefiletype>master</pagefiletype>
+                <pagefilelocation>Volume2/nccg_ck_1042-22_v2.TIF</pagefilelocation>
+            </pagefile>
+            <pagetext>        </pagetext>
+            <pagemetadata>
+                <title>World War II ration book (instructions)</title>
+                <descri></descri>
+                <creato></creato>
+                <creati></creati>
+                <date></date>
+                <search></search>
+                <inscri></inscri>
+                <captio></captio>
+                <subjec></subjec>
+                <subjea></subjea>
+                <subjeb></subjeb>
+                <usage>This item is presented courtesy of the North Carolina Collection at the University of North Carolina at Chapel Hill for research and educational purposes. Prior permission from the North Carolina Collection is required for any commercial use.</usage>
+                <releva></releva>
+                <subjed></subjed>
+                <notes></notes>
+                <titla></titla>
+                <origin></origin>
+                <resour>Image</resour>
+                <physic></physic>
+                <publis></publis>
+                <collec></collec>
+                <digita></digita>
+                <reposi></reposi>
+                <host></host>
+                <local></local>
+                <citati></citati>
+                <langua></langua>
+                <condit></condit>
+                <additi></additi>
+                <filena>nccg_ck_1042-22_v2.tif</filena>
+                <find>616.jp2</find>
+                <fullrs>Volume2/nccg_ck_1042-22_v2.TIF</fullrs>
+            </pagemetadata>
+        </page>
+    </structure>
+  </record>
+  <record>
+    <title>Tiffany's pillbox</title>
+    <descri>Commemorative pillbox made by Tiffany's for UNC's Bicentennial celebration, circa 1989.  The outside of the pillbox is enamel on copper with gold trim, depicting buildings on the UNC campus. The inside lid of the box reads, &quot;The University of North Carolina at Chapel Hill Bicentennial.&quot;   The pillbox is trademarked by Halycon Days enamels, a joint venture which began in 1970 of the Halcyon Days antique shop and Bilston and Battersea Enamels.   The pillbox is a recreation of the style of enameling practiced in Georgian times. This particular pillbox was designed and sold by Tiffany &amp; Co.  Housed in light blue double boxes, with the outer box labeled &quot;Tiffany &amp; Co.&quot; and the inner box featuring the &quot;Halcyon Days Enamels&quot; trademark, lined inside with white velour to cushion the box.  Dimensions:  6.2 cm. wide, 5.0 cm high, 2.0 cm deep.</descri>
+    <creato>Tiffany and Company</creato>
+    <creati>1989</creati>
+    <date>circa 1989</date>
+    <search>1980-1989</search>
+    <inscri></inscri>
+    <captio></captio>
+    <subjec>Containers; Memorabilia; Centennial celebrations</subjec>
+    <subjea>University of North Carolina at Chapel Hill.</subjea>
+    <subjeb></subjeb>
+    <usage>This item is presented courtesy of the North Carolina Collection at the University of North Carolina at Chapel Hill for research and educational purposes. Prior permission from the North Carolina Collection is required for any commercial use.</usage>
+    <releva>UNC memorabilia</releva>
+    <subjed>Chapel Hill (N.C.)</subjed>
+    <notes></notes>
+    <titla></titla>
+    <origin>Containers; Memorabilia</origin>
+    <resour>Image</resour>
+    <physic></physic>
+    <publis></publis>
+    <collec></collec>
+    <digita>Carolina Keepsakes</digita>
+    <reposi>North Carolina Collection, Wilson Library, University of North Carolina at Chapel Hill</reposi>
+    <host>University of North Carolina at Chapel Hill</host>
+    <local></local>
+    <citati>North Carolina Collection, Wilson Library Special Collections, University of North Carolina at Chapel Hill</citati>
+    <langua>English</langua>
+    <condit></condit>
+    <additi></additi>
+    <filena></filena>
+    <find>http://dc.lib.unc.edu:80/cdm/ref/collection/keepsakes/id/607</find>
+    <fullrs></fullrs>
+    <fullResolution></fullResolution>
+    <cdmid>607</cdmid>
+    <cdmaccess></cdmaccess>
+    <cdmcreated>2014-02-17</cdmcreated>
+    <cdmmodified>2014-03-17</cdmmodified>
+    <cdmoclc></cdmoclc>
+    <cdmfile>620.cpd</cdmfile>
+    <cdmpath>/keepsakes/image/620.cpd</cdmpath>
+    <thumbnailURL>http://dc.lib.unc.edu:82/cgi-bin/thumbnail.exe?CISOROOT=/keepsakes&amp;CISOPTR=607</thumbnailURL>
+    <viewerURL>http://dc.lib.unc.edu:80/cdm/ref/collection/keepsakes/id/607</viewerURL>
+    <structure>
+      <page>
+        <pagetitle>Tiffany's pillbox commemorating UNC's bicentennial (closed, in box)</pagetitle>
+        <pageptr>605</pageptr>
+        <pagefile>
+            <pagefiletype>thumbnail</pagefiletype>
+            <pagefilelocation>http://dc.lib.unc.edu:82/cgi-bin/thumbnail.exe?CISOROOT=/keepsakes&amp;CISOPTR=605</pagefilelocation>
+        </pagefile>
+        <pagefile>
+            <pagefiletype>access</pagefiletype>
+            <pagefilelocation>http://dc.lib.unc.edu:82/cgi-bin/showfile.exe?CISOROOT=/keepsakes&amp;CISOPTR=605</pagefilelocation>
+        </pagefile>
+        <pagefile>
+            <pagefiletype>master</pagefiletype>
+            <pagefilelocation>Volume2/nccg_ck_549-4_v1.TIF</pagefilelocation>
+        </pagefile>
+        <pagetext>        </pagetext>
+        <pagemetadata>
+            <title>Tiffany's pillbox (closed, in box)</title>
+            <descri></descri>
+            <creato></creato>
+            <creati></creati>
+            <date></date>
+            <search></search>
+            <inscri></inscri>
+            <captio></captio>
+            <subjec></subjec>
+            <subjea></subjea>
+            <subjeb></subjeb>
+            <usage>This item is presented courtesy of the North Carolina Collection</usage>
+            <releva></releva>
+            <subjed></subjed>
+            <notes></notes>
+            <titla></titla>
+            <origin></origin>
+            <resour>Image</resour>
+            <physic></physic>
+            <publis></publis>
+            <collec></collec>
+            <digita></digita>
+            <reposi></reposi>
+            <host></host>
+            <local></local>
+            <citati></citati>
+            <langua></langua>
+            <condit></condit>
+            <additi></additi>
+            <filena>nccg_ck_549-4_v1.tif</filena>
+            <find>618.jp2</find>
+            <fullrs>Volume2/nccg_ck_549-4_v1.TIF</fullrs>
+        </pagemetadata>
+      </page>
+      <page>
+        <pagetitle>Tiffany's pillbox (open, next to box)</pagetitle>
+        <pageptr>606</pageptr>
+        <pagefile>
+            <pagefiletype>thumbnail</pagefiletype>
+            <pagefilelocation>http://dc.lib.unc.edu:82/cgi-bin/thumbnail.exe?CISOROOT=/keepsakes&amp;CISOPTR=606</pagefilelocation>
+        </pagefile>
+        <pagefile>
+            <pagefiletype>access</pagefiletype>
+            <pagefilelocation>http://dc.lib.unc.edu:82/cgi-bin/showfile.exe?CISOROOT=/keepsakes&amp;CISOPTR=606</pagefilelocation>
+        </pagefile>
+        <pagefile>
+            <pagefiletype>master</pagefiletype>
+            <pagefilelocation>Volume2/nccg_ck_549-4_v2.TIF</pagefilelocation>
+        </pagefile>
+        <pagetext>        </pagetext>
+        <pagemetadata>
+            <title>Tiffany's pillbox (open, next to box)</title>
+            <descri></descri>
+            <creato></creato>
+            <creati></creati>
+            <date></date>
+            <search></search>
+            <inscri></inscri>
+            <captio></captio>
+            <subjec></subjec>
+            <subjea></subjea>
+            <subjeb></subjeb>
+            <usage>This item is presented courtesy of the North Carolina Collection at the University of North Carolina at Chapel Hill for research and educational purposes. Prior permission from the North Carolina Collection is required for any commercial use.</usage>
+            <releva></releva>
+            <subjed></subjed>
+            <notes></notes>
+            <titla></titla>
+            <origin></origin>
+            <resour>Image</resour>
+            <physic></physic>
+            <publis></publis>
+            <collec></collec>
+            <digita></digita>
+            <reposi></reposi>
+            <host></host>
+            <local></local>
+            <citati></citati>
+            <langua></langua>
+            <condit></condit>
+            <additi></additi>
+            <filena>nccg_ck_549-4_v2.tif</filena>
+            <find>619.jp2</find>
+            <fullrs>Volume2/nccg_ck_549-4_v2.TIF</fullrs>
+        </pagemetadata>
+      </page>
+    </structure>
+  </record>
+</metadata>

--- a/src/test/resources/sample_exports/export_compounds.xml
+++ b/src/test/resources/sample_exports/export_compounds.xml
@@ -29,7 +29,7 @@
     <langua>English</langua>
     <condit></condit>
     <additi></additi>
-    <filena>nccg_ck_09.tif</filena>
+    <file>nccg_ck_09.tif</file>
     <find>http://dc.lib.unc.edu:80/cdm/ref/collection/keepsakes/id/216</find>
     <fullrs>Volume1/nccg_ck_09.tif</fullrs>
     <fullResolution>Volume1/nccg_ck_09.tif</fullResolution>
@@ -74,14 +74,14 @@
     <langua>English</langua>
     <condit></condit>
     <additi></additi>
-    <filena></filena>
+    <file></file>
     <find>http://dc.lib.unc.edu:80/cdm/ref/collection/keepsakes/id/604</find>
     <fullrs></fullrs>
     <fullResolution></fullResolution>
     <cdmid>604</cdmid>
     <cdmaccess></cdmaccess>
-    <cdmcreated>2014-01-17</cdmcreated>
-    <cdmmodified>2014-01-17</cdmmodified>
+    <cdmcreated>2014-01-20</cdmcreated>
+    <cdmmodified>2014-01-20</cdmmodified>
     <cdmoclc></cdmoclc>
     <cdmfile>617.cpd</cdmfile>
     <cdmpath>/keepsakes/image/617.cpd</cdmpath>
@@ -134,7 +134,7 @@
                 <langua></langua>
                 <condit></condit>
                 <additi></additi>
-                <filena>nccg_ck_1042-22_v1.tif</filena>
+                <file>nccg_ck_1042-22_v1.tif</file>
                 <find>615.jp2</find>
                 <fullrs>Volume2/nccg_ck_1042-22_v1.TIF</fullrs>
             </pagemetadata>
@@ -185,7 +185,7 @@
                 <langua></langua>
                 <condit></condit>
                 <additi></additi>
-                <filena>nccg_ck_1042-22_v2.tif</filena>
+                <file>nccg_ck_1042-22_v2.tif</file>
                 <find>616.jp2</find>
                 <fullrs>Volume2/nccg_ck_1042-22_v2.TIF</fullrs>
             </pagemetadata>
@@ -222,7 +222,7 @@
     <langua>English</langua>
     <condit></condit>
     <additi></additi>
-    <filena></filena>
+    <file></file>
     <find>http://dc.lib.unc.edu:80/cdm/ref/collection/keepsakes/id/607</find>
     <fullrs></fullrs>
     <fullResolution></fullResolution>
@@ -282,7 +282,7 @@
             <langua></langua>
             <condit></condit>
             <additi></additi>
-            <filena>nccg_ck_549-4_v1.tif</filena>
+            <file>nccg_ck_549-4_v1.tif</file>
             <find>618.jp2</find>
             <fullrs>Volume2/nccg_ck_549-4_v1.TIF</fullrs>
         </pagemetadata>
@@ -333,7 +333,7 @@
             <langua></langua>
             <condit></condit>
             <additi></additi>
-            <filena>nccg_ck_549-4_v2.tif</filena>
+            <file>nccg_ck_549-4_v2.tif</file>
             <find>619.jp2</find>
             <fullrs>Volume2/nccg_ck_549-4_v2.TIF</fullrs>
         </pagemetadata>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3228

* Adds support for migration of compound objects, which are predefined multi-file works in CDM
    * Supports migration of compound object children
    * Compound children don't have the reserved CDM fields that their parent objects do (like cdmid, last modified, etc), so some refactoring of how lists of fields are calculated to account for this. Made some related variables into instance variables instead of method params to cut down on redundancy
* Exclude grouped works from description generation command, since they cannot have descriptions associated with them and cause errors when generating SIPs
* Test helper updates to support testing with other example collections