### PR TITLE
BXC-3490 - Skip missing fields, catch missing records

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/CdmExportOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/CdmExportOptions.java
@@ -37,8 +37,8 @@ public class CdmExportOptions {
     @CommandLine.Option(names = {"-n", "--records-per-page"},
             description = {"Page size for exports.",
                     "Default: ${DEFAULT-VALUE}. Max page size is " + MAX_EXPORT_RECORDS_PER_PAGE},
-            defaultValue = "1000")
-    private int pageSize = 1000;
+            defaultValue = "500")
+    private int pageSize = 500;
     public static final int MAX_LIST_IDS_PER_PAGE = 1000;
     @CommandLine.Option(names = {"--ids-per-page"},
             description = {"During initial listing of object IDs, the number of objects to list per page.",

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
@@ -178,15 +178,15 @@ public class CdmExportService {
         var exportedIds = recordEls.stream()
                 .map(el -> el.getChildTextTrim(CdmFieldInfo.CDM_ID))
                 .collect(Collectors.toList());
-        var missing = CollectionUtils.removeAll(cdmIds, exportedIds);
-        if (!missing.isEmpty()) {
+        var missingIds = CollectionUtils.removeAll(cdmIds, exportedIds);
+        if (!missingIds.isEmpty()) {
             throw new MigrationException("Export failure, document returned by CDM was missing the following records: "
-                + String.join(", ", missing));
+                + String.join(", ", missingIds));
         }
         if (exportedIds.size() != cdmIds.size()) {
-            var extra = CollectionUtils.removeAll(exportedIds, cdmIds);
+            var extraIds = CollectionUtils.removeAll(exportedIds, cdmIds);
             throw new MigrationException("Export failure, document contained IDs not in the requested set: "
-                    + String.join(", ", extra));
+                    + String.join(", ", extraIds));
         }
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
@@ -165,11 +165,10 @@ public class CdmIndexService {
                 .map(exportField -> {
                     Element childEl = objEl.getChild(exportField);
                     if (childEl == null) {
-                        throw new InvalidProjectStateException("Missing configured field " + exportField
-                                + " in export document, aborting indexing due to configuration mismatch");
+                        return "";
+                    } else {
+                        return childEl.getTextTrim();
                     }
-                    String value = childEl.getTextTrim();
-                    return value == null ? "" : value;
                 }).collect(Collectors.toList());
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
@@ -95,11 +95,11 @@ public class CdmIndexService {
                 indexDocument(doc, conn, fieldInfo);
             }
         } catch (IOException e) {
-            throw new MigrationException("Failed to read export files: " + e.getMessage());
+            throw new MigrationException("Failed to read export files", e);
         } catch (SQLException e) {
-            throw new MigrationException("Failed to update database: " + e.getMessage());
+            throw new MigrationException("Failed to update database", e);
         } catch (JDOMException e) {
-            throw new MigrationException("Failed to parse export file: " + e.getMessage());
+            throw new MigrationException("Failed to parse export file", e);
         } finally {
             closeDbConnection(conn);
         }
@@ -147,6 +147,7 @@ public class CdmIndexService {
         Element metadataEl = childEl.getChild("pagemetadata");
         String pageId = childEl.getChildText("pageptr");
         String parentCdmId = parentReservedValues.get(0);
+        log.debug("Indexing compound child {} from parent {}", pageId, parentCdmId);
 
         List<String> values = listFieldValues(metadataEl, fieldInfo.listConfiguredFields());
         // Use the page id as the child's cdm id

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CompleteMigrationIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CompleteMigrationIT.java
@@ -134,7 +134,7 @@ public class CompleteMigrationIT extends AbstractCommandIT {
         stubFor(get(urlEqualTo("/dmwebservices/index.php?q=dmQuery/my_coll/0/dmrecord/dmrecord/1000/1/1/0/0/0/0/json"))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/octet-stream")
-                        .withBody(IOUtils.toString(getClass().getResourceAsStream("/sample_pages/page_all.json"), StandardCharsets.UTF_8))));
+                        .withBody(IOUtils.toString(getClass().getResourceAsStream("/sample_pages/gilmer_3_page_all.json"), StandardCharsets.UTF_8))));
 
         String[] argsInit = new String[] {
                 "-w", baseDir.toString(),

--- a/src/test/resources/sample_pages/gilmer_3_page_all.json
+++ b/src/test/resources/sample_pages/gilmer_3_page_all.json
@@ -1,0 +1,1 @@
+{"pager":{"start":"1","maxrecs":"50","total":3},"records":[{"collection":"\/gilmer","pointer":25,"filetype":"jp2","parentobject":-1,"dmrecord":"25","find":"26.JP2"},{"collection":"\/gilmer","pointer":26,"filetype":"jp2","parentobject":-1,"dmrecord":"26","find":"27.JP2"},{"collection":"\/gilmer","pointer":27,"filetype":"jp2","parentobject":-1,"dmrecord":"27","find":"50.jp2"}]}


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3490
* If a configured field is no present for a record or a compound child, then store an empty string for that field. This is to account for some admin fields in cdm not being returned in exports, particularly for compound children
* Change default page size for exports, since CDM is losing ids when exporting 1000 at a time for some collections
* Add verification step to ensure that no ids are missing from an export before declaring export a success.