### PR TITLE
BXC-3288 - Escape field names during grouping sync

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommand.java
@@ -68,6 +68,7 @@ public class GroupMappingCommand {
             return 0;
         } catch (MigrationException | IllegalArgumentException e) {
             outputLogger.info("Cannot generate group mapping: {}", e.getMessage());
+            log.warn("Cannot generate group mapping", e);
             return 1;
         } catch (Exception e) {
             log.error("Failed to map group objects", e);
@@ -90,6 +91,7 @@ public class GroupMappingCommand {
             return 0;
         } catch (MigrationException | IllegalArgumentException e) {
             outputLogger.info("Cannot sync group mappings: {}", e.getMessage());
+            log.warn("Cannot sync group mapping", e);
             return 1;
         } catch (Exception e) {
             log.error("Failed to sync group mappings", e);
@@ -110,6 +112,7 @@ public class GroupMappingCommand {
             return 0;
         } catch (MigrationException | IllegalArgumentException e) {
             outputLogger.info("Status failed: {}", e.getMessage());
+            log.warn("Status failed", e);
             return 1;
         } catch (Exception e) {
             log.error("Status failed", e);

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingService.java
@@ -319,12 +319,14 @@ public class GroupMappingService {
                 if (groupEntry.getValue().size() <= 1) {
                     continue;
                 }
+
+                var joinedFields = "\"" + String.join("\",\"", exportFields) + "\"";
                 // Clone the first child's data as the base data for the new work
                 String firstChild = groupEntry.getValue().get(0);
                 stmt.executeUpdate("insert into " + CdmIndexService.TB_NAME
-                        + " (" + String.join(",", exportFields) + ","
+                        + " (" + joinedFields + ","
                             + CdmFieldInfo.CDM_ID + "," + CdmIndexService.ENTRY_TYPE_FIELD + ")"
-                        + " select " + String.join(",", exportFields)
+                        + " select " + joinedFields
                             + ",'" + groupEntry.getKey() + "','" + CdmIndexService.ENTRY_TYPE_GROUPED_WORK + "'"
                         + " from " + CdmIndexService.TB_NAME
                         + " where " + CdmFieldInfo.CDM_ID + " = " + firstChild);


### PR DESCRIPTION
Bug fix to support https://jira.lib.unc.edu/browse/BXC-3288 but does not complete it