### PR TITLE
Bxc 3465 add cdm fields to spreadsheet

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/CdmFieldInfo.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/CdmFieldInfo.java
@@ -90,6 +90,11 @@ public class CdmFieldInfo {
         private String exportAs;
         private String description;
         private Boolean skipExport;
+        private String cdmRequired;
+        private String cdmSearchable;
+        private String cdmHidden;
+        private String cdmVocab;
+        private String cdmDcMapping;
 
         public String getNickName() {
             return nickName;
@@ -122,5 +127,25 @@ public class CdmFieldInfo {
         public void setSkipExport(Boolean skipExport) {
             this.skipExport = skipExport;
         }
+
+        public String getCdmRequired() { return cdmRequired; }
+
+        public void setCdmRequired(String cdmRequired) { this.cdmRequired = cdmRequired; }
+
+        public String getCdmSearchable() { return cdmSearchable; }
+
+        public void setCdmSearchable(String cdmSearchable) { this.cdmSearchable = cdmSearchable; }
+
+        public String getCdmHidden() { return cdmHidden; }
+
+        public void setCdmHidden(String cdmHidden) { this.cdmHidden = cdmHidden; }
+
+        public String getCdmVocab() { return cdmVocab; }
+
+        public void setCdmVocab(String cdmVocab) { this.cdmVocab = cdmVocab; }
+
+        public String getCdmDcMapping() { return cdmDcMapping; }
+
+        public void setCdmDcMapping(String cdmDcMapping) { this.cdmDcMapping = cdmDcMapping; }
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldService.java
@@ -60,13 +60,24 @@ public class CdmFieldService {
 
     private static final String CDM_NICK_FIELD = "nick";
     private static final String CDM_NAME_FIELD = "name";
+    private static final String CDM_REQUIRED_FIELD = "req";
+    private static final String CDM_SEARCHABLE_FIELD = "search";
+    private static final String CDM_HIDDEN_FIELD = "hide";
+    private static final String CDM_VOCAB_FIELD = "vocab";
+    private static final String CDM_DC_MAPPING_FIELD = "dc";
 
     public static final String EXPORT_NICK_FIELD = "cdm_nick";
     public static final String EXPORT_AS_FIELD = "export_as";
     public static final String EXPORT_DESC_FIELD = "description";
     public static final String EXPORT_SKIP_FIELD = "skip_export";
+    public static final String EXPORT_CDM_REQUIRED = "cdm_required";
+    public static final String EXPORT_CDM_SEARCHABLE = "cdm_searchable";
+    public static final String EXPORT_CDM_HIDDEN = "cdm_hidden";
+    public static final String EXPORT_CDM_VOCAB = "cdm_vocab";
+    public static final String EXPORT_CDM_DC_MAPPING = "cdm_dc_mapping";
     public static final String[] EXPORT_CSV_HEADERS = new String[] {
-            EXPORT_NICK_FIELD, EXPORT_AS_FIELD, EXPORT_DESC_FIELD, EXPORT_SKIP_FIELD };
+            EXPORT_NICK_FIELD, EXPORT_AS_FIELD, EXPORT_DESC_FIELD, EXPORT_SKIP_FIELD, EXPORT_CDM_REQUIRED,
+            EXPORT_CDM_SEARCHABLE, EXPORT_CDM_HIDDEN, EXPORT_CDM_VOCAB, EXPORT_CDM_DC_MAPPING };
 
     public CdmFieldService() {
     }
@@ -109,11 +120,21 @@ public class CdmFieldService {
                 ObjectNode entryNode = mapper.readTree(parser);
                 String nick = entryNode.get(CDM_NICK_FIELD).asText();
                 String description = entryNode.get(CDM_NAME_FIELD).asText();
+                Boolean cdmRequired = (entryNode.get(CDM_REQUIRED_FIELD).asInt() == 1);
+                Boolean cdmSearchable = (entryNode.get(CDM_SEARCHABLE_FIELD).asInt() == 1);
+                Boolean cdmHidden = (entryNode.get(CDM_HIDDEN_FIELD).asInt() == 1);
+                Boolean cdmVocab = (entryNode.get(CDM_VOCAB_FIELD).asInt() == 1);
+                String dcMapping = entryNode.get(CDM_DC_MAPPING_FIELD).asText();
                 CdmFieldEntry fieldEntry = new CdmFieldEntry();
                 fieldEntry.setNickName(nick);
                 fieldEntry.setExportAs(nick);
                 fieldEntry.setDescription(description);
                 fieldEntry.setSkipExport(false);
+                fieldEntry.setCdmRequired(booleanToString(cdmRequired));
+                fieldEntry.setCdmSearchable(booleanToString(cdmSearchable));
+                fieldEntry.setCdmHidden(booleanToString(cdmHidden));
+                fieldEntry.setCdmVocab(booleanToString(cdmVocab));
+                fieldEntry.setCdmDcMapping(dcMapping);
                 fieldInfo.getFields().add(fieldEntry);
             }
         } catch (JsonParseException e) {
@@ -138,7 +159,8 @@ public class CdmFieldService {
         ) {
             for (CdmFieldEntry entry : fieldInfo.getFields()) {
                 csvPrinter.printRecord(entry.getNickName(), entry.getExportAs(), entry.getDescription(),
-                        entry.getSkipExport());
+                        entry.getSkipExport(), entry.getCdmRequired(), entry.getCdmSearchable(),
+                        entry.getCdmHidden(), entry.getCdmVocab(), entry.getCdmDcMapping());
             }
         }
     }
@@ -166,6 +188,11 @@ public class CdmFieldService {
                 entry.setExportAs(csvRecord.get(1));
                 entry.setDescription(csvRecord.get(2));
                 entry.setSkipExport(Boolean.parseBoolean(csvRecord.get(3)));
+                entry.setCdmRequired(csvRecord.get(4));
+                entry.setCdmSearchable(csvRecord.get(5));
+                entry.setCdmHidden(csvRecord.get(6));
+                entry.setCdmVocab(csvRecord.get(7));
+                entry.setCdmDcMapping(csvRecord.get(8));
                 fields.add(entry);
             }
             return fieldInfo;
@@ -189,7 +216,7 @@ public class CdmFieldService {
         ) {
             int line = 2;
             for (CSVRecord csvRecord : csvParser) {
-                if (csvRecord.size() != 4) {
+                if (csvRecord.size() != 9) {
                     throw new InvalidProjectStateException(
                             "Invalid CDM fields entry at line " + line);
                 }
@@ -219,6 +246,10 @@ public class CdmFieldService {
                     + field + "' at line " + line + ", values must be unique");
         }
         existing.add(field);
+    }
+
+    public String booleanToString(boolean bool) {
+        return bool ? "y" : "n";
     }
 
     public void setHttpClient(CloseableHttpClient httpClient) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/FieldAssessmentTemplateService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/FieldAssessmentTemplateService.java
@@ -47,7 +47,8 @@ public class FieldAssessmentTemplateService {
     private CdmFieldService cdmFieldService;
     private static final List<String> COLUMN_NAMES = Arrays.asList("Field Label", "Alias", "MD Source",
             "All fields blank?", "Some fields blank?", "Repeated fields?", "Retain?", "Display?",
-            "MODS mapping", "Notes", "Remediation needed");
+            "MODS mapping", "Notes", "Remediation needed", "cdm_required", "cdm_searchable", "cdm_hidden",
+            "cdm_vocab", "cdm_dc_mapping");
 
     /**
      * Generate field assessment spreadsheet template for a collection
@@ -96,12 +97,12 @@ public class FieldAssessmentTemplateService {
         color.setTint(0.85);
         fill.setFillBackgroundColor(color);
         fill.setFillPattern(PatternFormatting.SOLID_FOREGROUND);
-        CellRangeAddress[] regions = {CellRangeAddress.valueOf("A1:K200")};
+        CellRangeAddress[] regions = {CellRangeAddress.valueOf("A1:Z200")};
         sheetCF.addConditionalFormatting(regions, rule1);
 
         // Add a header row, and freeze it
         Row header = sheet.createRow(0);
-        sheet.setAutoFilter(new CellRangeAddress(0, 0, 0, 10));
+        sheet.setAutoFilter(new CellRangeAddress(0, 0, 0, 15));
         sheet.createFreezePane(0,1);
         header.setRowStyle(headerStyle);
         int cellNum = 0;
@@ -121,6 +122,11 @@ public class FieldAssessmentTemplateService {
             row.createCell(5).setCellValue("n");
             row.createCell(6).setCellValue("n");
             row.createCell(7).setCellValue("n");
+            row.createCell(11).setCellValue(fields.get(i).getCdmRequired());
+            row.createCell(12).setCellValue(fields.get(i).getCdmSearchable());
+            row.createCell(13).setCellValue(fields.get(i).getCdmHidden());
+            row.createCell(14).setCellValue(fields.get(i).getCdmVocab());
+            row.createCell(15).setCellValue(fields.get(i).getCdmDcMapping());
         }
 
         // Auto size the column widths

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
@@ -307,7 +307,7 @@ public class CdmFieldServiceTest {
             service.validateFieldsFile(project);
             fail();
         } catch (InvalidProjectStateException e) {
-            assertTrue(e.getMessage().contains("Invalid CDM fields entry at line 3"));
+            assertTrue(e.getMessage().contains("Invalid CDM fields entry at line 2"));
         }
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
@@ -86,11 +86,21 @@ public class CdmFieldServiceTest {
         CdmFieldInfo fieldInfo = service.retrieveFieldsForCollection(PROJECT_NAME);
         List<CdmFieldEntry> fields = fieldInfo.getFields();
 
-        assertHasFieldWithValue("title", "title", "Title", false, fields);
-        assertHasFieldWithValue("creato", "creato", "Creator", false, fields);
-        assertHasFieldWithValue("date", "date", "Creation Date", false, fields);
-        assertHasFieldWithValue("data", "data", "Date", false, fields);
-        assertHasFieldWithValue("digitb", "digitb", "Digital Collection", false, fields);
+        assertHasFieldWithValue("title", "title", "Title", false,
+                "y", "y", "n", "n",
+                "title", fields);
+        assertHasFieldWithValue("creato", "creato", "Creator", false,
+                "n", "y", "n", "y",
+                "creato", fields);
+        assertHasFieldWithValue("date", "date", "Creation Date", false,
+                "n", "y", "y", "n",
+                "datea", fields);
+        assertHasFieldWithValue("data", "data", "Date", false,
+                "n", "n", "n", "n",
+                "date", fields);
+        assertHasFieldWithValue("digitb", "digitb", "Digital Collection",
+                false, "n", "y", "n",
+                "n", "BLANK", fields);
     }
 
     @Test
@@ -157,6 +167,11 @@ public class CdmFieldServiceTest {
         field1.setExportAs("field1");
         field1.setDescription("First field");
         field1.setSkipExport(false);
+        field1.setCdmRequired("y");
+        field1.setCdmSearchable("y");
+        field1.setCdmHidden("y");
+        field1.setCdmVocab("y");
+        field1.setCdmDcMapping("field1");
         fieldsOriginal.add(field1);
 
         CdmFieldEntry field2 = new CdmFieldEntry();
@@ -164,6 +179,11 @@ public class CdmFieldServiceTest {
         field2.setExportAs("secondary");
         field2.setDescription("Secondary Field");
         field2.setSkipExport(true);
+        field2.setCdmRequired("n");
+        field2.setCdmSearchable("n");
+        field2.setCdmHidden("n");
+        field2.setCdmVocab("n");
+        field2.setCdmDcMapping("field2");
         fieldsOriginal.add(field2);
 
         service.persistFieldsToProject(project, fieldInfoOriginal);
@@ -172,8 +192,12 @@ public class CdmFieldServiceTest {
         CdmFieldInfo fieldInfoLoaded = service.loadFieldsFromProject(project);
         List<CdmFieldEntry> fieldsLoaded = fieldInfoLoaded.getFields();
         assertEquals(2, fieldsLoaded.size());
-        assertHasFieldWithValue("field1", "field1", "First field", false, fieldsLoaded);
-        assertHasFieldWithValue("field2", "secondary", "Secondary Field", true, fieldsLoaded);
+        assertHasFieldWithValue("field1", "field1", "First field", false,
+                "y", "y", "y", "y",
+                "field1", fieldsLoaded);
+        assertHasFieldWithValue("field2", "secondary", "Secondary Field", true,
+                "n", "n", "n", "n",
+                "field2", fieldsLoaded);
     }
 
     @Test
@@ -207,6 +231,11 @@ public class CdmFieldServiceTest {
         field1.setExportAs("field1");
         field1.setDescription("First field");
         field1.setSkipExport(false);
+        field1.setCdmRequired("y");
+        field1.setCdmSearchable("y");
+        field1.setCdmHidden("y");
+        field1.setCdmVocab("y");
+        field1.setCdmDcMapping("field1");
         fieldsOriginal.add(field1);
 
         CdmFieldEntry field2 = new CdmFieldEntry();
@@ -214,6 +243,11 @@ public class CdmFieldServiceTest {
         field2.setExportAs("secondary");
         field2.setDescription("Secondary Field");
         field2.setSkipExport(true);
+        field2.setCdmRequired("n");
+        field2.setCdmSearchable("n");
+        field2.setCdmHidden("n");
+        field2.setCdmVocab("n");
+        field2.setCdmDcMapping("field2");
         fieldsOriginal.add(field2);
 
         service.persistFieldsToProject(project, fieldInfoOriginal);
@@ -235,6 +269,11 @@ public class CdmFieldServiceTest {
         field1.setExportAs("field1");
         field1.setDescription("First field");
         field1.setSkipExport(false);
+        field1.setCdmRequired("y");
+        field1.setCdmSearchable("y");
+        field1.setCdmHidden("y");
+        field1.setCdmVocab("y");
+        field1.setCdmDcMapping("field1");
         fieldsOriginal.add(field1);
 
         CdmFieldEntry field2 = new CdmFieldEntry();
@@ -242,6 +281,11 @@ public class CdmFieldServiceTest {
         field2.setExportAs("field1");
         field2.setDescription("Secondary Field");
         field2.setSkipExport(true);
+        field2.setCdmRequired("n");
+        field2.setCdmSearchable("n");
+        field2.setCdmHidden("n");
+        field2.setCdmVocab("n");
+        field2.setCdmDcMapping("field2");
         fieldsOriginal.add(field2);
 
         service.persistFieldsToProject(project, fieldInfoOriginal);
@@ -284,20 +328,36 @@ public class CdmFieldServiceTest {
         CdmFieldInfo fieldInfoLoaded = service.loadFieldsFromProject(project);
         List<CdmFieldEntry> fieldsLoaded = fieldInfoLoaded.getFields();
 
-        assertHasFieldWithValue("title", "title", "Title", false, fieldsLoaded);
-        assertHasFieldWithValue("creato", "creato", "Creator", false, fieldsLoaded);
-        assertHasFieldWithValue("date", "date", "Creation Date", false, fieldsLoaded);
-        assertHasFieldWithValue("data", "data", "Date", false, fieldsLoaded);
-        assertHasFieldWithValue("digitb", "digitb", "Digital Collection", false, fieldsLoaded);
+        assertHasFieldWithValue("title", "title", "Title", false,
+                "y", "y", "n", "n",
+                "title", fieldsLoaded);
+        assertHasFieldWithValue("creato", "creato", "Creator", false,
+                "n", "y", "n", "y",
+                "creato", fieldsLoaded);
+        assertHasFieldWithValue("date", "date", "Creation Date", false,
+                "n", "y", "y", "n",
+                "datea", fieldsLoaded);
+        assertHasFieldWithValue("data", "data", "Date", false,
+                "n", "n", "n", "n",
+                "date", fieldsLoaded);
+        assertHasFieldWithValue("digitb", "digitb", "Digital Collection", false,
+                "n", "y", "n", "n",
+                "BLANK", fieldsLoaded);
     }
 
     private void assertHasFieldWithValue(String nick, String expectedExport, String expectedDesc,
-            boolean expectedSkip, List<CdmFieldEntry> fields) {
+            boolean expectedSkip, String expectedCdmRequired, String expectedCdmSearchable, String expectedCdmHidden,
+            String expectedCdmVocab, String expectedCdmDcMapping, List<CdmFieldEntry> fields) {
         Optional<CdmFieldEntry> matchOpt = fields.stream().filter(f -> nick.equals(f.getNickName())).findFirst();
         assertTrue("Field " + nick + " not present", matchOpt.isPresent());
         CdmFieldEntry entry = matchOpt.get();
         assertEquals(expectedDesc, entry.getDescription());
         assertEquals(expectedExport, entry.getExportAs());
         assertEquals(expectedSkip, entry.getSkipExport());
+        assertEquals(expectedCdmRequired, entry.getCdmRequired());
+        assertEquals(expectedCdmSearchable, entry.getCdmSearchable());
+        assertEquals(expectedCdmHidden, entry.getCdmHidden());
+        assertEquals(expectedCdmVocab, entry.getCdmVocab());
+        assertEquals(expectedCdmDcMapping, entry.getCdmDcMapping());
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldAssessmentTemplateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldAssessmentTemplateServiceTest.java
@@ -70,9 +70,9 @@ public class FieldAssessmentTemplateServiceTest {
         Sheet sheet = workbook.getSheetAt(0);
 
         assertEquals(60, sheet.getLastRowNum());
-        assertEquals(11, sheet.getRow(0).getPhysicalNumberOfCells());
-        assertEquals(7, sheet.getRow(1).getPhysicalNumberOfCells());
-        assertEquals(7, sheet.getRow(60).getPhysicalNumberOfCells());
+        assertEquals(16, sheet.getRow(0).getPhysicalNumberOfCells());
+        assertEquals(12, sheet.getRow(1).getPhysicalNumberOfCells());
+        assertEquals(12, sheet.getRow(60).getPhysicalNumberOfCells());
         assertNull(sheet.getRow(1).getCell(2));
         assertNull(sheet.getRow(1).getCell(8));
         assertNull(sheet.getRow(1).getCell(9));

--- a/src/test/resources/gilmer_fields.csv
+++ b/src/test/resources/gilmer_fields.csv
@@ -1,62 +1,61 @@
-cdm_nick,export_as,description,skip_export
-title,title,Title,false
-altern,altern,Alternative Title,false
-creato,creato,Creator,false
-contri,contri,Contributor,false
-date,date,Creation Date,false
-data,data,Date,false
-search,search,Search by Decade,true
-descri,descri,Description,false
-subjec,subjec,Subject (tgm),false
-subjea,subjea,Subject Topical,false
-subjeb,subjeb,Subject Name,false
-subjed,subjed,Subject Geographic,false
-titla,titla,Title Note,false
-dcmi,dcmi,DCMI Type,false
-captio,captio,Caption,false
-contra,contra,Contributor Note,false
-notes,notes,Notes,false
-type,type,Original Form,false
-resour,resour,Resource Type,false
-covera,covera,Geographic Location,false
-langub,langub,Language Code,false
-langua,langua,Language,false
-format,format,Physical Description of Original,false
-medium,medium,Medium of Original,false
-source,source,Collection in Repository,false
-digitb,digitb,Digital Collection,false
-publis,publis,Repository,false
-host,host,Host,false
-educat,educat,N.C. Ed. Standard,false
-identi,identi,URL,false
-local,local,Local Identifier,false
-creata,creata,Creator Identifier,false
-sponso,sponso,Citation,false
-file,file,filename,false
-rights,rights,Copyright,false
-orderi,orderi,Usage Rights,false
-initia,initia,Raw Scan Filename,false
-digita,digita,Digital Scan Date Raw Scan,false
-digitc,digitc,Digital Scan Date filename,false
-creatb,creatb,Creator Raw Scan,false
-creatc,creatc,Creator filename,false
-hardwa,hardwa,Hardware Raw Scan,false
-hardwb,hardwb,Hardware filename,false
-softwa,softwa,Software Raw Scan,false
-softwb,softwb,Software filename,false
-pixel,pixel,Pixel Array Raw Scan,false
-pixea,pixea,Pixel Array filename,false
-bit,bit,Bit Depth Raw Scan,false
-bia,bia,Bit Depth filename,false
-color,color,Color Space Raw Scan,false
-coloa,coloa,Color Space filename,false
-fila,fila,File Format Raw Scan,false
-filb,filb,File Format filename,false
-full,full,path,false
-fullrs,fullrs,Full resolution,false
-groupa,groupa,Group A,false
-dmoclcno,dmoclcno,OCLC number,false
-dmcreated,dmcreated,Date created,false
-dmmodified,dmmodified,Date modified,false
-dmrecord,dmrecord,CONTENTdm number,false
-find,find,CONTENTdm file name,false
+cdm_nick,export_as,description,skip_export,cdm_required,cdm_searchable,cdm_hidden,cdm_vocab,cdm_dc_mapping
+title,title,Title,false,y,y,n,n,title
+altern,altern,Alternative Title,false,n,y,n,n,title
+creato,creato,Creator,false,n,y,n,y,creato
+contri,contri,Contributor,false,n,y,n,y,contri
+date,date,Creation Date,false,n,y,y,n,datea
+data,data,Date,false,n,n,n,n,date
+descri,descri,Description,false,n,y,n,n,descri
+subjec,subjec,Subject (tgm),false,n,y,n,y,subjec
+subjea,subjea,Subject Topical,false,n,y,n,y,subjec
+subjeb,subjeb,Subject Name,false,n,y,n,y,subjec
+subjed,subjed,Subject Geographic,false,n,y,n,y,subjec
+titla,titla,Title Note,false,n,y,n,n,descri
+dcmi,dcmi,DCMI Type,false,n,n,n,n,type
+captio,captio,Caption,false,n,y,n,n,descri
+contra,contra,Contributor Note,false,n,n,n,n,descri
+notes,notes,Notes,false,n,y,n,n,descri
+type,type,Original Form,false,n,y,n,y,format
+resour,resour,Resource Type,false,n,n,y,y,format
+covera,covera,Geographic Location,false,n,y,n,y,coveraa
+langub,langub,Language Code,false,n,y,y,y,langua
+langua,langua,Language,false,n,y,n,y,langua
+format,format,Physical Description of Original,false,n,n,n,n,formata
+medium,medium,Medium of Original,false,n,y,n,y,formatb
+source,source,Collection in Repository,false,n,n,n,n,source
+digitb,digitb,Digital Collection,false,n,y,n,n,BLANK
+publis,publis,Repository,false,n,n,n,y,publis
+host,host,Host,false,n,n,n,n,BLANK
+educat,educat,N.C. Ed. Standard,false,n,n,n,y,relatim
+identi,identi,URL,false,n,n,n,n,identi
+local,local,Local Identifier,false,n,y,n,n,identi
+creata,creata,Creator Identifier,false,n,y,n,n,identi
+sponso,sponso,Citation,false,n,n,n,n,identi
+file,file,filename,false,n,y,n,n,BLANK
+rights,rights,Copyright,false,n,y,n,n,rights
+orderi,orderi,Usage Rights,false,n,n,n,n,rights
+initia,initia,Raw Scan Filename,false,n,n,y,n,BLANK
+digita,digita,Digital Scan Date Raw Scan,false,n,n,y,n,BLANK
+digitc,digitc,Digital Scan Date filename,false,n,n,y,n,BLANK
+creatb,creatb,Creator Raw Scan,false,n,n,y,n,BLANK
+creatc,creatc,Creator filename,false,n,n,y,n,BLANK
+hardwa,hardwa,Hardware Raw Scan,false,n,n,y,n,BLANK
+hardwb,hardwb,Hardware filename,false,n,n,y,n,BLANK
+softwa,softwa,Software Raw Scan,false,n,n,y,n,BLANK
+softwb,softwb,Software filename,false,n,n,y,n,BLANK
+pixel,pixel,Pixel Array Raw Scan,false,n,n,y,n,BLANK
+pixea,pixea,Pixel Array filename,false,n,n,y,n,BLANK
+bit,bit,Bit Depth Raw Scan,false,n,n,y,n,BLANK
+bia,bia,Bit Depth filename,false,n,n,y,n,BLANK
+color,color,Color Space Raw Scan,false,n,n,y,n,BLANK
+coloa,coloa,Color Space filename,false,n,n,y,n,BLANK
+fila,fila,File Format Raw Scan,false,n,n,y,y,BLANK
+filb,filb,File Format filename,false,n,n,y,y,BLANK
+full,full,path,false,n,n,n,n,BLANK
+fullrs,fullrs,Full resolution,false,n,n,y,n,
+dmoclcno,dmoclcno,OCLC number,false,n,n,y,n,
+dmcreated,dmcreated,Date created,false,y,n,y,n,
+dmmodified,dmmodified,Date modified,false,y,n,y,n,
+dmrecord,dmrecord,CONTENTdm number,false,y,n,y,n,
+find,find,CONTENTdm file name,false,y,n,y,n,
+groupa,groupa,Group A,false,n,y,n,n,descri


### PR DESCRIPTION
[https://jira.lib.unc.edu/browse/BXC-3465](https://jira.lib.unc.edu/browse/BXC-3465)

- `CdmFieldInfo`: add additional cdm field properties (cdmRequired, cdmSearchable, cdmHidden, cdmVocab, cdmDcMapping)
- `CdmFieldService`: add additional cdm fields to service
- `FieldAssessmentTemplateService`: add additional cdm fields to service and small changes to template styling
- Remaining changes include adding the cdm fields to the tests and test resource