### PR TITLE
BXC-3679/3680 - Group mapping ids

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/GroupMappingInfo.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/GroupMappingInfo.java
@@ -28,10 +28,9 @@ import org.apache.commons.lang3.StringUtils;
 public class GroupMappingInfo {
     public static final String GROUPED_WORK_PREFIX = "grp:";
     public static final String GROUP_KEY = "group";
-    public static final String MATCHED_VALUE = "matched";
     public static final String ID_FIELD = "id";
     public static final String[] CSV_HEADERS = new String[] {
-            ID_FIELD, MATCHED_VALUE, GROUP_KEY };
+            ID_FIELD, GROUP_KEY };
 
     private Map<String, List<String>> groupedMappings = new HashMap<>();
     private List<GroupMapping> mappings = new ArrayList<>();
@@ -66,25 +65,8 @@ public class GroupMappingInfo {
         return mappings.stream().filter(m -> m.getCdmId().equals(cdmId)).findFirst().orElse(null);
     }
 
-    /**
-     * @param matchedValue
-     * @return Group key associated with the provided matchedValue, or null if no match
-     */
-    public String getGroupKeyByMatchedValue(String matchedValue) {
-        return mappings.stream().filter(m -> matchedValue.equals(m.getMatchedValue()))
-                .map(GroupMapping::getGroupKey)
-                .findFirst().orElse(null);
-    }
-
-    public String getMatchedValueByGroupKey(String groupKey) {
-        return mappings.stream().filter(m -> groupKey.equals(m.getGroupKey()))
-                .map(GroupMapping::getMatchedValue)
-                .findFirst().orElse(null);
-    }
-
     public static class GroupMapping {
         private String cdmId;
-        private String matchedValue;
         private String groupKey;
 
         public String getCdmId() {
@@ -104,18 +86,6 @@ public class GroupMappingInfo {
                 this.groupKey = null;
             } else {
                 this.groupKey = groupKey;
-            }
-        }
-
-        public String getMatchedValue() {
-            return matchedValue;
-        }
-
-        public void setMatchedValue(String matchedValue) {
-            if (StringUtils.isBlank(matchedValue)) {
-                this.matchedValue = null;
-            } else {
-                this.matchedValue = matchedValue;
             }
         }
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsService.java
@@ -239,7 +239,10 @@ public class DescriptionsService {
      * @return The path for the individual MODS file
      */
     public Path getExpandedDescriptionFilePath(String cdmId) {
+        // To avoid having individual directories with too many files, MODS files are written to
+        // EXPANDED_FILES_BUCKETS number of bucket directories based on the hash code of the id provided
         String subdir = Integer.toString(Math.abs(cdmId.hashCode()) % EXPANDED_FILES_BUCKETS);
+        // Replace reserved filepath characters with underscores, primarily for grouped work ids
         String filename = cdmId.replaceAll("[: /\\\\<>|&]", "_");
         return project.getExpandedDescriptionsPath().resolve(subdir).resolve(filename + ".xml");
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsService.java
@@ -68,7 +68,7 @@ import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
  */
 public class DescriptionsService {
     private static final Logger log = LoggerFactory.getLogger(DescriptionsService.class);
-    private static final int EXPANDED_FILES_PER_DIR = 1024;
+    private static final int EXPANDED_FILES_BUCKETS = 1024;
 
     private static final QName TYPE_NAME = new QName("type");
     private static final QName DISPLAY_LABEL_NAME = new QName("displayLabel");
@@ -239,9 +239,9 @@ public class DescriptionsService {
      * @return The path for the individual MODS file
      */
     public Path getExpandedDescriptionFilePath(String cdmId) {
-        int cdmIdNum = Integer.parseInt(cdmId);
-        String subdir = Integer.toString(cdmIdNum / EXPANDED_FILES_PER_DIR);
-        return project.getExpandedDescriptionsPath().resolve(subdir).resolve(cdmId + ".xml");
+        String subdir = Integer.toString(Math.abs(cdmId.hashCode()) % EXPANDED_FILES_BUCKETS);
+        String filename = cdmId.replaceAll("[: /\\\\<>|&]", "_");
+        return project.getExpandedDescriptionsPath().resolve(subdir).resolve(filename + ".xml");
     }
 
     /**

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingService.java
@@ -100,7 +100,7 @@ public class GroupMappingService {
             stmt.setFetchSize(FETCH_SIZE);
 
             // Return set of all group keys that have at least 2 records in them
-            var groupSet = new HashSet<String>();
+            var multiMemberGroupSet = new HashSet<String>();
             ResultSet groupRs = stmt.executeQuery("select " + options.getGroupField()
                     + " from " + CdmIndexService.TB_NAME
                     + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " is null"
@@ -111,7 +111,7 @@ public class GroupMappingService {
                 if (StringUtils.isBlank(groupValue)) {
                     continue;
                 }
-                groupSet.add(groupValue);
+                multiMemberGroupSet.add(groupValue);
             }
 
             ResultSet rs = stmt.executeQuery("select " + CdmFieldInfo.CDM_ID + ", " + options.getGroupField()
@@ -123,7 +123,7 @@ public class GroupMappingService {
                 String matchedValue = rs.getString(2);
 
                 // Add empty mapping for records either not in groups or in groups with fewer than 2 members
-                if (StringUtils.isBlank(matchedValue) || !groupSet.contains(matchedValue)) {
+                if (StringUtils.isBlank(matchedValue) || !multiMemberGroupSet.contains(matchedValue)) {
                     log.debug("No matching field for object {}", cdmId);
                     csvPrinter.printRecord(cdmId, null);
                     continue;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
@@ -346,7 +346,6 @@ public class SipService {
             fileObjResc.addLiteral(CdrDeposit.createTime, cdmCreated);
 
             workBag.add(fileObjResc);
-            workBag.addProperty(Cdr.primaryObject, fileObjResc);
 
             // Link source file
             Resource origResc = DepositModelHelpers.addDatastream(fileObjResc, ORIGINAL_FILE);

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/GroupMappingStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/GroupMappingStatusService.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -89,23 +88,14 @@ public class GroupMappingStatusService extends AbstractStatusService {
             Map<String, List<String>> mappings = groupInfo.getGroupedMappings();
             int totalGroups = 0;
             int childrenInGroups = 0;
-            List<String> groupList = new ArrayList<>();
             for (Entry<String, List<String>> entry : mappings.entrySet()) {
                 if (entry.getValue().size() > 1) {
                     totalGroups++;
                     childrenInGroups += entry.getValue().size();
-                    if (verbosity.isVerbose()) {
-                        String matched = groupInfo.getMatchedValueByGroupKey(entry.getKey());
-                        groupList.add(matched + " (with id " + entry.getKey() + "): " + entry.getValue().size());
-                    }
                 }
             }
             showField("Total Groups", totalGroups);
             showFieldWithPercent("Objects In Groups", childrenInGroups, totalObjects);
-            if (verbosity.isVerbose()) {
-                showField("Counts per group", "");
-                showFieldListValues(groupList);
-            }
         } catch (IOException e) {
             log.error("Failed to load mappings", e);
             outputLogger.info("Failed to load mappings: {}", e.getMessage());

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommandIT.java
@@ -184,8 +184,6 @@ public class GroupMappingCommandIT extends AbstractCommandIT {
 
         assertOutputMatches(".*Total Groups: +1.*");
         assertOutputMatches(".*Objects In Groups: +2.*");
-        assertOutputMatches(".*Counts per group:.*");
-        assertOutputMatches(".*groupa:group1 \\(with id .+\\): 2.*");
     }
 
     private void assertFilesGrouped(Connection conn, String... expectedFileCdmIds)

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
@@ -106,17 +106,16 @@ public class GroupMappingServiceTest {
 
         GroupMappingInfo info = service.loadMappings();
         String group1Key = info.getGroupKeyByMatchedValue("groupa:group1");
-        String group2Key = info.getGroupKeyByMatchedValue("groupa:group2");
         assertMappingPresent(info, "25", "groupa:group1", group1Key);
         assertMappingPresent(info, "26", "groupa:group1", group1Key);
-        assertMappingPresent(info, "27", "groupa:group2", group2Key);
+        // Single member group should not be mapped
+        assertMappingPresent(info, "27", null, null);
         assertMappingPresent(info, "28", null, null);
         assertMappingPresent(info, "29", null, null);
         assertEquals(5, info.getMappings().size());
 
         assertGroupingPresent(info, group1Key, "25", "26");
-        assertGroupingPresent(info, group2Key, "27");
-        assertEquals(2, info.getGroupedMappings().size());
+        assertEquals(1, info.getGroupedMappings().size());
 
         assertMappedDatePresent();
     }
@@ -156,10 +155,9 @@ public class GroupMappingServiceTest {
         // mapping state should be unchanged
         GroupMappingInfo info = service.loadMappings();
         String group1Key = info.getGroupKeyByMatchedValue("groupa:group1");
-        String group2Key = info.getGroupKeyByMatchedValue("groupa:group2");
         assertMappingPresent(info, "25", "groupa:group1", group1Key);
         assertMappingPresent(info, "26", "groupa:group1", group1Key);
-        assertMappingPresent(info, "27", "groupa:group2", group2Key);
+        assertMappingPresent(info, "27", null, null);
         assertMappingPresent(info, "28", null, null);
         assertMappingPresent(info, "29", null, null);
         assertEquals(5, info.getMappings().size());
@@ -179,10 +177,9 @@ public class GroupMappingServiceTest {
             // mapping state should be unchanged
             GroupMappingInfo info = service.loadMappings();
             String group1Key = info.getGroupKeyByMatchedValue("groupa:group1");
-            String group2Key = info.getGroupKeyByMatchedValue("groupa:group2");
             assertMappingPresent(info, "25", "groupa:group1", group1Key);
             assertMappingPresent(info, "26", "groupa:group1", group1Key);
-            assertMappingPresent(info, "27", "groupa:group2", group2Key);
+            assertMappingPresent(info, "27", null, null);
             assertMappingPresent(info, "28", null, null);
             assertMappingPresent(info, "29", null, null);
             assertEquals(5, info.getMappings().size());
@@ -198,10 +195,9 @@ public class GroupMappingServiceTest {
 
         GroupMappingInfo info = service.loadMappings();
         String group1Key = info.getGroupKeyByMatchedValue("groupa:group1");
-        String group2Key = info.getGroupKeyByMatchedValue("groupa:group2");
         assertMappingPresent(info, "25", "groupa:group1", group1Key);
         assertMappingPresent(info, "26", "groupa:group1", group1Key);
-        assertMappingPresent(info, "27", "groupa:group2", group2Key);
+        assertMappingPresent(info, "27", null, null);
         assertMappingPresent(info, "28", null, null);
         assertMappingPresent(info, "29", null, null);
         assertEquals(5, info.getMappings().size());
@@ -214,19 +210,15 @@ public class GroupMappingServiceTest {
         // Mapping state should have been overwritten
         GroupMappingInfo info2 = service.loadMappings();
         String group1Key2 = info2.getGroupKeyByMatchedValue("digitc:2005-11-10");
-        String group2Key2 = info2.getGroupKeyByMatchedValue("digitc:2005-11-09");
-        String group3Key2 = info2.getGroupKeyByMatchedValue("digitc:2005-11-11");
         assertMappingPresent(info2, "25", "digitc:2005-11-10", group1Key2);
-        assertMappingPresent(info2, "26", "digitc:2005-11-09", group2Key2);
-        assertMappingPresent(info2, "27", "digitc:2005-11-11", group3Key2);
+        assertMappingPresent(info2, "26", null, null);
+        assertMappingPresent(info2, "27", null, null);
         assertMappingPresent(info2, "28", "digitc:2005-11-10", group1Key2);
         assertMappingPresent(info2, "29", "digitc:2005-11-10", group1Key2);
         assertEquals(5, info2.getMappings().size());
 
         assertGroupingPresent(info2, group1Key2, "25", "28", "29");
-        assertGroupingPresent(info2, group2Key2, "26");
-        assertGroupingPresent(info2, group3Key2, "27");
-        assertEquals(3, info2.getGroupedMappings().size());
+        assertEquals(1, info2.getGroupedMappings().size());
 
         assertMappedDatePresent();
     }
@@ -248,11 +240,10 @@ public class GroupMappingServiceTest {
         // Mapping state should have been overwritten
         GroupMappingInfo info2 = service.loadMappings();
         String group1Key = info2.getGroupKeyByMatchedValue("groupa:group1");
-        String group2Key = info2.getGroupKeyByMatchedValue("groupa:group2");
         String group3Key = info2.getGroupKeyByMatchedValue("digitc:2005-11-10");
         assertMappingPresent(info2, "25", "groupa:group1", group1Key);
         assertMappingPresent(info2, "26", "groupa:group1", group1Key);
-        assertMappingPresent(info2, "27", "groupa:group2", group2Key);
+        assertMappingPresent(info2, "27", null, null);
         assertMappingPresent(info2, "28", "digitc:2005-11-10", group3Key);
         assertMappingPresent(info2, "29", "digitc:2005-11-10", group3Key);
         assertEquals(5, info2.getMappings().size());
@@ -269,11 +260,9 @@ public class GroupMappingServiceTest {
 
         GroupMappingInfo info = service.loadMappings();
         String group1Key = info.getGroupKeyByMatchedValue("digitc:2005-11-10");
-        String group2Key = info.getGroupKeyByMatchedValue("digitc:2005-11-09");
-        String group3Key = info.getGroupKeyByMatchedValue("digitc:2005-11-11");
         assertMappingPresent(info, "25", "digitc:2005-11-10", group1Key);
-        assertMappingPresent(info, "26", "digitc:2005-11-09", group2Key);
-        assertMappingPresent(info, "27", "digitc:2005-11-11", group3Key);
+        assertMappingPresent(info, "26", null, null);
+        assertMappingPresent(info, "27", null, null);
         assertMappingPresent(info, "28", "digitc:2005-11-10", group1Key);
         assertMappingPresent(info, "29", "digitc:2005-11-10", group1Key);
         assertEquals(5, info.getMappings().size());
@@ -285,11 +274,10 @@ public class GroupMappingServiceTest {
 
         GroupMappingInfo info2 = service.loadMappings();
         String group1Key2 = info2.getGroupKeyByMatchedValue("groupa:group1");
-        String group2Key2 = info2.getGroupKeyByMatchedValue("groupa:group2");
         String group3Key2 = info2.getGroupKeyByMatchedValue("digitc:2005-11-10");
         assertMappingPresent(info2, "25", "groupa:group1", group1Key2);
         assertMappingPresent(info2, "26", "groupa:group1", group1Key2);
-        assertMappingPresent(info2, "27", "groupa:group2", group2Key2);
+        assertMappingPresent(info2, "27", null, null);
         assertMappingPresent(info2, "28", "digitc:2005-11-10", group3Key2);
         assertMappingPresent(info2, "29", "digitc:2005-11-10", group3Key2);
         assertEquals(5, info2.getMappings().size());
@@ -378,7 +366,6 @@ public class GroupMappingServiceTest {
         try {
             GroupMappingInfo info = service.loadMappings();
             String group1Key = info.getGroupKeyByMatchedValue("groupa:group1");
-            String group2Key = info.getGroupKeyByMatchedValue("groupa:group2");
             conn = indexService.openDbConnection();
             assertWorkSynched(conn, group1Key, "Redoubt C", "2005-11-23");
             assertFilesGrouped(conn, group1Key, "25", "26");
@@ -387,8 +374,7 @@ public class GroupMappingServiceTest {
             assertParentIdsPresent(conn, group1Key, null);
 
             assertGroupingPresent(info, group1Key, "25", "26");
-            assertGroupingPresent(info, group2Key, "27");
-            assertEquals(2, info.getGroupedMappings().size());
+            assertEquals(1, info.getGroupedMappings().size());
 
             assertSynchedDatePresent();
         } finally {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
@@ -15,33 +15,6 @@
  */
 package edu.unc.lib.boxc.migration.cdm.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
-import java.nio.file.Paths;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.Statement;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
-import edu.unc.lib.boxc.migration.cdm.test.OutputHelper;
-import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
 import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.exceptions.StateAlreadyExistsException;
 import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
@@ -50,7 +23,30 @@ import edu.unc.lib.boxc.migration.cdm.model.GroupMappingInfo.GroupMapping;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
 import edu.unc.lib.boxc.migration.cdm.options.GroupMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.test.OutputHelper;
+import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author bbpennel
@@ -105,16 +101,15 @@ public class GroupMappingServiceTest {
         service.generateMapping(options);
 
         GroupMappingInfo info = service.loadMappings();
-        String group1Key = info.getGroupKeyByMatchedValue("groupa:group1");
-        assertMappingPresent(info, "25", "groupa:group1", group1Key);
-        assertMappingPresent(info, "26", "groupa:group1", group1Key);
+        assertMappingPresent(info, "25", "groupa:group1");
+        assertMappingPresent(info, "26", "groupa:group1");
         // Single member group should not be mapped
-        assertMappingPresent(info, "27", null, null);
-        assertMappingPresent(info, "28", null, null);
-        assertMappingPresent(info, "29", null, null);
+        assertMappingPresent(info, "27", null);
+        assertMappingPresent(info, "28", null);
+        assertMappingPresent(info, "29", null);
         assertEquals(5, info.getMappings().size());
 
-        assertGroupingPresent(info, group1Key, "25", "26");
+        assertGroupingPresent(info, "groupa:group1", "25", "26");
         assertEquals(1, info.getGroupedMappings().size());
 
         assertMappedDatePresent();
@@ -154,12 +149,11 @@ public class GroupMappingServiceTest {
 
         // mapping state should be unchanged
         GroupMappingInfo info = service.loadMappings();
-        String group1Key = info.getGroupKeyByMatchedValue("groupa:group1");
-        assertMappingPresent(info, "25", "groupa:group1", group1Key);
-        assertMappingPresent(info, "26", "groupa:group1", group1Key);
-        assertMappingPresent(info, "27", null, null);
-        assertMappingPresent(info, "28", null, null);
-        assertMappingPresent(info, "29", null, null);
+        assertMappingPresent(info, "25", "groupa:group1");
+        assertMappingPresent(info, "26", "groupa:group1");
+        assertMappingPresent(info, "27", null);
+        assertMappingPresent(info, "28", null);
+        assertMappingPresent(info, "29", null);
         assertEquals(5, info.getMappings().size());
 
         assertMappedDatePresent();
@@ -176,12 +170,11 @@ public class GroupMappingServiceTest {
             service.generateMapping(options);
             // mapping state should be unchanged
             GroupMappingInfo info = service.loadMappings();
-            String group1Key = info.getGroupKeyByMatchedValue("groupa:group1");
-            assertMappingPresent(info, "25", "groupa:group1", group1Key);
-            assertMappingPresent(info, "26", "groupa:group1", group1Key);
-            assertMappingPresent(info, "27", null, null);
-            assertMappingPresent(info, "28", null, null);
-            assertMappingPresent(info, "29", null, null);
+            assertMappingPresent(info, "25", "groupa:group1");
+            assertMappingPresent(info, "26", "groupa:group1");
+            assertMappingPresent(info, "27", null);
+            assertMappingPresent(info, "28", null);
+            assertMappingPresent(info, "29", null);
             assertEquals(5, info.getMappings().size());
             assertMappedDatePresent();
         });
@@ -194,12 +187,11 @@ public class GroupMappingServiceTest {
         service.generateMapping(options);
 
         GroupMappingInfo info = service.loadMappings();
-        String group1Key = info.getGroupKeyByMatchedValue("groupa:group1");
-        assertMappingPresent(info, "25", "groupa:group1", group1Key);
-        assertMappingPresent(info, "26", "groupa:group1", group1Key);
-        assertMappingPresent(info, "27", null, null);
-        assertMappingPresent(info, "28", null, null);
-        assertMappingPresent(info, "29", null, null);
+        assertMappingPresent(info, "25", "groupa:group1");
+        assertMappingPresent(info, "26", "groupa:group1");
+        assertMappingPresent(info, "27", null);
+        assertMappingPresent(info, "28", null);
+        assertMappingPresent(info, "29", null);
         assertEquals(5, info.getMappings().size());
 
         options.setForce(true);
@@ -209,15 +201,14 @@ public class GroupMappingServiceTest {
 
         // Mapping state should have been overwritten
         GroupMappingInfo info2 = service.loadMappings();
-        String group1Key2 = info2.getGroupKeyByMatchedValue("digitc:2005-11-10");
-        assertMappingPresent(info2, "25", "digitc:2005-11-10", group1Key2);
-        assertMappingPresent(info2, "26", null, null);
-        assertMappingPresent(info2, "27", null, null);
-        assertMappingPresent(info2, "28", "digitc:2005-11-10", group1Key2);
-        assertMappingPresent(info2, "29", "digitc:2005-11-10", group1Key2);
+        assertMappingPresent(info2, "25", "digitc:2005-11-10");
+        assertMappingPresent(info2, "26", null);
+        assertMappingPresent(info2, "27", null);
+        assertMappingPresent(info2, "28", "digitc:2005-11-10");
+        assertMappingPresent(info2, "29", "digitc:2005-11-10");
         assertEquals(5, info2.getMappings().size());
 
-        assertGroupingPresent(info2, group1Key2, "25", "28", "29");
+        assertGroupingPresent(info2, "digitc:2005-11-10", "25", "28", "29");
         assertEquals(1, info2.getGroupedMappings().size());
 
         assertMappedDatePresent();
@@ -239,13 +230,11 @@ public class GroupMappingServiceTest {
 
         // Mapping state should have been overwritten
         GroupMappingInfo info2 = service.loadMappings();
-        String group1Key = info2.getGroupKeyByMatchedValue("groupa:group1");
-        String group3Key = info2.getGroupKeyByMatchedValue("digitc:2005-11-10");
-        assertMappingPresent(info2, "25", "groupa:group1", group1Key);
-        assertMappingPresent(info2, "26", "groupa:group1", group1Key);
-        assertMappingPresent(info2, "27", null, null);
-        assertMappingPresent(info2, "28", "digitc:2005-11-10", group3Key);
-        assertMappingPresent(info2, "29", "digitc:2005-11-10", group3Key);
+        assertMappingPresent(info2, "25", "groupa:group1");
+        assertMappingPresent(info2, "26", "groupa:group1");
+        assertMappingPresent(info2, "27", null);
+        assertMappingPresent(info2, "28", "digitc:2005-11-10");
+        assertMappingPresent(info2, "29", "digitc:2005-11-10");
         assertEquals(5, info2.getMappings().size());
 
         assertMappedDatePresent();
@@ -259,12 +248,11 @@ public class GroupMappingServiceTest {
         service.generateMapping(options);
 
         GroupMappingInfo info = service.loadMappings();
-        String group1Key = info.getGroupKeyByMatchedValue("digitc:2005-11-10");
-        assertMappingPresent(info, "25", "digitc:2005-11-10", group1Key);
-        assertMappingPresent(info, "26", null, null);
-        assertMappingPresent(info, "27", null, null);
-        assertMappingPresent(info, "28", "digitc:2005-11-10", group1Key);
-        assertMappingPresent(info, "29", "digitc:2005-11-10", group1Key);
+        assertMappingPresent(info, "25", "digitc:2005-11-10");
+        assertMappingPresent(info, "26", null);
+        assertMappingPresent(info, "27", null);
+        assertMappingPresent(info, "28", "digitc:2005-11-10");
+        assertMappingPresent(info, "29", "digitc:2005-11-10");
         assertEquals(5, info.getMappings().size());
 
         options.setUpdate(true);
@@ -273,13 +261,11 @@ public class GroupMappingServiceTest {
         service.generateMapping(options);
 
         GroupMappingInfo info2 = service.loadMappings();
-        String group1Key2 = info2.getGroupKeyByMatchedValue("groupa:group1");
-        String group3Key2 = info2.getGroupKeyByMatchedValue("digitc:2005-11-10");
-        assertMappingPresent(info2, "25", "groupa:group1", group1Key2);
-        assertMappingPresent(info2, "26", "groupa:group1", group1Key2);
-        assertMappingPresent(info2, "27", null, null);
-        assertMappingPresent(info2, "28", "digitc:2005-11-10", group3Key2);
-        assertMappingPresent(info2, "29", "digitc:2005-11-10", group3Key2);
+        assertMappingPresent(info2, "25", "groupa:group1");
+        assertMappingPresent(info2, "26", "groupa:group1");
+        assertMappingPresent(info2, "27", null);
+        assertMappingPresent(info2, "28", "digitc:2005-11-10");
+        assertMappingPresent(info2, "29", "digitc:2005-11-10");
         assertEquals(5, info2.getMappings().size());
 
         assertMappedDatePresent();
@@ -321,13 +307,12 @@ public class GroupMappingServiceTest {
         Connection conn = null;
         try {
             GroupMappingInfo info = service.loadMappings();
-            String group1Key = info.getGroupKeyByMatchedValue("groupa:group1");
             conn = indexService.openDbConnection();
-            assertWorkSynched(conn, group1Key, "Redoubt C", "2005-11-23");
-            assertFilesGrouped(conn, group1Key, "25", "26");
+            assertWorkSynched(conn, "groupa:group1", "Redoubt C", "2005-11-23");
+            assertFilesGrouped(conn, "groupa:group1", "25", "26");
             // Group key with a single child should not be grouped
             assertNumberOfGroups(conn, 1);
-            assertParentIdsPresent(conn, group1Key, null);
+            assertParentIdsPresent(conn, "groupa:group1", null);
             assertSynchedDatePresent();
         } finally {
             CdmIndexService.closeDbConnection(conn);
@@ -346,12 +331,11 @@ public class GroupMappingServiceTest {
         Connection conn = null;
         try {
             GroupMappingInfo info = service.loadMappings();
-            String group1Key = info.getGroupKeyByMatchedValue("digitc:2005-11-10");
             conn = indexService.openDbConnection();
-            assertWorkSynched(conn, group1Key, "Redoubt C", "2005-11-23");
-            assertFilesGrouped(conn, group1Key, "25", "28", "29");
+            assertWorkSynched(conn, "digitc:2005-11-10", "Redoubt C", "2005-11-23");
+            assertFilesGrouped(conn, "digitc:2005-11-10", "25", "28", "29");
             assertNumberOfGroups(conn, 1);
-            assertParentIdsPresent(conn, group1Key, null);
+            assertParentIdsPresent(conn, "digitc:2005-11-10", null);
             assertSynchedDatePresent();
         } finally {
             CdmIndexService.closeDbConnection(conn);
@@ -365,15 +349,14 @@ public class GroupMappingServiceTest {
 
         try {
             GroupMappingInfo info = service.loadMappings();
-            String group1Key = info.getGroupKeyByMatchedValue("groupa:group1");
             conn = indexService.openDbConnection();
-            assertWorkSynched(conn, group1Key, "Redoubt C", "2005-11-23");
-            assertFilesGrouped(conn, group1Key, "25", "26");
+            assertWorkSynched(conn, "groupa:group1", "Redoubt C", "2005-11-23");
+            assertFilesGrouped(conn, "groupa:group1", "25", "26");
             // Group key with a single child should not be grouped
             assertNumberOfGroups(conn, 1);
-            assertParentIdsPresent(conn, group1Key, null);
+            assertParentIdsPresent(conn, "groupa:group1", null);
 
-            assertGroupingPresent(info, group1Key, "25", "26");
+            assertGroupingPresent(info, "groupa:group1", "25", "26");
             assertEquals(1, info.getGroupedMappings().size());
 
             assertSynchedDatePresent();
@@ -384,9 +367,10 @@ public class GroupMappingServiceTest {
 
     private void assertWorkSynched(Connection conn, String workId, String expectedTitle, String expectedCreated)
             throws Exception {
+        String groupKey = asGroupKey(workId);
         Statement stmt = conn.createStatement();
         ResultSet rs = stmt.executeQuery("select * from " + CdmIndexService.TB_NAME
-                + " where " + CdmFieldInfo.CDM_ID + " = '" + workId + "'");
+                + " where " + CdmFieldInfo.CDM_ID + " = '" + groupKey + "'");
         while (rs.next()) {
             String cdmTitle = rs.getString("title");
             String cdmCreated = rs.getString(CdmFieldInfo.CDM_CREATED);
@@ -399,10 +383,11 @@ public class GroupMappingServiceTest {
 
     private void assertFilesGrouped(Connection conn, String workId, String... expectedFileCdmIds)
             throws Exception {
+        String groupKey = asGroupKey(workId);
         Statement stmt = conn.createStatement();
         ResultSet rs = stmt.executeQuery("select " + CdmFieldInfo.CDM_ID
                 + " from " + CdmIndexService.TB_NAME
-                + " where " + CdmIndexService.PARENT_ID_FIELD + " = '" + workId + "'");
+                + " where " + CdmIndexService.PARENT_ID_FIELD + " = '" + groupKey + "'");
         List<String> childIds = new ArrayList<>();
         while (rs.next()) {
             childIds.add(rs.getString(1));
@@ -432,9 +417,17 @@ public class GroupMappingServiceTest {
         while (rs.next()) {
             parentIds.add(rs.getString(1));
         }
-        List<String> expected = Arrays.asList(expectedParents);
+        var expected = Arrays.stream(expectedParents).map(this::asGroupKey).collect(Collectors.toList());
         assertTrue("Expected parent ids " + expected + " but found " + parentIds, parentIds.containsAll(expected));
         assertEquals("Expected parent ids " + expected + " but found " + parentIds, expected.size(), parentIds.size());
+    }
+
+    private String asGroupKey(String matchValue) {
+        if (matchValue == null) {
+            return null;
+        } else {
+            return GroupMappingInfo.GROUPED_WORK_PREFIX + matchValue;
+        }
     }
 
     private GroupMappingOptions makeDefaultOptions() {
@@ -448,18 +441,16 @@ public class GroupMappingServiceTest {
                 e.getMessage().contains(expected));
     }
 
-    private void assertMappingPresent(GroupMappingInfo info, String id, String expectedMatchedVal,
-            String expectedGroupKey) throws Exception {
+    private void assertMappingPresent(GroupMappingInfo info, String id, String expectedMatchedVal) {
         GroupMapping mapping = info.getMappingByCdmId(id);
         assertNotNull(mapping);
         assertEquals(id, mapping.getCdmId());
-        assertEquals(expectedMatchedVal, mapping.getMatchedValue());
-        assertEquals(expectedGroupKey, mapping.getGroupKey());
+        assertEquals(asGroupKey(expectedMatchedVal), mapping.getGroupKey());
     }
 
     private void assertGroupingPresent(GroupMappingInfo groupedInfo, String groupKey, String... cdmIds) {
         Map<String, List<String>> groupedMappings = groupedInfo.getGroupedMappings();
-        List<String> objIds = groupedMappings.get(groupKey);
+        List<String> objIds = groupedMappings.get(asGroupKey(groupKey));
         List<String> expectedIds = Arrays.asList(cdmIds);
         assertTrue("Expected group " + groupKey + " to contain " + expectedIds + " but contained " + objIds,
                 objIds.containsAll(expectedIds));

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
@@ -101,17 +101,7 @@ public class GroupMappingServiceTest {
         service.generateMapping(options);
 
         GroupMappingInfo info = service.loadMappings();
-        assertMappingPresent(info, "25", "groupa:group1");
-        assertMappingPresent(info, "26", "groupa:group1");
-        // Single member group should not be mapped
-        assertMappingPresent(info, "27", null);
-        assertMappingPresent(info, "28", null);
-        assertMappingPresent(info, "29", null);
-        assertEquals(5, info.getMappings().size());
-
-        assertGroupingPresent(info, "groupa:group1", "25", "26");
-        assertEquals(1, info.getGroupedMappings().size());
-
+        assertGroupAMappingsPresent(info);
         assertMappedDatePresent();
     }
 
@@ -149,12 +139,7 @@ public class GroupMappingServiceTest {
 
         // mapping state should be unchanged
         GroupMappingInfo info = service.loadMappings();
-        assertMappingPresent(info, "25", "groupa:group1");
-        assertMappingPresent(info, "26", "groupa:group1");
-        assertMappingPresent(info, "27", null);
-        assertMappingPresent(info, "28", null);
-        assertMappingPresent(info, "29", null);
-        assertEquals(5, info.getMappings().size());
+        assertGroupAMappingsPresent(info);
 
         assertMappedDatePresent();
     }
@@ -170,12 +155,7 @@ public class GroupMappingServiceTest {
             service.generateMapping(options);
             // mapping state should be unchanged
             GroupMappingInfo info = service.loadMappings();
-            assertMappingPresent(info, "25", "groupa:group1");
-            assertMappingPresent(info, "26", "groupa:group1");
-            assertMappingPresent(info, "27", null);
-            assertMappingPresent(info, "28", null);
-            assertMappingPresent(info, "29", null);
-            assertEquals(5, info.getMappings().size());
+            assertGroupAMappingsPresent(info);
             assertMappedDatePresent();
         });
     }
@@ -187,12 +167,7 @@ public class GroupMappingServiceTest {
         service.generateMapping(options);
 
         GroupMappingInfo info = service.loadMappings();
-        assertMappingPresent(info, "25", "groupa:group1");
-        assertMappingPresent(info, "26", "groupa:group1");
-        assertMappingPresent(info, "27", null);
-        assertMappingPresent(info, "28", null);
-        assertMappingPresent(info, "29", null);
-        assertEquals(5, info.getMappings().size());
+        assertGroupAMappingsPresent(info);
 
         options.setForce(true);
         options.setGroupField("digitc");
@@ -422,6 +397,11 @@ public class GroupMappingServiceTest {
         assertEquals("Expected parent ids " + expected + " but found " + parentIds, expected.size(), parentIds.size());
     }
 
+    /**
+     * @param matchValue
+     * @return the provided match value (fieldname+value) with the group prefix added, which is the expected
+     *   format for group keys, or null if the value is null
+     */
     private String asGroupKey(String matchValue) {
         if (matchValue == null) {
             return null;
@@ -476,6 +456,19 @@ public class GroupMappingServiceTest {
     private void assertSynchedDateNotPresent() throws Exception {
         MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
         assertNull(props.getGroupMappingsSynchedDate());
+    }
+
+    private void assertGroupAMappingsPresent(GroupMappingInfo info) {
+        assertMappingPresent(info, "25", "groupa:group1");
+        assertMappingPresent(info, "26", "groupa:group1");
+        // Single member group should not be mapped
+        assertMappingPresent(info, "27", null);
+        assertMappingPresent(info, "28", null);
+        assertMappingPresent(info, "29", null);
+        assertEquals(5, info.getMappings().size());
+
+        assertGroupingPresent(info, "groupa:group1", "25", "26");
+        assertEquals(1, info.getGroupedMappings().size());
     }
 
     private void indexExportSamples() throws Exception {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -450,7 +450,7 @@ public class SipServiceTest {
     public void generateSipsWithGroupedWork() throws Exception {
         testHelper.indexExportData("mini_gilmer");
         testHelper.generateDefaultDestinationsMapping(DEST_UUID, null);
-        testHelper.populateDescriptions("gilmer_mods1.xml");
+        testHelper.populateDescriptions("grouped_mods.xml");
         List<Path> stagingLocs = testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
 
         GroupMappingOptions groupOptions = new GroupMappingOptions();
@@ -477,7 +477,7 @@ public class SipServiceTest {
         assertEquals(2, depBagChildren.size());
 
         Resource workResc1 = testHelper.getResourceByCreateTime(depBagChildren, "2005-11-23");
-        testHelper.assertGroupedWorkPopulatedInSip(workResc1, dirManager, model, "25", false,
+        testHelper.assertGroupedWorkPopulatedInSip(workResc1, dirManager, model, "grp:groupa:group1", false,
                 stagingLocs.get(0), stagingLocs.get(1));
         Resource workResc3 = testHelper.getResourceByCreateTime(depBagChildren, "2005-12-08");
         testHelper.assertObjectPopulatedInSip(workResc3, dirManager, model, stagingLocs.get(2), null, "27");
@@ -489,7 +489,7 @@ public class SipServiceTest {
     public void generateSipsWithGroupedWorkWithAccessCopies() throws Exception {
         testHelper.indexExportData("mini_gilmer");
         testHelper.generateDefaultDestinationsMapping(DEST_UUID, null);
-        testHelper.populateDescriptions("gilmer_mods1.xml");
+        testHelper.populateDescriptions("grouped_mods.xml");
         List<Path> stagingLocs = testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
         List<Path> accessLocs = testHelper.populateAccessFiles("276_182_E.tif", "276_203_E.tif");
 
@@ -517,7 +517,7 @@ public class SipServiceTest {
         assertEquals(2, depBagChildren.size());
 
         Resource workResc1 = testHelper.getResourceByCreateTime(depBagChildren, "2005-11-23");
-        testHelper.assertGroupedWorkPopulatedInSip(workResc1, dirManager, model, "25", true,
+        testHelper.assertGroupedWorkPopulatedInSip(workResc1, dirManager, model, "grp:groupa:group1", true,
                 stagingLocs.get(0), accessLocs.get(0), stagingLocs.get(1), null);
         Resource workResc3 = testHelper.getResourceByCreateTime(depBagChildren, "2005-12-08");
         testHelper.assertObjectPopulatedInSip(workResc3, dirManager, model,
@@ -625,7 +625,7 @@ public class SipServiceTest {
     public void generateSipsWithGroupedWorkAndRedirectMapping() throws Exception {
         testHelper.indexExportData("mini_gilmer");
         testHelper.generateDefaultDestinationsMapping(DEST_UUID, null);
-        testHelper.populateDescriptions("gilmer_mods1.xml");
+        testHelper.populateDescriptions("grouped_mods.xml");
         testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
 
         GroupMappingOptions groupOptions = new GroupMappingOptions();
@@ -650,6 +650,7 @@ public class SipServiceTest {
             assertRedirectMappingRowContentIsCorrect(rows.get(0), project, "27"); // ungrouped items first
             assertRedirectMappingRowContentIsCorrect(rows.get(1), project, "25");
             assertRedirectMappingRowContentIsCorrect(rows.get(2), project, "26");
+            // Work generated for group should not have a redirect mapping
             assertRedirectMappingCollectionRowContentIsCorrect(rows.get(3), project, DEST_UUID);
             // grouped files should have the same boxc object ID
             assertEquals(rows.get(1).get("boxc_object_id"), rows.get(2).get("boxc_object_id"));

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
@@ -148,7 +148,6 @@ public class SipServiceHelper {
         assertEquals(1, workChildren.size());
         Resource fileObjResc = workChildren.get(0).asResource();
         assertTrue(fileObjResc.hasProperty(RDF.type, Cdr.FileObject));
-        assertTrue(workBag.hasProperty(Cdr.primaryObject, fileObjResc));
 
         // Check for source file
         Resource origResc = fileObjResc.getProperty(CdrDeposit.hasDatastreamOriginal).getResource();

--- a/src/test/resources/mods_collections/grouped_mods.xml
+++ b/src/test/resources/mods_collections/grouped_mods.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods:modsCollection xmlns:mods="http://www.loc.gov/mods/v3">
+    <mods:mods>
+        <mods:titleInfo><mods:title>Folder Group 1</mods:title></mods:titleInfo>
+        <mods:identifier type="local" displayLabel="CONTENTdm number">grp:groupa:group1</mods:identifier>
+    </mods:mods>
+    <mods:mods>
+        <mods:titleInfo><mods:title>Redoubt C</mods:title></mods:titleInfo>
+        <mods:identifier type="local" displayLabel="CONTENTdm number">25</mods:identifier>
+    </mods:mods>
+    <mods:mods>
+        <mods:titleInfo><mods:title>Plan of Battery McIntosh</mods:title></mods:titleInfo>
+        <mods:identifier>276/183</mods:identifier>
+        <mods:identifier type="local" displayLabel="CONTENTdm number">26</mods:identifier>
+    </mods:mods>
+    <mods:mods>
+        <mods:titleInfo><mods:title>Fort DeRussy on Red River, Louisiana</mods:title></mods:titleInfo>
+        <mods:identifier type="local">276/203</mods:identifier>
+        <mods:identifier type="local" displayLabel="CONTENTdm number">27</mods:identifier>
+    </mods:mods>
+</mods:modsCollection>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3679
https://jira.lib.unc.edu/browse/BXC-3680

* Single member groups will not be added to the group mapping file (they were already being excluded when syncing mappings back to the database)
* Group key is now the matched value with a prefix, and the matched value field has been removed from the CSV
* Matching between MODS files and group generated works is now based on the group key
* Removed assignment of primary objects from works (for multifile works, such as groups, it was assigning every file as a primary object, and we don't need primary objects in the migration)