### PR TITLE
Bxc 3498 improve error handling

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommand.java
@@ -32,6 +32,7 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ParentCommand;
@@ -43,6 +44,7 @@ import java.util.concurrent.Callable;
 
 import static edu.unc.lib.boxc.migration.cdm.services.export.ExportState.ProgressState;
 import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * @author bbpennel
@@ -52,6 +54,7 @@ import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
                 "If an export operation was started but did not complete, running this command again will "
                     + "resume from where it left off. To force a restart instead, use the --force option."})
 public class CdmExportCommand implements Callable<Integer> {
+    private static final Logger log = getLogger(CdmExportCommand.class);
     @ParentCommand
     private CLIMain parentCommand;
 
@@ -91,6 +94,7 @@ public class CdmExportCommand implements Callable<Integer> {
                     (System.nanoTime() - start) / 1e9);
             return 0;
         } catch (MigrationException e) {
+            log.error("Failed to export project", e);
             outputLogger.info("Failed to export project: {}", e.getMessage());
             return 1;
         }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmFieldsCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmFieldsCommand.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.boxc.migration.cdm;
 
 import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
@@ -23,6 +24,7 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
 import edu.unc.lib.boxc.migration.cdm.services.FieldAssessmentTemplateService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import org.slf4j.Logger;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ParentCommand;
 
@@ -32,6 +34,7 @@ import picocli.CommandLine.ParentCommand;
 @Command(name = "fields",
         description = "Interactions with CDM fields for the current project")
 public class CdmFieldsCommand {
+    private static final Logger log = getLogger(CdmFieldsCommand.class);
     @ParentCommand
     private CLIMain parentCommand;
 
@@ -51,6 +54,7 @@ public class CdmFieldsCommand {
             outputLogger.info("FAIL: {}", e.getMessage());
             return 1;
         } catch (MigrationException e) {
+            log.error("Failed to validate fields file", e);
             outputLogger.info("FAIL: Failed to validate fields file: {}", e.getMessage());
             return 1;
         }
@@ -70,6 +74,7 @@ public class CdmFieldsCommand {
             outputLogger.info("{}", e.getMessage());
             return 1;
         } catch (Exception e) {
+            log.error("Failed to generate report", e);
             outputLogger.info("Failed to generate report: {}", e.getMessage());
             return 1;
         }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/DescriptionsCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/DescriptionsCommand.java
@@ -89,6 +89,7 @@ public class DescriptionsCommand {
                     generated, project.getProjectName(), (System.nanoTime() - start) / 1e9);
             return 0;
         } catch (MigrationException e) {
+            log.error("Cannot generate descriptions", e);
             outputLogger.info("Cannot generate descriptions: {}", e.getMessage());
             return 1;
         } catch (Exception e) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommand.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.boxc.migration.cdm;
 
 import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -31,6 +32,7 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.services.FindingAidService;
+import org.slf4j.Logger;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
@@ -42,6 +44,7 @@ import picocli.CommandLine.ParentCommand;
 @Command(name = "init",
         description = "Initialize a new CDM migration project")
 public class InitializeProjectCommand implements Callable<Integer> {
+    private static final Logger log = getLogger(InitializeProjectCommand.class);
     @ParentCommand
     private CLIMain parentCommand;
 
@@ -86,6 +89,7 @@ public class InitializeProjectCommand implements Callable<Integer> {
             fieldService.setCdmBaseUri(cdmBaseUri);
             fieldInfo = fieldService.retrieveFieldsForCollection(collId);
         } catch (IOException | MigrationException e) {
+            log.error("Failed to retrieve field information for collection in project", e);
             outputLogger.info("Failed to retrieve field information for collection {} in project {}:\n{}",
                     collId, projDisplayName, e.getMessage());
             return 1;
@@ -112,6 +116,7 @@ public class InitializeProjectCommand implements Callable<Integer> {
             findingAidService.setCdmFieldService(fieldService);
             findingAidService.recordFindingAid();
         } catch (Exception e) {
+            log.error("Failed to record finding aid for collection", e);
             outputLogger.info("Failed to record finding aid for collection", e);
             return 1;
         }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/ProjectPropertiesCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/ProjectPropertiesCommand.java
@@ -19,6 +19,7 @@ import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.services.ProjectPropertiesService;
+import org.slf4j.Logger;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ParentCommand;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Command to update migration project properties
@@ -35,6 +37,7 @@ import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
 @Command(name = "config",
         description = "Configure a CDM migration project.")
 public class ProjectPropertiesCommand {
+    private static final Logger log = getLogger(ProjectPropertiesCommand.class);
     @ParentCommand
     private CLIMain parentCommand;
 
@@ -61,6 +64,7 @@ public class ProjectPropertiesCommand {
             outputLogger.info("{}", e.getMessage());
             return 1;
         } catch (Exception e) {
+            log.error("Failed to list project properties", e);
             outputLogger.info("Failed to list project properties", e.getMessage());
             return 1;
         }
@@ -84,6 +88,7 @@ public class ProjectPropertiesCommand {
             outputLogger.info("{}", e.getMessage());
             return 1;
         } catch (Exception e) {
+            log.error("Failed to set project property", e);
             outputLogger.info("Failed to set project property", e.getMessage());
             return 1;
         }
@@ -105,6 +110,7 @@ public class ProjectPropertiesCommand {
             outputLogger.info("{}", e.getMessage());
             return 1;
         } catch (Exception e) {
+            log.error("Failed to unset project property(ies)", e);
             outputLogger.info("Failed to unset project property(ies)", e.getMessage());
             return 1;
         }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/StatusCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/StatusCommand.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.boxc.migration.cdm;
 
 import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -25,6 +26,7 @@ import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.status.ProjectStatusService;
+import org.slf4j.Logger;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ParentCommand;
 
@@ -34,7 +36,7 @@ import picocli.CommandLine.ParentCommand;
 @Command(name = "status",
         description = "Display the status of the current project")
 public class StatusCommand implements Callable<Integer>  {
-
+    private static final Logger log = getLogger(StatusCommand.class);
     @ParentCommand
     private CLIMain parentCommand;
 
@@ -50,6 +52,7 @@ public class StatusCommand implements Callable<Integer>  {
 
             return 0;
         } catch (MigrationException e) {
+            log.error("Failed to report project status", e);
             outputLogger.info("Failed to report project status: {}", e.getMessage());
             return 1;
         }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldService.java
@@ -139,7 +139,7 @@ public class CdmFieldService {
             }
         } catch (JsonParseException e) {
             throw new MigrationException("Failed to parse response from URL " + infoUri
-                    + ": " + e.getMessage());
+                    + ": ", e);
         }
         return fieldInfo;
     }
@@ -228,9 +228,9 @@ public class CdmFieldService {
                 throw new InvalidProjectStateException("CDM fields file is empty, it must contain at least 1 entry");
             }
         } catch (NoSuchFileException e) {
-            throw new InvalidProjectStateException("CDM fields file is missing, expected at path: " + e.getMessage());
+            throw new InvalidProjectStateException("CDM fields file is missing, expected at path", e);
         } catch (IOException e) {
-            throw new InvalidProjectStateException("Cannot read fields file: " + e.getMessage());
+            throw new InvalidProjectStateException("Cannot read fields file", e);
         }
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldService.java
@@ -138,8 +138,7 @@ public class CdmFieldService {
                 fieldInfo.getFields().add(fieldEntry);
             }
         } catch (JsonParseException e) {
-            throw new MigrationException("Failed to parse response from URL " + infoUri
-                    + ": ", e);
+            throw new MigrationException("Failed to parse response from URL " + infoUri, e);
         }
         return fieldInfo;
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
@@ -277,7 +277,7 @@ public class CdmIndexService {
                 conn.close();
             }
         } catch (SQLException e) {
-            throw new MigrationException("Failed to close database connection: " + e.getMessage());
+            throw new MigrationException("Failed to close database connection", e);
         }
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmListIdService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmListIdService.java
@@ -88,7 +88,7 @@ public class CdmListIdService {
                 return pager.get("total").asInt();
         } catch (JsonParseException e) {
             throw new MigrationException("Failed to parse response from URL " + totalUri
-                    + ": " + e.getMessage());
+                    + ": ", e);
         }
     }
 
@@ -154,7 +154,7 @@ public class CdmListIdService {
             }
         } catch (JsonParseException e) {
             throw new MigrationException("Failed to parse response from URL " + objectUri
-                    + ": " + e.getMessage());
+                    + ": ", e);
         }
         return objectIds;
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmListIdService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmListIdService.java
@@ -87,8 +87,7 @@ public class CdmListIdService {
                 JsonNode pager = entryNode.get("pager");
                 return pager.get("total").asInt();
         } catch (JsonParseException e) {
-            throw new MigrationException("Failed to parse response from URL " + totalUri
-                    + ": ", e);
+            throw new MigrationException("Failed to parse response from URL " + totalUri, e);
         }
     }
 
@@ -153,8 +152,7 @@ public class CdmListIdService {
                 throw new MigrationException("Retrieved no object ids for listing request: " + objectUri);
             }
         } catch (JsonParseException e) {
-            throw new MigrationException("Failed to parse response from URL " + objectUri
-                    + ": ", e);
+            throw new MigrationException("Failed to parse response from URL " + objectUri, e);
         }
         return objectIds;
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/AbstractStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/AbstractStatusService.java
@@ -16,7 +16,6 @@
 package edu.unc.lib.boxc.migration.cdm.status;
 
 import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
-import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -25,13 +24,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 
-import edu.unc.lib.boxc.migration.cdm.AccessFilesCommand;
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.collect.Iterators;
 
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
-import org.slf4j.Logger;
 
 /**
  * @author bbpennel

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/AbstractStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/AbstractStatusService.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.boxc.migration.cdm.status;
 
 import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -24,11 +25,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 
+import edu.unc.lib.boxc.migration.cdm.AccessFilesCommand;
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.collect.Iterators;
 
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import org.slf4j.Logger;
 
 /**
  * @author bbpennel
@@ -84,7 +87,7 @@ public class AbstractStatusService {
         } catch (FileNotFoundException e) {
             return 0;
         } catch (IOException e) {
-            outputLogger.info("Unable to count files for {}: {}", dirPath, e);
+            outputLogger.info("Unable to count files for {}", dirPath, e);
             return 0;
         }
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/AbstractStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/AbstractStatusService.java
@@ -84,7 +84,7 @@ public class AbstractStatusService {
         } catch (FileNotFoundException e) {
             return 0;
         } catch (IOException e) {
-            outputLogger.info("Unable to count files for {}: {}", dirPath, e.getMessage());
+            outputLogger.info("Unable to count files for {}: {}", dirPath, e);
             return 0;
         }
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/DescriptionsStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/DescriptionsStatusService.java
@@ -16,13 +16,16 @@
 package edu.unc.lib.boxc.migration.cdm.status;
 
 import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Set;
 
+import edu.unc.lib.boxc.migration.cdm.AccessFilesCommand;
 import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
 import edu.unc.lib.boxc.migration.cdm.services.DescriptionsService;
+import org.slf4j.Logger;
 
 /**
  * Service for displaying status related to descriptive records
@@ -30,6 +33,7 @@ import edu.unc.lib.boxc.migration.cdm.services.DescriptionsService;
  * @author bbpennel
  */
 public class DescriptionsStatusService extends AbstractStatusService {
+    private static final Logger log = getLogger(DescriptionsStatusService.class);
     private DescriptionsService descService;
 
     /**
@@ -62,7 +66,8 @@ public class DescriptionsStatusService extends AbstractStatusService {
                 showFieldListValues(indexedIds);
             }
         } catch (IOException e) {
-            outputLogger.info("Failed to list MODS records: {}", e);
+            log.error("Failed to list MODS records", e);
+            outputLogger.info("Failed to list MODS records: {}", e.getMessage());
         }
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/DescriptionsStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/DescriptionsStatusService.java
@@ -62,7 +62,7 @@ public class DescriptionsStatusService extends AbstractStatusService {
                 showFieldListValues(indexedIds);
             }
         } catch (IOException e) {
-            outputLogger.info("Failed to list MODS records: {}", e.getMessage());
+            outputLogger.info("Failed to list MODS records: {}", e);
         }
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/DescriptionsStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/DescriptionsStatusService.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Set;
 
-import edu.unc.lib.boxc.migration.cdm.AccessFilesCommand;
 import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
 import edu.unc.lib.boxc.migration.cdm.services.DescriptionsService;
 import org.slf4j.Logger;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusService.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.boxc.migration.cdm.status;
 
 import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -23,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import edu.unc.lib.boxc.migration.cdm.AccessFilesCommand;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.unc.lib.boxc.migration.cdm.model.DestinationsInfo;
@@ -30,12 +32,14 @@ import edu.unc.lib.boxc.migration.cdm.model.DestinationsInfo.DestinationMapping;
 import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
 import edu.unc.lib.boxc.migration.cdm.services.DestinationsService;
 import edu.unc.lib.boxc.migration.cdm.validators.DestinationsValidator;
+import org.slf4j.Logger;
 
 /**
  * Service which reports status of destination mappings
  * @author bbpennel
  */
 public class DestinationsStatusService extends AbstractStatusService {
+    private static final Logger log = getLogger(DestinationsStatusService.class);
     /**
      * Display a stand alone report of the destination mapping status
      * @param verbosity
@@ -138,7 +142,8 @@ public class DestinationsStatusService extends AbstractStatusService {
                 showFieldListValues(newColls);
             }
         } catch (IOException e) {
-            outputLogger.info("Failed to load destinations mapping: {}", e);
+            log.error("Failed to load destinations mapping", e);
+            outputLogger.info("Failed to load destinations mapping: {}", e.getMessage());
         }
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusService.java
@@ -138,7 +138,7 @@ public class DestinationsStatusService extends AbstractStatusService {
                 showFieldListValues(newColls);
             }
         } catch (IOException e) {
-            outputLogger.info("Failed to load destinations mapping: {}", e.getMessage());
+            outputLogger.info("Failed to load destinations mapping: {}", e);
         }
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusService.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import edu.unc.lib.boxc.migration.cdm.AccessFilesCommand;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.unc.lib.boxc.migration.cdm.model.DestinationsInfo;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/GroupMappingStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/GroupMappingStatusService.java
@@ -63,7 +63,7 @@ public class GroupMappingStatusService extends AbstractStatusService {
             try {
                 modified = Files.getLastModifiedTime(mappingsPath).toInstant();
             } catch (IOException e) {
-                outputLogger.info("Failed to check mappings: {}", e.getMessage());
+                outputLogger.info("Failed to check mappings: {}", e);
             }
         }
         showField("Mappings Modified", modified == null ? "Not present" : modified);
@@ -103,7 +103,7 @@ public class GroupMappingStatusService extends AbstractStatusService {
                 showFieldListValues(groupList);
             }
         } catch (IOException e) {
-            outputLogger.info("Failed to load mappings: {}", e.getMessage());
+            outputLogger.info("Failed to load mappings: {}", e);
         }
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/GroupMappingStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/GroupMappingStatusService.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import edu.unc.lib.boxc.migration.cdm.AccessFilesCommand;
 import edu.unc.lib.boxc.migration.cdm.model.GroupMappingInfo;
 import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
 import edu.unc.lib.boxc.migration.cdm.services.GroupMappingService;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/GroupMappingStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/GroupMappingStatusService.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.boxc.migration.cdm.status;
 
 import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -26,9 +27,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import edu.unc.lib.boxc.migration.cdm.AccessFilesCommand;
 import edu.unc.lib.boxc.migration.cdm.model.GroupMappingInfo;
 import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
 import edu.unc.lib.boxc.migration.cdm.services.GroupMappingService;
+import org.slf4j.Logger;
 
 /**
  * Service to display status of object group mapping
@@ -36,6 +39,7 @@ import edu.unc.lib.boxc.migration.cdm.services.GroupMappingService;
  * @author bbpennel
  */
 public class GroupMappingStatusService extends AbstractStatusService {
+    private static final Logger log = getLogger(GroupMappingStatusService.class);
 
     /**
      * Display a stand alone report of the source file mapping status
@@ -63,7 +67,8 @@ public class GroupMappingStatusService extends AbstractStatusService {
             try {
                 modified = Files.getLastModifiedTime(mappingsPath).toInstant();
             } catch (IOException e) {
-                outputLogger.info("Failed to check mappings: {}", e);
+                log.error("Failed to check mappings", e);
+                outputLogger.info("Failed to check mappings: {}", e.getMessage());
             }
         }
         showField("Mappings Modified", modified == null ? "Not present" : modified);
@@ -103,7 +108,8 @@ public class GroupMappingStatusService extends AbstractStatusService {
                 showFieldListValues(groupList);
             }
         } catch (IOException e) {
-            outputLogger.info("Failed to load mappings: {}", e);
+            log.error("Failed to load mappings", e);
+            outputLogger.info("Failed to load mappings: {}", e.getMessage());
         }
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusService.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import edu.unc.lib.boxc.migration.cdm.AccessFilesCommand;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusService.java
@@ -111,7 +111,7 @@ public class SourceFilesStatusService extends AbstractStatusService {
                 showField("Potential Matches", cntPotential);
             }
         } catch (IOException e) {
-            outputLogger.info("Failed to load mappings: {}", e.getMessage());
+            outputLogger.info("Failed to load mappings: {}", e);
         }
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusService.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.boxc.migration.cdm.status;
 
 import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -23,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import edu.unc.lib.boxc.migration.cdm.AccessFilesCommand;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo;
@@ -30,6 +32,7 @@ import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo.SourceFileMapping;
 import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
 import edu.unc.lib.boxc.migration.cdm.services.SourceFileService;
 import edu.unc.lib.boxc.migration.cdm.validators.SourceFilesValidator;
+import org.slf4j.Logger;
 
 /**
  * Service for displaying reports of source file mappings
@@ -37,6 +40,7 @@ import edu.unc.lib.boxc.migration.cdm.validators.SourceFilesValidator;
  * @author bbpennel
  */
 public class SourceFilesStatusService extends AbstractStatusService {
+    private static final Logger log = getLogger(SourceFilesStatusService.class);
     /**
      * Display a stand alone report of the source file mapping status
      * @param verbosity
@@ -111,7 +115,8 @@ public class SourceFilesStatusService extends AbstractStatusService {
                 showField("Potential Matches", cntPotential);
             }
         } catch (IOException e) {
-            outputLogger.info("Failed to load mappings: {}", e);
+            log.error("Failed to load mappings", e);
+            outputLogger.info("Failed to load mappings: {}", e.getMessage());
         }
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
@@ -112,7 +112,6 @@ public class CdmFieldServiceTest {
             fail();
         } catch (MigrationException e) {
             assertTrue(e.getMessage().contains("Failed to parse response from URL"));
-            assertTrue(e.getMessage().contains("Unrecognized token"));
         }
     }
 


### PR DESCRIPTION
[https://jira.lib.unc.edu/browse/BXC-3498](https://jira.lib.unc.edu/browse/BXC-3498)

This PR includes improvements to error reporting when chompb operations fail. Small changes were made to services and commands.
- Services: change how errors are thrown
- Commands: add stacktrace to migration.log