### PR TITLE
BXC-3422 allowing cdm_object_id to be null

### DIFF
--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/RedirectMappingHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/RedirectMappingHelper.java
@@ -56,7 +56,7 @@ public class RedirectMappingHelper {
             statement.execute("CREATE TABLE redirect_mappings (" +
                     "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
                     "cdm_collection_id varchar(64) NOT NULL, " +
-                    "cdm_object_id varchar(64) NOT NULL, " +
+                    "cdm_object_id varchar(64) DEFAULT NULL, " +
                     "boxc_work_id varchar(64) NOT NULL, " +
                     "boxc_file_id varchar(64) DEFAULT NULL, " +
                     "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, " +


### PR DESCRIPTION
We need to allow nulls in the cdm_object_id field in the redirect_mappings table. The tables on the server are created by hand, but this change allows the test suite to have the same specifications.