### PR TITLE
BXC-3335 - Display export progress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,17 @@
             <groupId>it.ozimov</groupId>
             <artifactId>embedded-redis</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportProgressService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportProgressService.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.services.export;
+
+import edu.unc.lib.boxc.migration.cdm.util.DisplayProgressUtil;
+import org.slf4j.Logger;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static edu.unc.lib.boxc.migration.cdm.services.export.ExportState.ProgressState;
+import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Service which displays progress of an export operation
+ *
+ * @author bbpennel
+ */
+public class ExportProgressService {
+    private static final Logger log = getLogger(ExportProgressService.class);
+
+    private ProgressState previousProgressState;
+    private ExportStateService exportStateService;
+    private boolean listingNeedsClose;
+    private boolean exportingNeedsClose;
+
+    private Thread displayThread;
+    private AtomicBoolean displayActive = new AtomicBoolean(false);
+    private static final long DEFAULT_UPDATE_RATE = 250l;
+    private long displayUpdateRate = DEFAULT_UPDATE_RATE;
+
+    /**
+     * Start display of progress in a separate thread.
+     */
+    public void startProgressDisplay() {
+        if (displayThread != null) {
+            log.error("Progress display already active, cannot start again");
+            return;
+        }
+        displayActive.set(true);
+        displayThread = new Thread(() -> {
+            // Update the display every
+            while (displayActive.get()) {
+                update();
+                try {
+                    TimeUnit.MILLISECONDS.sleep(displayUpdateRate);
+                } catch (InterruptedException e) {
+                    log.warn("Interrupting progress display");
+                    return;
+                }
+            }
+        });
+        displayThread.start();
+    }
+
+    /**
+     * End refreshing of the progress display, waiting for the display to terminate
+     */
+    public void endProgressDisplay() {
+        if (displayThread == null) {
+            log.error("Progress display not active");
+            return;
+        }
+        displayActive.set(false);
+        // Wait up to 10 ticks for the display thread to end, just in case it doesn't end immediately
+        try {
+            displayThread.join(displayUpdateRate * 10);
+        } catch (InterruptedException e) {
+            log.warn("Interrupted while waiting for progress display to shut down");
+        }
+        displayThread = null;
+    }
+
+    /**
+     * Update the display of progress for the active export
+     */
+    public void update() {
+        ProgressState lastUpdateState = previousProgressState;
+        ExportState currentState = exportStateService.getState();
+        previousProgressState = currentState.getProgressState();
+
+        ProgressState currentProgress = currentState.getProgressState();
+        // Display counting message if starting or we missed the starting state and haven't displayed message yet
+        if (ProgressState.STARTING.equals(currentProgress)
+                || (currentProgress != null && !currentState.isResuming() && lastUpdateState == null)) {
+            // First entered counting state
+            if (lastUpdateState == null) {
+                outputLogger.info("Determining size of collection for export...");
+            }
+        }
+        if (ProgressState.LISTING_OBJECTS.equals(currentProgress)) {
+            // Transitioning into listing state
+            if (!ProgressState.LISTING_OBJECTS.equals(lastUpdateState)) {
+                outputLogger.info("Listing CDM Object IDs:");
+                listingNeedsClose = true;
+            }
+            DisplayProgressUtil.displayProgress(currentState.getListedObjectCount(), currentState.getTotalObjects());
+            return;
+        } else if (listingNeedsClose) {
+            // Final update of progress, to make sure it reaches end
+            DisplayProgressUtil.displayProgress(currentState.getListedObjectCount(), currentState.getTotalObjects());
+            DisplayProgressUtil.finishProgress();
+            listingNeedsClose = false;
+        }
+
+        // export count is the index plus one, unless none have been exported yet
+        int exportCount = currentState.getLastExportedIndex() == 0 ? 0 : (currentState.getLastExportedIndex() + 1);
+        if (ProgressState.EXPORTING.equals(currentProgress)) {
+            // Transitioning into listing state
+            if (!ProgressState.EXPORTING.equals(lastUpdateState)) {
+                outputLogger.info("Exporting object metadata:");
+                exportingNeedsClose = true;
+            }
+            DisplayProgressUtil.displayProgress(exportCount, currentState.getTotalObjects());
+            return;
+        } else if (exportingNeedsClose) {
+            // Final update of progress, to make sure it reaches end
+            DisplayProgressUtil.displayProgress(exportCount, currentState.getTotalObjects());
+            DisplayProgressUtil.finishProgress();
+            exportingNeedsClose = false;
+        }
+    }
+
+    public void setExportStateService(ExportStateService exportStateService) {
+        this.exportStateService = exportStateService;
+    }
+
+    public void setDisplayUpdateRate(long displayUpdateRate) {
+        this.displayUpdateRate = displayUpdateRate;
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportState.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportState.java
@@ -18,6 +18,7 @@ package edu.unc.lib.boxc.migration.cdm.services.export;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.time.Instant;
+import java.util.Arrays;
 
 /**
  * State of a CDM export operation
@@ -29,6 +30,7 @@ public class ExportState {
     private Integer exportPageSize;
     private Integer listIdPageSize;
     private Integer totalObjects;
+    private int listedObjectCount;
     // Int so it will start at 0 instead of null
     private int lastExportedIndex;
     private boolean resuming = false;
@@ -62,6 +64,19 @@ public class ExportState {
         this.listIdPageSize = listIdPageSize;
     }
 
+    @JsonIgnore
+    public int getListedObjectCount() {
+        return listedObjectCount;
+    }
+
+    public void setListedObjectCount(int listedObjectCount) {
+        this.listedObjectCount = listedObjectCount;
+    }
+
+    public void incrementListedObjectCount(int increVal) {
+        this.listedObjectCount += increVal;
+    }
+
     public Integer getTotalObjects() {
         return totalObjects;
     }
@@ -76,6 +91,23 @@ public class ExportState {
 
     public void setProgressState(ProgressState progressState) {
         this.progressState = progressState;
+    }
+
+    /**
+     *
+     * @param exportState
+     * @param expectedStates
+     * @return True if the progressState of the provided exportState matches any of the expected states
+     */
+    public static boolean inState(ExportState exportState, ProgressState... expectedStates) {
+        if (exportState == null) {
+            return false;
+        }
+        ProgressState pState = exportState.getProgressState();
+        if (pState == null) {
+            return false;
+        }
+        return Arrays.stream(expectedStates).anyMatch(s -> s.equals(pState));
     }
 
     public int getLastExportedIndex() {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/util/DisplayProgressUtil.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/util/DisplayProgressUtil.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.util;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.repeat;
+
+/**
+ * Utilities for displaying progress in a CLI
+ *
+ * @author bbpennel
+ */
+public class DisplayProgressUtil {
+    private static final int PROGRESS_BAR_UNITS = 40;
+    private static final double PROGRESS_BAR_DIVIDOR = (double) 100 / PROGRESS_BAR_UNITS;
+
+    /**
+     * Render a progress bar, percent, and total
+     *
+     * @param current
+     * @param total
+     */
+    public static void displayProgress(long current, long total) {
+        long percent = Math.round(((float) current / total) * 100);
+        int progressBars = (int) Math.round(percent / PROGRESS_BAR_DIVIDOR);
+
+        StringBuilder sb = new StringBuilder("\r");
+        sb.append(format("%1$3s", percent)).append("% [");
+        sb.append(repeat("=", progressBars));
+        sb.append(repeat(" ", PROGRESS_BAR_UNITS - progressBars));
+        sb.append("] ").append(current).append("/").append(total);
+        // Append spaces to clear rest of line
+        sb.append(repeat(" ", 40));
+        sb.append("\r");
+
+        System.out.print(sb.toString());
+        System.out.flush();
+    }
+
+    public static void finishProgress() {
+        System.out.println();
+        System.out.flush();
+    }
+
+    private DisplayProgressUtil() {
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/util/DisplayProgressUtil.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/util/DisplayProgressUtil.java
@@ -25,17 +25,20 @@ import static org.apache.commons.lang3.StringUtils.repeat;
  */
 public class DisplayProgressUtil {
     private static final int PROGRESS_BAR_UNITS = 40;
-    private static final double PROGRESS_BAR_DIVIDOR = (double) 100 / PROGRESS_BAR_UNITS;
+    private static final double PROGRESS_BAR_DIVISOR = (double) 100 / PROGRESS_BAR_UNITS;
 
     /**
-     * Render a progress bar, percent, and total
+     * Render a progress bar, percent, and total.
+     *
+     * For example, given current = 120 and total = 161, it would display:
+     *  75% [==============================          ] 120/161
      *
      * @param current
      * @param total
      */
     public static void displayProgress(long current, long total) {
         long percent = Math.round(((float) current / total) * 100);
-        int progressBars = (int) Math.round(percent / PROGRESS_BAR_DIVIDOR);
+        int progressBars = (int) Math.round(percent / PROGRESS_BAR_DIVISOR);
 
         StringBuilder sb = new StringBuilder("\r");
         sb.append(format("%1$3s", percent)).append("% [");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportProgressServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportProgressServiceTest.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.services.export;
+
+import edu.unc.lib.boxc.migration.cdm.AbstractOutputTest;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static edu.unc.lib.boxc.migration.cdm.services.export.ExportState.ProgressState;
+
+/**
+ * @author bbpennel
+ */
+public class ExportProgressServiceTest extends AbstractOutputTest {
+    private static final String PROJECT_NAME = "proj";
+
+    private MigrationProject project;
+    private ExportStateService exportStateService;
+    private ExportProgressService exportProgressService;
+
+    @Before
+    public void setup() throws Exception {
+        project = MigrationProjectFactory.createMigrationProject(
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user");
+        exportStateService = new ExportStateService();
+        exportStateService.setProject(project);
+        exportProgressService = new ExportProgressService();
+        exportProgressService.setExportStateService(exportStateService);
+    }
+
+    @Test
+    public void updateProgressNotStartedTest() throws Exception {
+        exportProgressService.update();
+
+        assertOutputDoesNotContain("Determining size of collection for export");
+    }
+
+    @Test
+    public void updateProgressStartingTest() throws Exception {
+        exportStateService.getState().setProgressState(ProgressState.STARTING);
+
+        exportProgressService.update();
+
+        assertOutputContains("Determining size of collection for export");
+    }
+
+    @Test
+    public void updateListingFromNotStartedTest() throws Exception {
+        exportStateService.getState().setProgressState(ProgressState.LISTING_OBJECTS);
+        exportStateService.getState().setTotalObjects(160);
+
+        exportProgressService.update();
+
+        assertOutputContains("Determining size of collection for export");
+        assertOutputMatches(".*Listing CDM Object IDs:\n.* 0/160.*");
+    }
+
+    @Test
+    public void updateListingFromCountCompletedTest() throws Exception {
+        exportStateService.getState().setProgressState(ProgressState.COUNT_COMPLETED);
+        exportStateService.getState().setTotalObjects(160);
+        exportProgressService.update();
+
+        resetOutput();
+
+        exportStateService.getState().setListedObjectCount(50);
+        exportStateService.getState().setProgressState(ProgressState.LISTING_OBJECTS);
+
+        exportProgressService.update();
+
+        assertOutputDoesNotContain("Determining size of collection for export");
+        assertOutputMatches(".*Listing CDM Object IDs:\n.* 50/160.*");
+    }
+
+    @Test
+    public void updateListingThroughCompleteTest() throws Exception {
+        exportStateService.getState().setProgressState(ProgressState.COUNT_COMPLETED);
+        exportStateService.getState().setTotalObjects(160);
+        exportProgressService.update();
+        resetOutput();
+
+        exportStateService.getState().setProgressState(ProgressState.LISTING_OBJECTS);
+
+        exportStateService.getState().incrementListedObjectCount(50);
+        exportProgressService.update();
+        assertOutputMatches(".*Listing CDM Object IDs:\n.* 50/160.*");
+        resetOutput();
+
+        // Update called without any changes
+        exportProgressService.update();
+        assertOutputMatches(".* 50/160.*");
+        resetOutput();
+
+        exportStateService.getState().incrementListedObjectCount(50);
+        exportProgressService.update();
+        assertOutputMatches(".* 100/160.*");
+        resetOutput();
+
+        exportStateService.getState().incrementListedObjectCount(50);
+        exportProgressService.update();
+        assertOutputMatches(".* 150/160.*");
+        resetOutput();
+
+        exportStateService.getState().incrementListedObjectCount(10);
+        exportStateService.getState().setProgressState(ProgressState.COUNT_COMPLETED);
+        exportProgressService.update();
+        assertOutputMatches(".* 160/160.*");
+    }
+
+    @Test
+    public void updateExportFromListingTest() throws Exception {
+        exportStateService.getState().setProgressState(ProgressState.LISTING_OBJECTS);
+        exportStateService.getState().setTotalObjects(160);
+        exportStateService.getState().setListedObjectCount(160);
+        exportProgressService.update();
+        resetOutput();
+
+        exportStateService.getState().setProgressState(ProgressState.EXPORTING);
+        exportProgressService.update();
+        // This is the finalization of the listing progress, since we skipped the completed step
+        assertOutputMatches(".* 160/160.*");
+        assertOutputMatches(".*Exporting object metadata:\n.* 0/160.*");
+    }
+
+    @Test
+    public void updateExportFromListCompletedTest() throws Exception {
+        exportStateService.getState().setProgressState(ProgressState.LISTING_COMPLETED);
+        exportStateService.getState().setTotalObjects(160);
+        exportStateService.getState().setListedObjectCount(160);
+        exportProgressService.update();
+        resetOutput();
+
+        exportStateService.getState().setProgressState(ProgressState.EXPORTING);
+        exportProgressService.update();
+        assertOutputMatches(".*Exporting object metadata:\n.* 0/160.*");
+        resetOutput();
+
+        exportStateService.getState().setLastExportedIndex(99);
+        exportProgressService.update();
+        assertOutputMatches(".* 100/160.*");
+        resetOutput();
+
+        exportStateService.getState().setLastExportedIndex(159);
+        exportStateService.getState().setProgressState(ProgressState.EXPORT_COMPLETED);
+        exportProgressService.update();
+        assertOutputMatches(".* 160/160.*");
+    }
+
+    @Test
+    public void displayProgressTest() throws Exception {
+        try {
+            exportProgressService.setDisplayUpdateRate(10);
+            exportProgressService.startProgressDisplay();
+
+            assertOutputDoesNotContain("Determining size of collection for export");
+
+            exportStateService.getState().setProgressState(ProgressState.STARTING);
+            awaitOutputMatches(".*Determining size of collection for export.*");
+
+            exportStateService.getState().setTotalObjects(160);
+            exportStateService.getState().setProgressState(ProgressState.COUNT_COMPLETED);
+
+            exportStateService.getState().setProgressState(ProgressState.LISTING_OBJECTS);
+            awaitOutputMatches(".*Listing CDM Object IDs:\n.* 0/160.*");
+
+            exportStateService.getState().setListedObjectCount(100);
+            awaitOutputMatches(".* 100/160.*");
+
+            exportStateService.getState().setListedObjectCount(160);
+            exportStateService.getState().setProgressState(ProgressState.LISTING_COMPLETED);
+
+            exportStateService.getState().setProgressState(ProgressState.EXPORTING);
+            awaitOutputMatches(".*Exporting object metadata:\n.* 0/160.*");
+
+            exportStateService.getState().setLastExportedIndex(159);
+            exportStateService.getState().setProgressState(ProgressState.EXPORT_COMPLETED);
+            awaitOutputMatches(".* 160/160.*");
+        } finally {
+            exportProgressService.endProgressDisplay();
+        }
+    }
+}

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
@@ -338,15 +338,18 @@ public class ExportStateServiceTest {
     public void registerObjectIdsTest() throws Exception {
         exportStateService.startOrResumeExport(false);
         exportStateService.getState().setProgressState(ProgressState.LISTING_OBJECTS);
+        assertEquals(0, exportStateService.getState().getListedObjectCount());
 
         List<String> allIds = generateIdList(100);
         List<String> firstPage = allIds.subList(0, 50);
         exportStateService.registerObjectIds(firstPage);
         assertEquals(firstPage, exportStateService.retrieveObjectIds());
+        assertEquals(50, exportStateService.getState().getListedObjectCount());
 
         List<String> secondPage = allIds.subList(50, 100);
         exportStateService.registerObjectIds(secondPage);
         assertEquals(allIds, exportStateService.retrieveObjectIds());
+        assertEquals(100, exportStateService.getState().getListedObjectCount());
     }
 
     @Test


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3336

* Adds service which displays progress of export operations
    * Runs in its own thread on a timer, based on monitoring the current export state
    * ExportState records the number of objects listed so far
    * Pulled in utility for rendering progress bars from bxc3 migration util
    * Test method for asynchronous output testing added to help with monitor progress display
* Excluding slf4j-simple dependency which was causing some confusion when debugging a test