### PR TITLE
BXC-3335 - Support resumption of export operations

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommand.java
@@ -104,7 +104,8 @@ public class CdmExportCommand implements Callable<Integer> {
     private void startOrResumeExport() throws IOException {
         exportStateService.startOrResumeExport(options.isForce());
         if (exportStateService.isResuming()) {
-            outputLogger.info("Resuming incomplete export from where it left off...");
+            outputLogger.info("Resuming incomplete export started {} from where it left off...",
+                    exportStateService.getState().getStartTime());
             ExportState exportState = exportStateService.getState();
             if (ProgressState.LISTING_OBJECTS.equals(exportState.getProgressState())) {
                 outputLogger.info("Resuming listing of object IDs");
@@ -140,12 +141,13 @@ public class CdmExportCommand implements Callable<Integer> {
     }
 
     private void validate() {
-        if (options.getPageSize() < 1 || options.getPageSize() > CdmExportOptions.MAX_EXPORT_PER_PAGE) {
-            throw new MigrationException("Page size must be between 1 and " + CdmExportOptions.MAX_EXPORT_PER_PAGE);
+        if (options.getPageSize() < 1 || options.getPageSize() > CdmExportOptions.MAX_EXPORT_RECORDS_PER_PAGE) {
+            throw new MigrationException("Page size must be between 1 and "
+                    + CdmExportOptions.MAX_EXPORT_RECORDS_PER_PAGE);
         }
-        if (options.getListingPageSize() < 1 || options.getListingPageSize() > CdmExportOptions.MAX_LISTING_PER_PAGE) {
+        if (options.getListingPageSize() < 1 || options.getListingPageSize() > CdmExportOptions.MAX_LIST_IDS_PER_PAGE) {
             throw new MigrationException("Listing page size must be between 1 and "
-                    + CdmExportOptions.MAX_LISTING_PER_PAGE);
+                    + CdmExportOptions.MAX_LIST_IDS_PER_PAGE);
         }
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/CdmExportOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/CdmExportOptions.java
@@ -33,11 +33,18 @@ public class CdmExportOptions {
                     "Defaults to current user: ${DEFAULT-VALUE}"},
             defaultValue = "${sys:user.name}")
     private String cdmUsername;
-    @CommandLine.Option(names = {"-n", "-per-page"},
+    public static final int MAX_EXPORT_PER_PAGE = 5000;
+    @CommandLine.Option(names = {"-n", "--per-page"},
             description = {"Page size for exports.",
-                    "Default: ${DEFAULT-VALUE}. Max page size is 5000"},
+                    "Default: ${DEFAULT-VALUE}. Max page size is " + MAX_EXPORT_PER_PAGE},
             defaultValue = "1000")
-    private int pageSize;
+    private int pageSize = 1000;
+    public static final int MAX_LISTING_PER_PAGE = 1000;
+    @CommandLine.Option(names = {"--object-listing-per-page"},
+            description = {"During initial listing of objects, the number of objects to list per page.",
+                    "Default: ${DEFAULT-VALUE}. Max page size is " + MAX_LISTING_PER_PAGE},
+            defaultValue = "1000")
+    private int listingPageSize = 1000;
     @CommandLine.Option(names = { "-f", "--force"},
             description = "Force the export to restart from the beginning. Use if a previous export was started "
                     + "or completed, but you would like to begin the export again.")
@@ -65,6 +72,14 @@ public class CdmExportOptions {
 
     public void setPageSize(int pageSize) {
         this.pageSize = pageSize;
+    }
+
+    public int getListingPageSize() {
+        return listingPageSize;
+    }
+
+    public void setListingPageSize(int listingPageSize) {
+        this.listingPageSize = listingPageSize;
     }
 
     public boolean isForce() {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/CdmExportOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/CdmExportOptions.java
@@ -38,6 +38,10 @@ public class CdmExportOptions {
                     "Default: ${DEFAULT-VALUE}. Max page size is 5000"},
             defaultValue = "1000")
     private int pageSize;
+    @CommandLine.Option(names = { "-f", "--force"},
+            description = "Force the export to restart from the beginning. Use if a previous export was started "
+                    + "or completed, but you would like to begin the export again.")
+    private boolean force;
 
     public String getCdmBaseUri() {
         return cdmBaseUri;
@@ -61,5 +65,13 @@ public class CdmExportOptions {
 
     public void setPageSize(int pageSize) {
         this.pageSize = pageSize;
+    }
+
+    public boolean isForce() {
+        return force;
+    }
+
+    public void setForce(boolean force) {
+        this.force = force;
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/CdmExportOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/CdmExportOptions.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.options;
+
+import picocli.CommandLine;
+
+/**
+ * Options for CDM export operation
+ *
+ * @author bbpennel
+ */
+public class CdmExportOptions {
+    @CommandLine.Option(names = { "--cdm-url" },
+            description = {"Base URL to the CDM web service API. Falls back to CDM_BASE_URL env variable.",
+                    "Default: ${DEFAULT-VALUE}"},
+            defaultValue = "${env:CDM_BASE_URL:-http://localhost:82/}")
+    private String cdmBaseUri;
+    @CommandLine.Option(names = { "-u", "--cdm-user"},
+            description = {"User name for CDM requests.",
+                    "Defaults to current user: ${DEFAULT-VALUE}"},
+            defaultValue = "${sys:user.name}")
+    private String cdmUsername;
+    @CommandLine.Option(names = {"-n", "-per-page"},
+            description = {"Page size for exports.",
+                    "Default: ${DEFAULT-VALUE}. Max page size is 5000"},
+            defaultValue = "1000")
+    private int pageSize;
+
+    public String getCdmBaseUri() {
+        return cdmBaseUri;
+    }
+
+    public void setCdmBaseUri(String cdmBaseUri) {
+        this.cdmBaseUri = cdmBaseUri;
+    }
+
+    public String getCdmUsername() {
+        return cdmUsername;
+    }
+
+    public void setCdmUsername(String cdmUsername) {
+        this.cdmUsername = cdmUsername;
+    }
+
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/CdmExportOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/CdmExportOptions.java
@@ -33,16 +33,16 @@ public class CdmExportOptions {
                     "Defaults to current user: ${DEFAULT-VALUE}"},
             defaultValue = "${sys:user.name}")
     private String cdmUsername;
-    public static final int MAX_EXPORT_PER_PAGE = 5000;
-    @CommandLine.Option(names = {"-n", "--per-page"},
+    public static final int MAX_EXPORT_RECORDS_PER_PAGE = 5000;
+    @CommandLine.Option(names = {"-n", "--records-per-page"},
             description = {"Page size for exports.",
-                    "Default: ${DEFAULT-VALUE}. Max page size is " + MAX_EXPORT_PER_PAGE},
+                    "Default: ${DEFAULT-VALUE}. Max page size is " + MAX_EXPORT_RECORDS_PER_PAGE},
             defaultValue = "1000")
     private int pageSize = 1000;
-    public static final int MAX_LISTING_PER_PAGE = 1000;
-    @CommandLine.Option(names = {"--object-listing-per-page"},
-            description = {"During initial listing of objects, the number of objects to list per page.",
-                    "Default: ${DEFAULT-VALUE}. Max page size is " + MAX_LISTING_PER_PAGE},
+    public static final int MAX_LIST_IDS_PER_PAGE = 1000;
+    @CommandLine.Option(names = {"--ids-per-page"},
+            description = {"During initial listing of object IDs, the number of objects to list per page.",
+                    "Default: ${DEFAULT-VALUE}. Max page size is " + MAX_LIST_IDS_PER_PAGE},
             defaultValue = "1000")
     private int listingPageSize = 1000;
     @CommandLine.Option(names = { "-f", "--force"},

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
@@ -69,7 +69,7 @@ public class CdmExportService {
         // Generate body of export request using the list of fields configure for export
         cdmFieldService.validateFieldsFile(project);
         initializeExportDir(project);
-        exportStateService.startOrResumeExport(false);
+        exportStateService.startOrResumeExport(options.isForce());
         CdmFieldInfo fieldInfo = cdmFieldService.loadFieldsFromProject(project);
         String fieldParams = fieldInfo.getFields().stream()
                 .filter(f -> !f.getSkipExport())

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
@@ -68,7 +68,7 @@ public class CdmExportService {
         // Generate body of export request using the list of fields configure for export
         cdmFieldService.validateFieldsFile(project);
         initializeExportDir(project);
-        exportStateService.transitionToStarting();
+        exportStateService.startOrResumeExport(false);
         CdmFieldInfo fieldInfo = cdmFieldService.loadFieldsFromProject(project);
         String fieldParams = fieldInfo.getFields().stream()
                 .filter(f -> !f.getSkipExport())

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
@@ -21,7 +21,6 @@ import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.options.CdmExportOptions;
-import edu.unc.lib.boxc.migration.cdm.services.export.ExportState;
 import edu.unc.lib.boxc.migration.cdm.services.export.ExportStateService;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 import org.apache.commons.io.IOUtils;
@@ -40,9 +39,9 @@ import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static edu.unc.lib.boxc.migration.cdm.services.export.ExportState.ProgressState;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static org.slf4j.LoggerFactory.getLogger;
-import static edu.unc.lib.boxc.migration.cdm.services.export.ExportState.ProgressState;
 
 /**
  * Service for exporting CDM item records
@@ -62,14 +61,13 @@ public class CdmExportService {
 
     /**
      * Export all records from CDM for the provided project
-     * @param project
+     * @param options
      * @throws IOException
      */
     public void exportAll(CdmExportOptions options) throws IOException {
         // Generate body of export request using the list of fields configure for export
         cdmFieldService.validateFieldsFile(project);
         initializeExportDir(project);
-        exportStateService.startOrResumeExport(options.isForce());
         CdmFieldInfo fieldInfo = cdmFieldService.loadFieldsFromProject(project);
         String fieldParams = fieldInfo.getFields().stream()
                 .filter(f -> !f.getSkipExport())
@@ -132,6 +130,7 @@ public class CdmExportService {
         listId.setHttpClient(httpClient);
         listId.setCdmBaseUri(options.getCdmBaseUri());
         listId.setExportStateService(exportStateService);
+        listId.setPageSize(options.getListingPageSize());
         listId.setProject(project);
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
@@ -87,6 +87,7 @@ public class CdmExportService {
             for (List<String> chunk : chunks) {
                 // Name each exported page
                 exportPage++;
+                // When resuming, skip over pages until past the previously recorded last exported record
                 if (exportStateService.isResuming()
                         && (exportPage * pageSize - 1) <= exportStateService.getState().getLastExportedIndex()) {
                     continue;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmListIdService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmListIdService.java
@@ -117,18 +117,18 @@ public class CdmListIdService {
 
     /**
      * Parse json for object IDs
-     * @param url
+     * @param objectUri
      * @throw IOException
      * @return
      */
-    private List<String> parseJson(String url) throws IOException {
+    private List<String> parseJson(String objectUri) throws IOException {
         String collectionId = project.getProjectProperties().getCdmCollectionId();
-        String objectUri = url;
 
         List<String> objectIds = new ArrayList<>();
 
         ObjectMapper mapper = new ObjectMapper();
         HttpGet getMethod = new HttpGet(objectUri);
+        log.debug("Requesting object list from URI: {}", objectUri);
         try (CloseableHttpResponse resp = httpClient.execute(getMethod)) {
             String body = IOUtils.toString(resp.getEntity().getContent(), ISO_8859_1);
             if (body.contains("Error looking up collection")) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportState.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportState.java
@@ -29,7 +29,8 @@ public class ExportState {
     private Integer exportPageSize;
     private Integer listIdPageSize;
     private Integer totalObjects;
-    private Integer lastExportedIndex;
+    // Int so it will start at 0 instead of null
+    private int lastExportedIndex;
     private boolean resuming = false;
     private ProgressState progressState;
 
@@ -77,11 +78,11 @@ public class ExportState {
         this.progressState = progressState;
     }
 
-    public Integer getLastExportedIndex() {
+    public int getLastExportedIndex() {
         return lastExportedIndex;
     }
 
-    public void setLastExportedIndex(Integer lastExportedIndex) {
+    public void setLastExportedIndex(int lastExportedIndex) {
         this.lastExportedIndex = lastExportedIndex;
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportState.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportState.java
@@ -31,7 +31,7 @@ public class ExportState {
     private Integer totalObjects;
     private Integer lastExportedIndex;
     private boolean resuming = false;
-    private ProgressState state;
+    private ProgressState progressState;
 
     public enum ProgressState {
         STARTING, COUNT_COMPLETED, LISTING_OBJECTS, LISTING_COMPLETED, EXPORTING, EXPORT_COMPLETED;
@@ -69,12 +69,12 @@ public class ExportState {
         this.totalObjects = totalObjects;
     }
 
-    public ProgressState getState() {
-        return state;
+    public ProgressState getProgressState() {
+        return progressState;
     }
 
-    public void setState(ProgressState state) {
-        this.state = state;
+    public void setProgressState(ProgressState progressState) {
+        this.progressState = progressState;
     }
 
     public Integer getLastExportedIndex() {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportState.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportState.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.services.export;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.time.Instant;
+
+/**
+ * State of a CDM export operation
+ *
+ * @author bbpennel
+ */
+public class ExportState {
+    private Instant startTime;
+    private Integer exportPageSize;
+    private Integer listIdPageSize;
+    private Integer totalObjects;
+    private Integer lastExportedIndex;
+    private boolean resuming = false;
+    private ProgressState state;
+
+    public enum ProgressState {
+        STARTING, COUNT_COMPLETED, LISTING_OBJECTS, LISTING_COMPLETED, EXPORTING, EXPORT_COMPLETED;
+    }
+
+    public Instant getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(Instant startTime) {
+        this.startTime = startTime;
+    }
+
+    public Integer getExportPageSize() {
+        return exportPageSize;
+    }
+
+    public void setExportPageSize(Integer exportPageSize) {
+        this.exportPageSize = exportPageSize;
+    }
+
+    public Integer getListIdPageSize() {
+        return listIdPageSize;
+    }
+
+    public void setListIdPageSize(Integer listIdPageSize) {
+        this.listIdPageSize = listIdPageSize;
+    }
+
+    public Integer getTotalObjects() {
+        return totalObjects;
+    }
+
+    public void setTotalObjects(Integer totalObjects) {
+        this.totalObjects = totalObjects;
+    }
+
+    public ProgressState getState() {
+        return state;
+    }
+
+    public void setState(ProgressState state) {
+        this.state = state;
+    }
+
+    public Integer getLastExportedIndex() {
+        return lastExportedIndex;
+    }
+
+    public void setLastExportedIndex(Integer lastExportedIndex) {
+        this.lastExportedIndex = lastExportedIndex;
+    }
+
+    @JsonIgnore
+    public boolean isResuming() {
+        return resuming;
+    }
+
+    public void setResuming(boolean resuming) {
+        this.resuming = resuming;
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateService.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -120,6 +121,7 @@ public class ExportStateService {
      */
     public void transitionToStarting() throws IOException {
         state.setProgressState(ProgressState.STARTING);
+        state.setStartTime(Instant.now());
         writeState();
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateService.java
@@ -182,8 +182,14 @@ public class ExportStateService {
      */
     public void registerExported(List<String> objectIds) throws IOException {
         assertState(ProgressState.EXPORTING);
-        int lastIndex = state.getLastExportedIndex() == null ? 0 : state.getLastExportedIndex();
-        state.setLastExportedIndex(lastIndex + objectIds.size() - 1);
+        int lastIndex;
+        if (state.getLastExportedIndex() == null) {
+            // Subtract 1 from size to shift to 0 based index for the first page
+            lastIndex = objectIds.size() - 1;
+        } else {
+            lastIndex = state.getLastExportedIndex() + objectIds.size();
+        }
+        state.setLastExportedIndex(lastIndex);
         writeState();
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateService.java
@@ -1,0 +1,199 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.services.export;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static edu.unc.lib.boxc.migration.cdm.services.export.ExportState.ProgressState;
+
+/**
+ * @author bbpennel
+ */
+public class ExportStateService {
+    private static final String IDS_FILENAME = ".object_ids.txt";
+    private static final String STATE_FILENAME = ".export_state.json";
+    private MigrationProject project;
+    private ExportState state;
+    private static final ObjectWriter STATE_WRITER;
+    private static final ObjectReader STATE_READER;
+    static {
+        JavaTimeModule module = new JavaTimeModule();
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(module);
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+
+        STATE_READER = mapper.readerFor(ExportState.class);
+        STATE_WRITER = mapper.writerFor(ExportState.class);
+    }
+
+    /**
+     * Transition the export to the listing object ids state
+     * @throws IOException
+     */
+    public void transitionToStarting() throws IOException {
+        state = new ExportState();
+        state.setState(ProgressState.STARTING);
+        writeState();
+    }
+
+    /**
+     * Record the count of objects in this collection has completed
+     * @param count
+     * @throws IOException
+     */
+    public void objectCountCompleted(int count) throws IOException {
+        assertState(ProgressState.STARTING);
+        state.setTotalObjects(count);
+        state.setState(ExportState.ProgressState.COUNT_COMPLETED);
+        writeState();
+    }
+
+    /**
+     * Transition the export to the listing object ids state
+     * @param listingPageSize
+     * @throws IOException
+     */
+    public void transitionToListing(int listingPageSize) throws IOException {
+        assertState(ProgressState.COUNT_COMPLETED);
+        state.setState(ProgressState.LISTING_OBJECTS);
+        state.setListIdPageSize(listingPageSize);
+        writeState();
+    }
+
+    /**
+     * Indicate that listing of object ids has completed
+     * @throws IOException
+     */
+    public void listingComplete() throws IOException {
+        assertState(ProgressState.LISTING_OBJECTS);
+        state.setState(ProgressState.LISTING_COMPLETED);
+        writeState();
+    }
+
+    /**
+     * Record a list of object ids which are included in this export
+     * @param ids
+     */
+    public void registerObjectIds(List<String> ids) throws IOException {
+        assertState(ProgressState.LISTING_OBJECTS);
+        String idsJoined = String.join("\r\n", ids);
+        Files.write(
+                getObjectListPath(),
+                idsJoined.getBytes(),
+                StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+    }
+
+    /**
+     * @return the list of object ids for this CDM project
+     */
+    public List<String> retrieveObjectIds() throws IOException {
+        try (Stream<String> lines = Files.lines(getObjectListPath())) {
+            return lines.collect(Collectors.toList());
+        }
+    }
+
+    /**
+     * Transition the export to the exporting objects state
+     * @param exportPageSize
+     * @throws IOException
+     */
+    public void transitionToExporting(int exportPageSize) throws IOException {
+        assertState(ProgressState.LISTING_COMPLETED);
+        state.setState(ProgressState.EXPORTING);
+        state.setExportPageSize(exportPageSize);
+        writeState();
+    }
+
+    /**
+     * Register a list of object ids as having been exported
+     * @param objectIds
+     * @throws IOException
+     */
+    public void registerExported(List<String> objectIds) throws IOException {
+        assertState(ProgressState.EXPORTING);
+        int lastIndex = state.getLastExportedIndex() == null ? 0 : state.getLastExportedIndex();
+        state.setLastExportedIndex(lastIndex + objectIds.size() - 1);
+        writeState();
+    }
+
+    /**
+     * Indicate that the export step has completed
+     * @throws IOException
+     */
+    public void exportingCompleted() throws IOException {
+        assertState(ProgressState.EXPORTING);
+        state.setState(ProgressState.EXPORT_COMPLETED);
+        writeState();
+    }
+
+    public Path getObjectListPath() {
+        return project.getExportPath().resolve(IDS_FILENAME);
+    }
+
+    public Path getExportStatePath() {
+        return project.getExportPath().resolve(STATE_FILENAME);
+    }
+
+    private void assertState(ProgressState expectedState) {
+        if (!state.getState().equals(expectedState)) {
+            throw new InvalidProjectStateException("Invalid state, export must be in " + expectedState + " state");
+        }
+    }
+
+    /**
+     * Serialize the state of the export operation
+     * @throws IOException
+     */
+    public void writeState() throws IOException {
+        STATE_WRITER.writeValue(getExportStatePath().toFile(), state);
+    }
+
+    /**
+     * @return Deserialized state of the export operation
+     * @throws IOException
+     */
+    public ExportState readState() throws IOException {
+        return STATE_READER.readValue(getExportStatePath().toFile());
+    }
+
+    /**
+     * Clear any existing export state for the project
+     * @throws IOException
+     */
+    public void clearState() throws IOException {
+        Files.deleteIfExists(getExportStatePath());
+        Files.deleteIfExists(getObjectListPath());
+        state = new ExportState();
+    }
+
+    public void setProject(MigrationProject project) {
+        this.project = project;
+    }
+}

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
@@ -336,7 +336,7 @@ public class CdmExportCommandIT extends AbstractCommandIT {
                 "-p", PASSWORD,
                 "-n", PAGESIZE};
         executeExpectSuccess(args2);
-        assertOutputContains("Resuming incomplete export from where it left off");
+        assertOutputMatches(".*Resuming incomplete export started [0-9\\-T.:Z]+ from where it left off.*");
         assertOutputContains("Listing of object IDs complete");
         assertOutputContains("Resuming export of object records");
 
@@ -443,7 +443,7 @@ public class CdmExportCommandIT extends AbstractCommandIT {
                 "export",
                 "--cdm-url", cdmBaseUrl,
                 "-p", PASSWORD,
-                "--object-listing-per-page", "50"};
+                "--ids-per-page", "50"};
         executeExpectFailure(args);
         // Export no export files
         MigrationProject project = MigrationProjectFactory.loadMigrationProject(projPath);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
@@ -199,7 +199,7 @@ public class CdmExportCommandIT extends AbstractCommandIT {
 
         MigrationProject project = MigrationProjectFactory.loadMigrationProject(projPath);
 
-        assertFalse("Description folder should not be created", Files.exists(project.getExportPath()));
+        assertFalse("Export file should not be created", Files.exists(project.getExportPath().resolve("export_1.xml")));
         assertOutputContains("Failed to request export");
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
@@ -100,6 +100,7 @@ public class CdmExportServiceTest {
         fieldService = new CdmFieldService();
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);
+        exportStateService.transitionToStarting();
         service = new CdmExportService();
         service.setHttpClient(httpClient);
         service.setProject(project);
@@ -182,7 +183,8 @@ public class CdmExportServiceTest {
         fieldService.persistFieldsToProject(project, fieldInfo);
 
         when(postStatus.getStatusCode()).thenReturn(200);
-        when(getStatus.getStatusCode()).thenReturn(400);
+        // First status is for object listing requests
+        when(getStatus.getStatusCode()).thenReturn(200, 200, 400);
         when(getEntity.getContent()).thenReturn(this.getClass().getResourceAsStream("/sample_pages/cdm_listid_resp.json"))
                 .thenReturn(this.getClass().getResourceAsStream("/sample_pages/page_all.json"))
                 .thenReturn(new ByteArrayInputStream("bad".getBytes()));

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import edu.unc.lib.boxc.migration.cdm.options.CdmExportOptions;
 import edu.unc.lib.boxc.migration.cdm.services.export.ExportStateService;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -101,7 +102,7 @@ public class CdmExportServiceTest {
         exportStateService.setProject(project);
         service = new CdmExportService();
         service.setHttpClient(httpClient);
-        service.setCdmBaseUri(CDM_BASE_URL);
+        service.setProject(project);
         service.setCdmFieldService(fieldService);
         service.setExportStateService(exportStateService);
 
@@ -112,6 +113,14 @@ public class CdmExportServiceTest {
         when(postResp.getStatusLine()).thenReturn(postStatus);
         when(postResp.getEntity()).thenReturn(postEntity);
         when(getEntity.getContent()).thenReturn(new ByteArrayInputStream(EXPORT_BODY.getBytes()));
+    }
+
+    private CdmExportOptions makeExportOptions() {
+        CdmExportOptions options = new CdmExportOptions();
+        options.setCdmBaseUri(CDM_BASE_URL);
+        options.setCdmUsername("user");
+        options.setPageSize(1000);
+        return options;
     }
 
     @Test
@@ -125,7 +134,7 @@ public class CdmExportServiceTest {
                 .thenReturn(this.getClass().getResourceAsStream("/sample_pages/page_all.json"))
                 .thenReturn(this.getClass().getResourceAsStream("/sample_exports/gilmer/export_all.xml"));
 
-        service.exportAll(project);
+        service.exportAll(makeExportOptions());
 
         verify(httpClient, times(4)).execute(requestCaptor.capture());
         List<HttpUriRequest> requests = requestCaptor.getAllValues();
@@ -158,7 +167,7 @@ public class CdmExportServiceTest {
                 .thenReturn(new ByteArrayInputStream("bad".getBytes()));
 
         try {
-            service.exportAll(project);
+            service.exportAll(makeExportOptions());
             fail();
         } catch (MigrationException e) {
             // Should only have made one call
@@ -179,7 +188,7 @@ public class CdmExportServiceTest {
                 .thenReturn(new ByteArrayInputStream("bad".getBytes()));
 
         try {
-            service.exportAll(project);
+            service.exportAll(makeExportOptions());
             fail();
         } catch (MigrationException e) {
             verify(httpClient, times(4)).execute(any());
@@ -199,7 +208,7 @@ public class CdmExportServiceTest {
                 .thenReturn(this.getClass().getResourceAsStream("/sample_pages/page_all.json"))
                 .thenReturn(this.getClass().getResourceAsStream("/sample_exports/gilmer/export_all.xml"));
 
-        service.exportAll(project);
+        service.exportAll(makeExportOptions());
 
         verify(httpClient, times(4)).execute(requestCaptor.capture());
         List<HttpUriRequest> requests = requestCaptor.getAllValues();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
@@ -359,6 +359,24 @@ public class ExportStateServiceTest {
         assertEquals(allIds, exportStateService.retrieveObjectIds());
     }
 
+    @Test
+    public void registerExportedTest() throws Exception {
+        exportStateService.startOrResumeExport(false);
+        exportStateService.getState().setProgressState(ProgressState.EXPORTING);
+
+        List<String> allIds = generateIdList(120);
+        List<String> firstPage = allIds.subList(0, 50);
+        List<String> secondPage = allIds.subList(50, 100);
+        List<String> thirdPage = allIds.subList(100, 120);
+
+        exportStateService.registerExported(firstPage);
+        assertEquals(49, exportStateService.getState().getLastExportedIndex().intValue());
+        exportStateService.registerExported(secondPage);
+        assertEquals(99, exportStateService.getState().getLastExportedIndex().intValue());
+        exportStateService.registerExported(thirdPage);
+        assertEquals(119, exportStateService.getState().getLastExportedIndex().intValue());
+    }
+
     private List<String> generateIdList(int count) {
         return IntStream.range(0, count)
                 .mapToObj(Integer::toString)

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
@@ -124,7 +124,7 @@ public class ExportStateServiceTest {
         assertEquals(ProgressState.EXPORT_COMPLETED, state.getProgressState());
         assertEquals(99, state.getTotalObjects().intValue());
         assertEquals(cdmIds, exportStateService.retrieveObjectIds());
-        assertEquals(cdmIds.size() - 1, state.getLastExportedIndex().intValue());
+        assertEquals(cdmIds.size() - 1, state.getLastExportedIndex());
     }
 
     @Test
@@ -146,13 +146,8 @@ public class ExportStateServiceTest {
         assertFalse(state.isResuming());
         assertEquals(ProgressState.STARTING, state.getProgressState());
         assertNull(state.getTotalObjects());
-        try {
-            exportStateService.retrieveObjectIds();
-            fail();
-        } catch (NoSuchFileException e) {
-            // expected
-        }
-        assertNull(state.getLastExportedIndex());
+        assertTrue(exportStateService.retrieveObjectIds().isEmpty());
+        assertEquals(0, state.getLastExportedIndex());
     }
 
     @Test
@@ -176,13 +171,13 @@ public class ExportStateServiceTest {
         assertEquals(ProgressState.EXPORTING, state.getProgressState());
         assertEquals(99, state.getTotalObjects().intValue());
         assertEquals(cdmIds, exportStateService.retrieveObjectIds());
-        assertEquals(49, state.getLastExportedIndex().intValue());
+        assertEquals(49, state.getLastExportedIndex());
 
         // Active state should indicate it was resumed
         ExportState activeState = exportStateService.getState();
         assertTrue(activeState.isResuming());
         assertEquals(ProgressState.EXPORTING, activeState.getProgressState());
-        assertEquals(49, state.getLastExportedIndex().intValue());
+        assertEquals(49, state.getLastExportedIndex());
     }
 
     @Test
@@ -204,13 +199,8 @@ public class ExportStateServiceTest {
         assertFalse(state.isResuming());
         assertEquals(ProgressState.STARTING, state.getProgressState());
         assertNull(state.getTotalObjects());
-        try {
-            exportStateService.retrieveObjectIds();
-            fail();
-        } catch (NoSuchFileException e) {
-            // expected
-        }
-        assertNull(state.getLastExportedIndex());
+        assertTrue(exportStateService.retrieveObjectIds().isEmpty());
+        assertEquals(0, state.getLastExportedIndex());
     }
 
     @Test
@@ -370,11 +360,11 @@ public class ExportStateServiceTest {
         List<String> thirdPage = allIds.subList(100, 120);
 
         exportStateService.registerExported(firstPage);
-        assertEquals(49, exportStateService.getState().getLastExportedIndex().intValue());
+        assertEquals(49, exportStateService.getState().getLastExportedIndex());
         exportStateService.registerExported(secondPage);
-        assertEquals(99, exportStateService.getState().getLastExportedIndex().intValue());
+        assertEquals(99, exportStateService.getState().getLastExportedIndex());
         exportStateService.registerExported(thirdPage);
-        assertEquals(119, exportStateService.getState().getLastExportedIndex().intValue());
+        assertEquals(119, exportStateService.getState().getLastExportedIndex());
     }
 
     private List<String> generateIdList(int count) {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
@@ -1,0 +1,367 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.services.export;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static edu.unc.lib.boxc.migration.cdm.services.export.ExportState.ProgressState;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author bbpennel
+ */
+public class ExportStateServiceTest {
+    private static final String PROJECT_NAME = "proj";
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private ExportStateService exportStateService;
+    private MigrationProject project;
+
+    @Before
+    public void setup() throws Exception {
+        tmpFolder.create();
+        project = MigrationProjectFactory.createMigrationProject(
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user");
+        Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
+        exportStateService = new ExportStateService();
+        exportStateService.setProject(project);
+    }
+
+    @Test
+    public void startOrResumeExportNewRun() throws Exception {
+        exportStateService.startOrResumeExport(false);
+        ExportState state = exportStateService.readState();
+        assertFalse(state.isResuming());
+        assertEquals(ProgressState.STARTING, state.getProgressState());
+    }
+
+    @Test
+    public void startOrResumeExportNewRunWithForceRestart() throws Exception {
+        exportStateService.startOrResumeExport(true);
+        ExportState state = exportStateService.readState();
+        assertFalse(state.isResuming());
+        assertEquals(ProgressState.STARTING, state.getProgressState());
+    }
+
+    @Test
+    public void startOrResumeExportResumeInStartingState() throws Exception {
+        ExportState initState = exportStateService.getState();
+        initState.setProgressState(ProgressState.STARTING);
+        exportStateService.writeState();
+
+        exportStateService.startOrResumeExport(false);
+        ExportState state = exportStateService.readState();
+        assertFalse(state.isResuming());
+        assertEquals(ProgressState.STARTING, state.getProgressState());
+    }
+
+    @Test
+    public void startOrResumeExportResumeInCountedState() throws Exception {
+        ExportState initState = exportStateService.getState();
+        initState.setProgressState(ProgressState.COUNT_COMPLETED);
+        initState.setTotalObjects(99);
+        exportStateService.writeState();
+
+        exportStateService.startOrResumeExport(false);
+        ExportState state = exportStateService.readState();
+        assertFalse(state.isResuming());
+        assertEquals(ProgressState.STARTING, state.getProgressState());
+        assertNull(state.getTotalObjects());
+    }
+
+    @Test
+    public void startOrResumeExportResumeInCompletedState() throws Exception {
+        exportStateService.startOrResumeExport(false);
+        ExportState initState = exportStateService.getState();
+        initState.setTotalObjects(99);
+        List<String> cdmIds = generateIdList(99);
+        initState.setProgressState(ProgressState.LISTING_OBJECTS);
+        exportStateService.registerObjectIds(cdmIds);
+        initState.setProgressState(ProgressState.EXPORTING);
+        exportStateService.registerExported(cdmIds);
+        initState.setProgressState(ProgressState.EXPORT_COMPLETED);
+        exportStateService.writeState();
+
+        try {
+            exportStateService.startOrResumeExport(false);
+            fail();
+        } catch (InvalidProjectStateException e) {
+            assertTrue(e.getMessage().contains("Export has already completed"));
+        }
+        ExportState state = exportStateService.readState();
+        assertFalse(state.isResuming());
+        assertEquals(ProgressState.EXPORT_COMPLETED, state.getProgressState());
+        assertEquals(99, state.getTotalObjects().intValue());
+        assertEquals(cdmIds, exportStateService.retrieveObjectIds());
+        assertEquals(cdmIds.size() - 1, state.getLastExportedIndex().intValue());
+    }
+
+    @Test
+    public void startOrResumeExportResumeInCompletedStateWithRestart() throws Exception {
+        exportStateService.startOrResumeExport(false);
+        ExportState initState = exportStateService.getState();
+        initState.setTotalObjects(99);
+        List<String> cdmIds = generateIdList(99);
+        initState.setProgressState(ProgressState.LISTING_OBJECTS);
+        exportStateService.registerObjectIds(cdmIds);
+        initState.setProgressState(ProgressState.EXPORTING);
+        exportStateService.registerExported(cdmIds);
+        initState.setProgressState(ProgressState.EXPORT_COMPLETED);
+        exportStateService.writeState();
+
+        exportStateService.startOrResumeExport(true);
+
+        ExportState state = exportStateService.readState();
+        assertFalse(state.isResuming());
+        assertEquals(ProgressState.STARTING, state.getProgressState());
+        assertNull(state.getTotalObjects());
+        try {
+            exportStateService.retrieveObjectIds();
+            fail();
+        } catch (NoSuchFileException e) {
+            // expected
+        }
+        assertNull(state.getLastExportedIndex());
+    }
+
+    @Test
+    public void startOrResumeExportResumeInExportingState() throws Exception {
+        exportStateService.startOrResumeExport(false);
+        ExportState initState = exportStateService.getState();
+        initState.setTotalObjects(99);
+        initState.setExportPageSize(50);
+        List<String> cdmIds = generateIdList(99);
+        initState.setProgressState(ProgressState.LISTING_OBJECTS);
+        exportStateService.registerObjectIds(cdmIds);
+        initState.setProgressState(ProgressState.EXPORTING);
+        exportStateService.registerExported(cdmIds.subList(0, 50));
+        exportStateService.writeState();
+
+        exportStateService.startOrResumeExport(false);
+
+        // Persisted state should not be modified during resumption
+        ExportState state = exportStateService.readState();
+        assertFalse(state.isResuming());
+        assertEquals(ProgressState.EXPORTING, state.getProgressState());
+        assertEquals(99, state.getTotalObjects().intValue());
+        assertEquals(cdmIds, exportStateService.retrieveObjectIds());
+        assertEquals(49, state.getLastExportedIndex().intValue());
+
+        // Active state should indicate it was resumed
+        ExportState activeState = exportStateService.getState();
+        assertTrue(activeState.isResuming());
+        assertEquals(ProgressState.EXPORTING, activeState.getProgressState());
+        assertEquals(49, state.getLastExportedIndex().intValue());
+    }
+
+    @Test
+    public void startOrResumeExportResumeInExportingStateWithForceRestart() throws Exception {
+        exportStateService.startOrResumeExport(false);
+        ExportState initState = exportStateService.getState();
+        initState.setTotalObjects(99);
+        initState.setExportPageSize(50);
+        List<String> cdmIds = generateIdList(99);
+        initState.setProgressState(ProgressState.LISTING_OBJECTS);
+        exportStateService.registerObjectIds(cdmIds);
+        initState.setProgressState(ProgressState.EXPORTING);
+        exportStateService.registerExported(cdmIds.subList(0, 50));
+        exportStateService.writeState();
+
+        exportStateService.startOrResumeExport(true);
+
+        ExportState state = exportStateService.getState();
+        assertFalse(state.isResuming());
+        assertEquals(ProgressState.STARTING, state.getProgressState());
+        assertNull(state.getTotalObjects());
+        try {
+            exportStateService.retrieveObjectIds();
+            fail();
+        } catch (NoSuchFileException e) {
+            // expected
+        }
+        assertNull(state.getLastExportedIndex());
+    }
+
+    @Test
+    public void inStateOrNotResumingNoResumeTest() throws Exception {
+        assertTrue(exportStateService.inStateOrNotResuming());
+    }
+
+    @Test
+    public void inStateOrNotResumingNoResumeInStateTest() throws Exception {
+        ExportState state = exportStateService.getState();
+        state.setProgressState(ProgressState.LISTING_OBJECTS);
+        assertTrue(exportStateService.inStateOrNotResuming(ProgressState.LISTING_OBJECTS));
+    }
+
+    @Test
+    public void inStateOrNotResumingIsResumingInStateTest() throws Exception {
+        ExportState state = exportStateService.getState();
+        state.setResuming(true);
+        state.setProgressState(ProgressState.LISTING_OBJECTS);
+        assertTrue(exportStateService.inStateOrNotResuming(ProgressState.LISTING_OBJECTS));
+        assertTrue(exportStateService.inStateOrNotResuming(ProgressState.LISTING_OBJECTS,
+                ProgressState.LISTING_COMPLETED));
+    }
+
+    @Test
+    public void inStateOrNotResumingIsResumingNotInStateTest() throws Exception {
+        ExportState state = exportStateService.getState();
+        state.setResuming(true);
+        state.setProgressState(ProgressState.EXPORTING);
+        assertFalse(exportStateService.inStateOrNotResuming(ProgressState.LISTING_OBJECTS));
+        assertFalse(exportStateService.inStateOrNotResuming(ProgressState.LISTING_OBJECTS,
+                ProgressState.LISTING_COMPLETED));
+    }
+
+    @Test
+    public void objectCountCompletedTest() throws Exception {
+        exportStateService.startOrResumeExport(false);
+
+        exportStateService.objectCountCompleted(120);
+
+        ExportState state = exportStateService.readState();
+        assertEquals(ProgressState.COUNT_COMPLETED, state.getProgressState());
+        assertEquals(120, state.getTotalObjects().intValue());
+    }
+
+    @Test
+    public void objectCountCompletedWrongStateTest() throws Exception {
+        exportStateService.startOrResumeExport(false);
+        exportStateService.getState().setProgressState(ProgressState.EXPORTING);
+
+        try {
+            exportStateService.objectCountCompleted(120);
+            fail();
+        } catch (InvalidProjectStateException e) {
+        }
+        ExportState state = exportStateService.readState();
+        assertEquals(ProgressState.STARTING, state.getProgressState());
+        assertNull(state.getTotalObjects());
+    }
+
+    @Test
+    public void transitionToListingTest() throws Exception {
+        exportStateService.startOrResumeExport(false);
+        exportStateService.getState().setProgressState(ProgressState.COUNT_COMPLETED);
+
+        exportStateService.transitionToListing(100);
+
+        ExportState state = exportStateService.readState();
+        assertEquals(ProgressState.LISTING_OBJECTS, state.getProgressState());
+        assertEquals(100, state.getListIdPageSize().intValue());
+    }
+
+    @Test
+    public void transitionToListingWrongStateTest() throws Exception {
+        exportStateService.startOrResumeExport(false);
+
+        try {
+            exportStateService.transitionToListing(100);
+            fail();
+        } catch (InvalidProjectStateException e) {
+        }
+        ExportState state = exportStateService.readState();
+        assertEquals(ProgressState.STARTING, state.getProgressState());
+        assertNull(state.getListIdPageSize());
+    }
+
+    @Test
+    public void listingCompleteTest() throws Exception {
+        exportStateService.startOrResumeExport(false);
+        exportStateService.getState().setProgressState(ProgressState.LISTING_OBJECTS);
+
+        exportStateService.listingComplete();
+
+        ExportState state = exportStateService.readState();
+        assertEquals(ProgressState.LISTING_COMPLETED, state.getProgressState());
+    }
+
+    @Test
+    public void listingCompleteWrongStateTest() throws Exception {
+        exportStateService.startOrResumeExport(false);
+
+        try {
+            exportStateService.listingComplete();
+            fail();
+        } catch (InvalidProjectStateException e) {
+        }
+        ExportState state = exportStateService.readState();
+        assertEquals(ProgressState.STARTING, state.getProgressState());
+    }
+
+    @Test
+    public void transitionToExportingTest() throws Exception {
+        exportStateService.startOrResumeExport(false);
+        exportStateService.getState().setProgressState(ProgressState.LISTING_COMPLETED);
+
+        exportStateService.transitionToExporting(500);
+
+        ExportState state = exportStateService.readState();
+        assertEquals(ProgressState.EXPORTING, state.getProgressState());
+        assertEquals(500, state.getExportPageSize().intValue());
+    }
+
+    @Test
+    public void exportingCompletedTest() throws Exception {
+        exportStateService.startOrResumeExport(false);
+        exportStateService.getState().setProgressState(ProgressState.EXPORTING);
+
+        exportStateService.exportingCompleted();
+
+        ExportState state = exportStateService.readState();
+        assertEquals(ProgressState.EXPORT_COMPLETED, state.getProgressState());
+    }
+
+    @Test
+    public void registerObjectIdsTest() throws Exception {
+        exportStateService.startOrResumeExport(false);
+        exportStateService.getState().setProgressState(ProgressState.LISTING_OBJECTS);
+
+        List<String> allIds = generateIdList(100);
+        List<String> firstPage = allIds.subList(0, 50);
+        exportStateService.registerObjectIds(firstPage);
+        assertEquals(firstPage, exportStateService.retrieveObjectIds());
+
+        List<String> secondPage = allIds.subList(50, 100);
+        exportStateService.registerObjectIds(secondPage);
+        assertEquals(allIds, exportStateService.retrieveObjectIds());
+    }
+
+    private List<String> generateIdList(int count) {
+        return IntStream.range(0, count)
+                .mapToObj(Integer::toString)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3335

* Export operations will attempt to pick up after the last page listed or exported in order to support export of large collections in the case the process is interrupted
    * In order to totally restart an export, the `-f` flag will need to be provided if an export was previously started or completed.
    * The user will be alerted if an export is resuming, or if they are being prevented from starting a new one.
    * Since there are a few major stages to the export process (counting objects, listing ids, exporting metadata), implementation is a simple state machine, with state persisted to a json file, plus a flat text file for recording object ids.
* Updates to related services to bring them more in line with services developer later, and because the list of parameters was getting long: setting the project as an instant variable, using an Options mixin to more easily pass in flags to services.
* Added a commandline option for setting page size for listing of objects, mostly to support testing