### PR TITLE
BXC-3665 - Set CDM Env during Init

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
@@ -15,17 +15,19 @@
  */
 package edu.unc.lib.boxc.migration.cdm;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.concurrent.Callable;
-
 import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
+import edu.unc.lib.boxc.migration.cdm.services.ChompbConfigService;
 import edu.unc.lib.boxc.migration.cdm.util.BannerUtility;
 import edu.unc.lib.boxc.migration.cdm.util.CLIConstants;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ScopeType;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.Callable;
 
 /**
  * Main class for the CLI utils
@@ -65,6 +67,13 @@ public class CLIMain implements Callable<Integer> {
             description = "Set output to quiet level of verbosity")
     private boolean quiet;
 
+    @Option(names = { "--env-config" },
+            description = "Path to the chompb environment configuration file. Default: ${DEFAULT-VALUE}",
+            defaultValue = "${env:ENV_CONFIG}")
+    private Path envConfigPath;
+
+    private ChompbConfigService.ChompbConfig chompbConfig;
+
     /**
      * @return Get the effective working directory
      */
@@ -84,6 +93,21 @@ public class CLIMain implements Callable<Integer> {
             return Verbosity.QUIET;
         }
         return Verbosity.NORMAL;
+    }
+
+    /**
+     * @return Application configuration
+     */
+    public ChompbConfigService.ChompbConfig getChompbConfig() throws IOException {
+        if (chompbConfig == null) {
+            if (envConfigPath == null) {
+                throw new IllegalArgumentException("Must provide an env-config option");
+            }
+            var configService = new ChompbConfigService();
+            configService.setEnvConfigPath(envConfigPath);
+            chompbConfig = configService.getConfig();
+        }
+        return chompbConfig;
     }
 
     protected CLIMain() {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommand.java
@@ -78,14 +78,14 @@ public class CdmExportCommand implements Callable<Integer> {
             outputLogger.info("Exported project {} in {}s", project.getProjectName(),
                     (System.nanoTime() - start) / 1e9);
             return 0;
-        } catch (MigrationException e) {
+        } catch (MigrationException | IOException e) {
             log.error("Failed to export project", e);
             outputLogger.info("Failed to export project: {}", e.getMessage());
             return 1;
         }
     }
 
-    public void initializeServices() {
+    public void initializeServices() throws IOException {
         fieldService = new CdmFieldService();
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);
@@ -93,6 +93,7 @@ public class CdmExportCommand implements Callable<Integer> {
         exportService.setProject(project);
         exportService.setCdmFieldService(fieldService);
         exportService.setExportStateService(exportStateService);
+        exportService.setChompbConfig(parentCommand.getChompbConfig());
         exportProgressService = new ExportProgressService();
         exportProgressService.setExportStateService(exportStateService);
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommand.java
@@ -19,9 +19,15 @@ import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.unc.lib.boxc.migration.cdm.model.CdmEnvironment;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 
@@ -48,11 +54,15 @@ public class InitializeProjectCommand implements Callable<Integer> {
     @ParentCommand
     private CLIMain parentCommand;
 
-    @Option(names = { "--cdm-url" },
-            description = "Base URL to the CDM web service API. Falls back to CDM_BASE_URL env variable. "
+    @Option(names = { "-e", "--cdm-env" },
+            description = "CDM environment used for retrieving data. Env-config must be set. Values: test, qa, prod. "
                     + "Default: ${DEFAULT-VALUE}",
-            defaultValue = "${env:CDM_BASE_URL:-http://localhost:82/}")
-    private String cdmBaseUri;
+            defaultValue = "${env:CDM_ENV:-test}")
+    private String cdmEnv;
+    @Option(names = { "--env-config" },
+            description = "Path to the chompb environment configuration file. Default: ${DEFAULT-VALUE}",
+            defaultValue = "${env:ENV_CONFIG}")
+    private Path envConfigPath;
     @Option(names = { "-c", "--cdm-coll-id" },
             description = "Identifier of the CDM collection to migrate. Use if the name of the project directory"
                     + " does not match the CDM Collection ID.")
@@ -79,6 +89,25 @@ public class InitializeProjectCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         long start = System.nanoTime();
 
+        if (envConfigPath == null) {
+            outputLogger.info("Must provide and env-config option");
+            return 1;
+        }
+
+        Map<String, CdmEnvironment> cdmEnvMapping;
+        try {
+            cdmEnvMapping = loadCdmEnvironmentMapping();
+            if (!cdmEnvMapping.containsKey(cdmEnv)) {
+                outputLogger.info("Unknown cdm-env value {}, configured values are: {}",
+                        cdmEnv, String.join(", ", cdmEnvMapping.keySet()));
+                return 1;
+            }
+        } catch (IOException e) {
+            outputLogger.info("Unable to read cdm environment", e);
+            return 1;
+        }
+        var cdmEnvConfig = cdmEnvMapping.get(cdmEnv);
+
         Path currentPath = parentCommand.getWorkingDirectory();
         String projDisplayName = projectName == null ? currentPath.getFileName().toString() : projectName;
         String collId = cdmCollectionId == null ? projDisplayName : cdmCollectionId;
@@ -86,7 +115,7 @@ public class InitializeProjectCommand implements Callable<Integer> {
         // Retrieve field information from CDM
         CdmFieldInfo fieldInfo;
         try {
-            fieldService.setCdmBaseUri(cdmBaseUri);
+            fieldService.setCdmBaseUri(cdmEnvConfig.getHttpBaseUrl());
             fieldInfo = fieldService.retrieveFieldsForCollection(collId);
         } catch (IOException | MigrationException e) {
             log.error("Failed to retrieve field information for collection in project", e);
@@ -101,7 +130,7 @@ public class InitializeProjectCommand implements Callable<Integer> {
         MigrationProject project = null;
         try {
             project = MigrationProjectFactory.createMigrationProject(
-                    currentPath, projectName, cdmCollectionId, username);
+                    currentPath, projectName, cdmCollectionId, username, cdmEnvConfig);
 
             // Persist field info to the project
             fieldService.persistFieldsToProject(project, fieldInfo);
@@ -123,5 +152,11 @@ public class InitializeProjectCommand implements Callable<Integer> {
 
         outputLogger.info("Initialized project {} in {}s", projDisplayName, (System.nanoTime() - start) / 1e9);
         return 0;
+    }
+
+    private Map<String, CdmEnvironment> loadCdmEnvironmentMapping() throws IOException {
+        var typeRef = new TypeReference<HashMap<String, CdmEnvironment>>() {};
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(Files.newInputStream(envConfigPath), typeRef);
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommand.java
@@ -52,7 +52,7 @@ public class InitializeProjectCommand implements Callable<Integer> {
             description = "CDM environment used for retrieving data. Env-config must be set. "
                     + "Default: ${DEFAULT-VALUE}",
             defaultValue = "${env:CDM_ENV}")
-    private String cdmEnv;
+    private String cdmEnvId;
     @Option(names = { "-c", "--cdm-coll-id" },
             description = "Identifier of the CDM collection to migrate. Use if the name of the project directory"
                     + " does not match the CDM Collection ID.")
@@ -82,9 +82,9 @@ public class InitializeProjectCommand implements Callable<Integer> {
         ChompbConfig config;
         try {
             config = parentCommand.getChompbConfig();
-            if (!config.getCdmEnvironments().containsKey(cdmEnv)) {
+            if (!config.getCdmEnvironments().containsKey(cdmEnvId)) {
                 outputLogger.info("Unknown cdm-env value {}, configured values are: {}",
-                        cdmEnv, String.join(", ", config.getCdmEnvironments().keySet()));
+                        cdmEnvId, String.join(", ", config.getCdmEnvironments().keySet()));
                 return 1;
             }
         } catch (IllegalArgumentException | IOException e) {
@@ -92,7 +92,7 @@ public class InitializeProjectCommand implements Callable<Integer> {
             log.error("Unable to read application configuration", e);
             return 1;
         }
-        var cdmEnvConfig = config.getCdmEnvironments().get(cdmEnv);
+        var cdmEnvConfig = config.getCdmEnvironments().get(cdmEnvId);
 
         Path currentPath = parentCommand.getWorkingDirectory();
         String projDisplayName = projectName == null ? currentPath.getFileName().toString() : projectName;
@@ -116,7 +116,7 @@ public class InitializeProjectCommand implements Callable<Integer> {
         MigrationProject project = null;
         try {
             project = MigrationProjectFactory.createMigrationProject(
-                    currentPath, projectName, cdmCollectionId, username, cdmEnv);
+                    currentPath, projectName, cdmCollectionId, username, cdmEnvId);
 
             // Persist field info to the project
             fieldService.persistFieldsToProject(project, fieldInfo);

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/CdmEnvironment.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/CdmEnvironment.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.model;
+
+/**
+ * Configuration information for a cdm environment
+ *
+ * @author bbpennel
+ */
+public class CdmEnvironment {
+    private String sshHost;
+    private int sshPort;
+    private String httpBaseUrl;
+    private String sshDownloadBasePath;
+
+    public String getSshHost() {
+        return sshHost;
+    }
+
+    public void setSshHost(String sshHost) {
+        this.sshHost = sshHost;
+    }
+
+    public int getSshPort() {
+        return sshPort;
+    }
+
+    public void setSshPort(int sshPort) {
+        this.sshPort = sshPort;
+    }
+
+    public String getSshDownloadBasePath() {
+        return sshDownloadBasePath;
+    }
+
+    public void setSshDownloadBasePath(String sshDownloadBasePath) {
+        this.sshDownloadBasePath = sshDownloadBasePath;
+    }
+
+    public String getHttpBaseUrl() {
+        return httpBaseUrl;
+    }
+
+    public void setHttpBaseUrl(String httpBaseUrl) {
+        this.httpBaseUrl = httpBaseUrl;
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
@@ -41,6 +41,7 @@ public class MigrationProjectProperties {
     private Set<String> sipsSubmitted;
     private String hookId;
     private String collectionNumber;
+    private CdmEnvironment cdmEnvironment;
 
     public MigrationProjectProperties() {
         sipsSubmitted = new HashSet<>();
@@ -220,5 +221,16 @@ public class MigrationProjectProperties {
 
     public void setCollectionNumber(String collectionNumber) {
         this.collectionNumber = collectionNumber;
+    }
+
+    /**
+     * @return configuration information related to the CDM environment being used for this migration
+     */
+    public CdmEnvironment getCdmEnvironment() {
+        return cdmEnvironment;
+    }
+
+    public void setCdmEnvironment(CdmEnvironment cdmEnvironment) {
+        this.cdmEnvironment = cdmEnvironment;
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
@@ -41,7 +41,7 @@ public class MigrationProjectProperties {
     private Set<String> sipsSubmitted;
     private String hookId;
     private String collectionNumber;
-    private CdmEnvironment cdmEnvironment;
+    private String cdmEnvironment;
 
     public MigrationProjectProperties() {
         sipsSubmitted = new HashSet<>();
@@ -224,13 +224,13 @@ public class MigrationProjectProperties {
     }
 
     /**
-     * @return configuration information related to the CDM environment being used for this migration
+     * @return Key indicating which CDM environment is being used for this migration
      */
-    public CdmEnvironment getCdmEnvironment() {
+    public String getCdmEnvironment() {
         return cdmEnvironment;
     }
 
-    public void setCdmEnvironment(CdmEnvironment cdmEnvironment) {
+    public void setCdmEnvironment(String cdmEnvironment) {
         this.cdmEnvironment = cdmEnvironment;
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
@@ -41,7 +41,7 @@ public class MigrationProjectProperties {
     private Set<String> sipsSubmitted;
     private String hookId;
     private String collectionNumber;
-    private String cdmEnvironment;
+    private String cdmEnvironmentId;
 
     public MigrationProjectProperties() {
         sipsSubmitted = new HashSet<>();
@@ -226,11 +226,11 @@ public class MigrationProjectProperties {
     /**
      * @return Key indicating which CDM environment is being used for this migration
      */
-    public String getCdmEnvironment() {
-        return cdmEnvironment;
+    public String getCdmEnvironmentId() {
+        return cdmEnvironmentId;
     }
 
-    public void setCdmEnvironment(String cdmEnvironment) {
-        this.cdmEnvironment = cdmEnvironment;
+    public void setCdmEnvironmentId(String cdmEnvironmentId) {
+        this.cdmEnvironmentId = cdmEnvironmentId;
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/CdmExportOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/CdmExportOptions.java
@@ -37,21 +37,6 @@ public class CdmExportOptions {
             description = "Force the export to restart from the beginning. Use if a previous export was started "
                     + "or completed, but you would like to begin the export again.")
     private boolean force;
-    @CommandLine.Option(names = { "-H", "--ssh-host"},
-            description = {"Host name of the CDM SSH server.",
-                    "Default: ${DEFAULT-VALUE}"},
-            defaultValue = "${env:CDM_SSH_HOST:-127.0.0.1}")
-    private String cdmSshHost;
-    @CommandLine.Option(names = { "-P", "--ssh-port"},
-            description = {"Port of the CDM SSH server.",
-                    "Default: ${DEFAULT-VALUE}"},
-            defaultValue = "22")
-    private int cdmSshPort;
-    @CommandLine.Option(names = { "-D", "--download-path"},
-            description = {"Remote base path where CDM files should be located for transfer via SSH.",
-                    "Default: ${DEFAULT-VALUE}"},
-            defaultValue = "${env:CDM_SSH_DOWNLOAD_PATH}")
-    private String cdmSshDownloadBasePath;
 
     public String getCdmUsername() {
         return cdmUsername;
@@ -67,30 +52,6 @@ public class CdmExportOptions {
 
     public void setCdmPassword(String cdmPassword) {
         this.cdmPassword = cdmPassword;
-    }
-
-    public String getCdmSshHost() {
-        return cdmSshHost;
-    }
-
-    public void setCdmSshHost(String cdmSshHost) {
-        this.cdmSshHost = cdmSshHost;
-    }
-
-    public int getCdmSshPort() {
-        return cdmSshPort;
-    }
-
-    public void setCdmSshPort(int cdmSshPort) {
-        this.cdmSshPort = cdmSshPort;
-    }
-
-    public String getCdmSshDownloadBasePath() {
-        return cdmSshDownloadBasePath;
-    }
-
-    public void setCdmSshDownloadBasePath(String cdmSshDownloadBasePath) {
-        this.cdmSshDownloadBasePath = cdmSshDownloadBasePath;
     }
 
     public boolean isForce() {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
@@ -73,11 +73,8 @@ public class CdmExportService {
     private void initializeFileRetrievalService(CdmExportOptions options) {
         if (fileRetrievalService == null) {
             fileRetrievalService = new CdmFileRetrievalService();
-            fileRetrievalService.setCdmHost(options.getCdmSshHost());
             fileRetrievalService.setSshPassword(options.getCdmPassword());
-            fileRetrievalService.setSshPort(options.getCdmSshPort());
             fileRetrievalService.setSshUsername(options.getCdmUsername());
-            fileRetrievalService.setDownloadBasePath(options.getCdmSshDownloadBasePath());
             fileRetrievalService.setProject(project);
         }
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportService.java
@@ -18,6 +18,7 @@ package edu.unc.lib.boxc.migration.cdm.services;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.options.CdmExportOptions;
 import edu.unc.lib.boxc.migration.cdm.services.export.ExportStateService;
+import edu.unc.lib.boxc.migration.cdm.services.ChompbConfigService.ChompbConfig;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 import org.slf4j.Logger;
 
@@ -39,6 +40,7 @@ public class CdmExportService {
     private ExportStateService exportStateService;
     private CdmFileRetrievalService fileRetrievalService;
     private MigrationProject project;
+    private ChompbConfig chompbConfig;
 
     public CdmExportService() {
     }
@@ -75,6 +77,7 @@ public class CdmExportService {
             fileRetrievalService = new CdmFileRetrievalService();
             fileRetrievalService.setSshPassword(options.getCdmPassword());
             fileRetrievalService.setSshUsername(options.getCdmUsername());
+            fileRetrievalService.setChompbConfig(chompbConfig);
             fileRetrievalService.setProject(project);
         }
     }
@@ -97,5 +100,9 @@ public class CdmExportService {
 
     public void setProject(MigrationProject project) {
         this.project = project;
+    }
+
+    public void setChompbConfig(ChompbConfig chompbConfig) {
+        this.chompbConfig = chompbConfig;
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmFileRetrievalService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmFileRetrievalService.java
@@ -83,8 +83,9 @@ public class CdmFileRetrievalService {
         SshClient client = SshClient.setUpDefaultClient();
         client.setFilePasswordProvider(FilePasswordProvider.of(sshPassword));
         client.start();
-        var cdmEnv = chompbConfig.getCdmEnvironments().get(project.getProjectProperties().getCdmEnvironment());
-        try (var sshSession = client.connect(sshUsername, cdmEnv.getSshHost(), cdmEnv.getSshPort())
+        var cdmEnvId = project.getProjectProperties().getCdmEnvironmentId();
+        var cdmEnvConfig = chompbConfig.getCdmEnvironments().get(cdmEnvId);
+        try (var sshSession = client.connect(sshUsername, cdmEnvConfig.getSshHost(), cdmEnvConfig.getSshPort())
                 .verify(SSH_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .getSession()) {
             sshSession.addPasswordIdentity(sshPassword);
@@ -94,7 +95,7 @@ public class CdmFileRetrievalService {
             var scpClientCreator = ScpClientCreator.instance();
             var scpClient = scpClientCreator.createScpClient(sshSession);
             String collectionId = project.getProjectProperties().getCdmCollectionId();
-            var remotePath = Paths.get(cdmEnv.getSshDownloadBasePath(), collectionId, remoteSubPath).toString();
+            var remotePath = Paths.get(cdmEnvConfig.getSshDownloadBasePath(), collectionId, remoteSubPath).toString();
             scpClient.download(remotePath, localDestination);
         } catch (IOException e) {
             throw new MigrationException("Failed to download desc.all file", e);

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmFileRetrievalService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmFileRetrievalService.java
@@ -17,6 +17,7 @@ package edu.unc.lib.boxc.migration.cdm.services;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.services.ChompbConfigService.ChompbConfig;
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.common.config.keys.FilePasswordProvider;
 import org.apache.sshd.scp.client.ScpClientCreator;
@@ -43,6 +44,7 @@ public class CdmFileRetrievalService {
 
     private String sshUsername;
     private String sshPassword;
+    private ChompbConfig chompbConfig;
 
     /**
      * Download the desc.all file for the collection being migrated
@@ -81,7 +83,7 @@ public class CdmFileRetrievalService {
         SshClient client = SshClient.setUpDefaultClient();
         client.setFilePasswordProvider(FilePasswordProvider.of(sshPassword));
         client.start();
-        var cdmEnv = project.getProjectProperties().getCdmEnvironment();
+        var cdmEnv = chompbConfig.getCdmEnvironments().get(project.getProjectProperties().getCdmEnvironment());
         try (var sshSession = client.connect(sshUsername, cdmEnv.getSshHost(), cdmEnv.getSshPort())
                 .verify(SSH_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .getSession()) {
@@ -109,5 +111,9 @@ public class CdmFileRetrievalService {
 
     public void setSshPassword(String sshPassword) {
         this.sshPassword = sshPassword;
+    }
+
+    public void setChompbConfig(ChompbConfig chompbConfig) {
+        this.chompbConfig = chompbConfig;
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/ChompbConfigService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/ChompbConfigService.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.unc.lib.boxc.migration.cdm.model.CdmEnvironment;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Service for interactions with chompb application environment configuration
+ *
+ * @author bbpennel
+ */
+public class ChompbConfigService {
+    private Path envConfigPath;
+    private ChompbConfig config;
+
+    public ChompbConfig getConfig() throws IOException {
+        if (config == null) {
+            ObjectMapper mapper = new ObjectMapper();
+            config = mapper.readValue(Files.newInputStream(envConfigPath), ChompbConfig.class);
+        }
+        return config;
+    }
+
+    public void setEnvConfigPath(Path envConfigPath) {
+        this.envConfigPath = envConfigPath;
+    }
+
+    public static class ChompbConfig {
+        private Map<String, CdmEnvironment> cdmEnvironments;
+
+        public Map<String, CdmEnvironment> getCdmEnvironments() {
+            return cdmEnvironments;
+        }
+
+        public void setCdmEnvironments(Map<String, CdmEnvironment> cdmEnvironments) {
+            this.cdmEnvironments = cdmEnvironments;
+        }
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactory.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactory.java
@@ -81,7 +81,7 @@ public class MigrationProjectFactory {
         properties.setCreatedDate(Instant.now());
         properties.setName(projectName);
         properties.setCdmCollectionId(collectionId == null ? projectName : collectionId);
-        properties.setCdmEnvironment(cdmEnv);
+        properties.setCdmEnvironmentId(cdmEnv);
         project.setProjectProperties(properties);
         ProjectPropertiesSerialization.write(propertiesPath, properties);
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactory.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactory.java
@@ -42,12 +42,12 @@ public class MigrationProjectFactory {
      * @param name
      * @param collectionId
      * @param user
-     * @param cdmEnv
+     * @param cdmEnvId
      * @return
      * @throws IOException
      */
     public static MigrationProject createMigrationProject(Path path, String name,
-                                                          String collectionId, String user, String cdmEnv)
+                                                          String collectionId, String user, String cdmEnvId)
             throws IOException {
         Assert.notNull(path, "Project path not set");
         Assert.notNull(user, "Username not set");
@@ -81,7 +81,7 @@ public class MigrationProjectFactory {
         properties.setCreatedDate(Instant.now());
         properties.setName(projectName);
         properties.setCdmCollectionId(collectionId == null ? projectName : collectionId);
-        properties.setCdmEnvironmentId(cdmEnv);
+        properties.setCdmEnvironmentId(cdmEnvId);
         project.setProjectProperties(properties);
         ProjectPropertiesSerialization.write(propertiesPath, properties);
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactory.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactory.java
@@ -15,19 +15,17 @@
  */
 package edu.unc.lib.boxc.migration.cdm.services;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Instant;
-
-import edu.unc.lib.boxc.migration.cdm.model.CdmEnvironment;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.util.Assert;
-
 import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.Assert;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
 
 /**
  * Service which provides MigrationProject objects
@@ -44,11 +42,12 @@ public class MigrationProjectFactory {
      * @param name
      * @param collectionId
      * @param user
+     * @param cdmEnv
      * @return
      * @throws IOException
      */
     public static MigrationProject createMigrationProject(Path path, String name,
-                                                          String collectionId, String user, CdmEnvironment cdmEnv)
+                                                          String collectionId, String user, String cdmEnv)
             throws IOException {
         Assert.notNull(path, "Project path not set");
         Assert.notNull(user, "Username not set");

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactory.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactory.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 
+import edu.unc.lib.boxc.migration.cdm.model.CdmEnvironment;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.Assert;
 
@@ -47,7 +48,8 @@ public class MigrationProjectFactory {
      * @throws IOException
      */
     public static MigrationProject createMigrationProject(Path path, String name,
-            String collectionId, String user) throws IOException {
+                                                          String collectionId, String user, CdmEnvironment cdmEnv)
+            throws IOException {
         Assert.notNull(path, "Project path not set");
         Assert.notNull(user, "Username not set");
 
@@ -80,6 +82,7 @@ public class MigrationProjectFactory {
         properties.setCreatedDate(Instant.now());
         properties.setName(projectName);
         properties.setCdmCollectionId(collectionId == null ? projectName : collectionId);
+        properties.setCdmEnvironment(cdmEnv);
         project.setProjectProperties(properties);
         ProjectPropertiesSerialization.write(propertiesPath, properties);
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateService.java
@@ -79,7 +79,7 @@ public class ExportStateService {
             return;
         }
         // If resuming in initial steps, start over
-        if (ProgressState.STARTING.equals(progressState)) {
+        if (ProgressState.STARTING.equals(progressState) || ProgressState.DOWNLOADING_DESC.equals(progressState)) {
             clearState();
             transitionToStarting();
             log.debug("Restarting export, had not reached listing or exporting states");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractCommandIT.java
@@ -15,7 +15,9 @@
  */
 package edu.unc.lib.boxc.migration.cdm;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.services.ChompbConfigService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
@@ -25,6 +27,7 @@ import org.slf4j.Logger;
 import picocli.CommandLine;
 
 import java.io.IOException;
+import java.nio.file.Files;
 
 import static org.junit.Assert.fail;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -43,6 +46,7 @@ public class AbstractCommandIT extends AbstractOutputTest {
     protected SipServiceHelper testHelper;
 
     protected MigrationProject project;
+    protected String chompbConfigPath;
 
     @After
     public void resetProps() {
@@ -61,13 +65,22 @@ public class AbstractCommandIT extends AbstractOutputTest {
     }
 
     protected void initProject() throws IOException {
-        project = MigrationProjectFactory.createMigrationProject(
-                baseDir, PROJECT_ID, COLLECTION_ID, USERNAME, CdmEnvironmentHelper.getTestEnv());
+        project = MigrationProjectFactory.createMigrationProject(baseDir, PROJECT_ID, COLLECTION_ID, USERNAME,
+                CdmEnvironmentHelper.DEFAULT_ENV);
     }
 
     protected void initProjectAndHelper() throws IOException {
         initProject();
         initTestHelper();
+    }
+
+    protected void setupChompbConfig() throws IOException {
+        var configPath = tmpFolder.getRoot().toPath().resolve("config.json");
+        var config = new ChompbConfigService.ChompbConfig();
+        config.setCdmEnvironments(CdmEnvironmentHelper.getTestMapping());
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(Files.newOutputStream(configPath), config);
+        chompbConfigPath = configPath.toString();
     }
 
     protected void executeExpectSuccess(String[] args) {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractCommandIT.java
@@ -15,24 +15,34 @@
  */
 package edu.unc.lib.boxc.migration.cdm;
 
-import static org.junit.Assert.fail;
-import static org.slf4j.LoggerFactory.getLogger;
-
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
+import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import org.junit.After;
 import org.junit.Before;
 import org.slf4j.Logger;
-
 import picocli.CommandLine;
+
+import java.io.IOException;
+
+import static org.junit.Assert.fail;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * @author bbpennel
  */
 public class AbstractCommandIT extends AbstractOutputTest {
     private static final Logger log = getLogger(AbstractCommandIT.class);
+    protected final static String COLLECTION_ID = "my_coll";
+    protected final static String PROJECT_ID = "my_proj";
     protected final static String USERNAME = "theuser";
     private final String initialUser = System.getProperty("user.name");
 
     protected CommandLine migrationCommand;
+    protected SipServiceHelper testHelper;
+
+    protected MigrationProject project;
 
     @After
     public void resetProps() {
@@ -43,6 +53,21 @@ public class AbstractCommandIT extends AbstractOutputTest {
     public void baseSetUp() throws Exception {
         System.setProperty("user.name", USERNAME);
         migrationCommand = new CommandLine(new CLIMain());
+        tmpFolder.create();
+    }
+
+    protected void initTestHelper() throws IOException {
+        testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());;
+    }
+
+    protected void initProject() throws IOException {
+        project = MigrationProjectFactory.createMigrationProject(
+                baseDir, PROJECT_ID, COLLECTION_ID, USERNAME, CdmEnvironmentHelper.getTestEnv());
+    }
+
+    protected void initProjectAndHelper() throws IOException {
+        initProject();
+        initTestHelper();
     }
 
     protected void executeExpectSuccess(String[] args) {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractCommandIT.java
@@ -61,12 +61,12 @@ public class AbstractCommandIT extends AbstractOutputTest {
     }
 
     protected void initTestHelper() throws IOException {
-        testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());;
+        testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
     }
 
     protected void initProject() throws IOException {
         project = MigrationProjectFactory.createMigrationProject(baseDir, PROJECT_ID, COLLECTION_ID, USERNAME,
-                CdmEnvironmentHelper.DEFAULT_ENV);
+                CdmEnvironmentHelper.DEFAULT_ENV_ID);
     }
 
     protected void initProjectAndHelper() throws IOException {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AccessFilesCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AccessFilesCommandIT.java
@@ -15,42 +15,32 @@
  */
 package edu.unc.lib.boxc.migration.cdm;
 
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Instant;
-
-import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
-import org.junit.Before;
-import org.junit.Test;
-
-import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
-import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
-import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
-import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
-
 /**
  * @author bbpennel
  */
 public class AccessFilesCommandIT extends AbstractCommandIT {
-    private final static String COLLECTION_ID = "my_coll";
 
-    private MigrationProject project;
+
     private Path basePath;
-    private SipServiceHelper testHelper;
 
     @Before
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                baseDir, COLLECTION_ID, null, USERNAME);
+        initProjectAndHelper();
         basePath = tmpFolder.newFolder().toPath();
-        testHelper = new SipServiceHelper(project, tmpFolder.getRoot().toPath());
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
@@ -21,6 +21,7 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.TestSshServer;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -67,8 +68,6 @@ public class CdmExportCommandIT extends AbstractCommandIT {
         String[] defaultArgs = new String[] {
                 "-w", projPath.toString(),
                 "export",
-                "-D", Paths.get("src/test/resources/descriptions").toAbsolutePath().toString(),
-                "-P", "42222",
                 "-p", PASSWORD};
         return ArrayUtils.addAll(defaultArgs, extras);
     }
@@ -185,7 +184,7 @@ public class CdmExportCommandIT extends AbstractCommandIT {
 
     private Path createProject(String collId) throws Exception {
         MigrationProject project = MigrationProjectFactory.createMigrationProject(
-                baseDir, collId, null, USERNAME);
+                baseDir, collId, null, USERNAME, CdmEnvironmentHelper.getTestEnv());
         CdmFieldInfo fieldInfo = new CdmFieldInfo();
         CdmFieldEntry fieldEntry = new CdmFieldEntry();
         fieldEntry.setNickName("title");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
@@ -33,7 +33,6 @@ import org.junit.Test;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -186,7 +185,7 @@ public class CdmExportCommandIT extends AbstractCommandIT {
 
     private Path createProject(String collId) throws Exception {
         MigrationProject project = MigrationProjectFactory.createMigrationProject(
-                baseDir, collId, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV);
+                baseDir, collId, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
         CdmFieldInfo fieldInfo = new CdmFieldInfo();
         CdmFieldEntry fieldEntry = new CdmFieldEntry();
         fieldEntry.setNickName("title");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
@@ -57,6 +57,7 @@ public class CdmExportCommandIT extends AbstractCommandIT {
         testSshServer = new TestSshServer();
         testSshServer.setPassword(PASSWORD);
         testSshServer.startServer();
+        setupChompbConfig();
     }
 
     @After
@@ -67,6 +68,7 @@ public class CdmExportCommandIT extends AbstractCommandIT {
     private String[] exportArgs(Path projPath, String... extras) {
         String[] defaultArgs = new String[] {
                 "-w", projPath.toString(),
+                "--env-config", chompbConfigPath,
                 "export",
                 "-p", PASSWORD};
         return ArrayUtils.addAll(defaultArgs, extras);
@@ -184,7 +186,7 @@ public class CdmExportCommandIT extends AbstractCommandIT {
 
     private Path createProject(String collId) throws Exception {
         MigrationProject project = MigrationProjectFactory.createMigrationProject(
-                baseDir, collId, null, USERNAME, CdmEnvironmentHelper.getTestEnv());
+                baseDir, collId, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV);
         CdmFieldInfo fieldInfo = new CdmFieldInfo();
         CdmFieldEntry fieldEntry = new CdmFieldEntry();
         fieldEntry.setNickName("title");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmFieldsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmFieldsCommandIT.java
@@ -113,7 +113,7 @@ public class CdmFieldsCommandIT extends AbstractCommandIT {
         testHelper.indexExportData("mini_gilmer");
 
         Path projectPath = project.getProjectPath();
-        Path reportPath = projectPath.resolve("gilmer_field_urls.csv");
+        Path reportPath = projectPath.resolve("my_proj_field_urls.csv");
 
         String[] cmdArgs = new String[] {
                 "-w", projectPath.toString(),

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmIndexCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmIndexCommandIT.java
@@ -15,6 +15,17 @@
  */
 package edu.unc.lib.boxc.migration.cdm;
 
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
+import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -22,32 +33,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.time.Instant;
-
-import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
-import org.apache.commons.io.FileUtils;
-import org.junit.Test;
-
-import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
-import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
-import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
-import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
-
 /**
  * @author bbpennel
  */
 public class CdmIndexCommandIT extends AbstractCommandIT {
-    private final static String COLLECTION_ID = "my_coll";
-
-    private MigrationProject project;
-
     @Test
     public void indexGilmerTest() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                baseDir, COLLECTION_ID, null, USERNAME);
+        initProject();
         Files.createDirectories(project.getExportPath());
 
         Files.copy(Paths.get("src/test/resources/descriptions/gilmer/index/description/desc.all"),
@@ -66,8 +58,7 @@ public class CdmIndexCommandIT extends AbstractCommandIT {
 
     @Test
     public void indexAlreadyExistsTest() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                baseDir, COLLECTION_ID, null, USERNAME);
+        initProject();
         Files.createDirectories(project.getExportPath());
 
         Files.copy(Paths.get("src/test/resources/descriptions/mini_gilmer/index/description/desc.all"),
@@ -105,8 +96,7 @@ public class CdmIndexCommandIT extends AbstractCommandIT {
 
     @Test
     public void indexingFailureTest() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                baseDir, COLLECTION_ID, null, USERNAME);
+        initProject();
         Files.createDirectories(project.getExportPath());
 
         FileUtils.write(CdmFileRetrievalService.getDescAllPath(project).toFile(), "uh oh", ISO_8859_1);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CompleteMigrationIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CompleteMigrationIT.java
@@ -15,25 +15,18 @@
  */
 package edu.unc.lib.boxc.migration.cdm;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.junit.Assert.assertEquals;
-
-import java.io.File;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Map;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import edu.unc.lib.boxc.deposit.api.RedisWorkerConstants.DepositField;
+import edu.unc.lib.boxc.deposit.impl.model.DepositDirectoryManager;
+import edu.unc.lib.boxc.deposit.impl.model.DepositStatusFactory;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationSip;
+import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
+import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import edu.unc.lib.boxc.migration.cdm.test.TestSshServer;
-import org.apache.commons.io.FileUtils;
+import edu.unc.lib.boxc.persist.api.PackagingType;
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
@@ -43,20 +36,24 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-
-import edu.unc.lib.boxc.deposit.api.RedisWorkerConstants.DepositField;
-import edu.unc.lib.boxc.deposit.impl.model.DepositDirectoryManager;
-import edu.unc.lib.boxc.deposit.impl.model.DepositStatusFactory;
-import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
-import edu.unc.lib.boxc.migration.cdm.model.MigrationSip;
-import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
-import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
-import edu.unc.lib.boxc.persist.api.PackagingType;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.embedded.RedisServer;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test which runs a single collection through a full set of migration steps
@@ -70,10 +67,10 @@ public class CompleteMigrationIT extends AbstractCommandIT {
     private final static int REDIS_PORT = 46380;
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
+    public WireMockRule wireMockRule = new WireMockRule(options().port(CdmEnvironmentHelper.TEST_HTTP_PORT));
     private TestSshServer testSshServer;
-    private String cdmBaseUrl;
     private Path filesBasePath;
+    private String cdmEnvConfig;
 
     private RedisServer redisServer;
     private DepositStatusFactory depositStatusFactory;
@@ -82,7 +79,6 @@ public class CompleteMigrationIT extends AbstractCommandIT {
     @Before
     public void setup() throws Exception {
         filesBasePath = tmpFolder.newFolder().toPath();
-        cdmBaseUrl = "http://localhost:" + wireMockRule.port();
         String validRespBody = IOUtils.toString(this.getClass().getResourceAsStream("/cdm_fields_resp.json"),
                 StandardCharsets.UTF_8);
 
@@ -99,6 +95,12 @@ public class CompleteMigrationIT extends AbstractCommandIT {
         testSshServer = new TestSshServer();
         testSshServer.setPassword(CDM_PASSWORD);
         testSshServer.startServer();
+
+        var cdmEnvPath = tmpFolder.getRoot().toPath().resolve("cdm_envs.json");
+        var envMapping = CdmEnvironmentHelper.getTestMapping();
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(Files.newOutputStream(cdmEnvPath), envMapping);
+        cdmEnvConfig = cdmEnvPath.toString();
     }
 
     public void initDepositStatusFactory() {
@@ -128,7 +130,7 @@ public class CompleteMigrationIT extends AbstractCommandIT {
         String[] argsInit = new String[] {
                 "-w", baseDir.toString(),
                 "init",
-                "--cdm-url", cdmBaseUrl,
+                "--env-config", cdmEnvConfig,
                 "-p", COLLECTION_ID };
         executeExpectSuccess(argsInit);
 
@@ -138,8 +140,6 @@ public class CompleteMigrationIT extends AbstractCommandIT {
         String[] argsExport = new String[] {
                 "-w", projPath.toString(),
                 "export",
-                "-D", Paths.get("src/test/resources/descriptions").toAbsolutePath().toString(),
-                "-P", "42222",
                 "-p", CDM_PASSWORD };
         executeExpectSuccess(argsExport);
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CompleteMigrationIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CompleteMigrationIT.java
@@ -127,7 +127,8 @@ public class CompleteMigrationIT extends AbstractCommandIT {
                 "-w", baseDir.toString(),
                 "--env-config", chompbConfigPath,
                 "init",
-                "-p", COLLECTION_ID };
+                "-p", COLLECTION_ID,
+                "-e", "test"};
         executeExpectSuccess(argsInit);
 
         Path projPath = baseDir.resolve(COLLECTION_ID);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CompleteMigrationIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CompleteMigrationIT.java
@@ -23,6 +23,7 @@ import edu.unc.lib.boxc.deposit.impl.model.DepositStatusFactory;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationSip;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
+import edu.unc.lib.boxc.migration.cdm.services.ChompbConfigService;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import edu.unc.lib.boxc.migration.cdm.test.TestSshServer;
@@ -70,7 +71,6 @@ public class CompleteMigrationIT extends AbstractCommandIT {
     public WireMockRule wireMockRule = new WireMockRule(options().port(CdmEnvironmentHelper.TEST_HTTP_PORT));
     private TestSshServer testSshServer;
     private Path filesBasePath;
-    private String cdmEnvConfig;
 
     private RedisServer redisServer;
     private DepositStatusFactory depositStatusFactory;
@@ -96,11 +96,7 @@ public class CompleteMigrationIT extends AbstractCommandIT {
         testSshServer.setPassword(CDM_PASSWORD);
         testSshServer.startServer();
 
-        var cdmEnvPath = tmpFolder.getRoot().toPath().resolve("cdm_envs.json");
-        var envMapping = CdmEnvironmentHelper.getTestMapping();
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.writeValue(Files.newOutputStream(cdmEnvPath), envMapping);
-        cdmEnvConfig = cdmEnvPath.toString();
+        setupChompbConfig();
     }
 
     public void initDepositStatusFactory() {
@@ -129,8 +125,8 @@ public class CompleteMigrationIT extends AbstractCommandIT {
     public void migrateSimpleCollectionTest() throws Exception {
         String[] argsInit = new String[] {
                 "-w", baseDir.toString(),
+                "--env-config", chompbConfigPath,
                 "init",
-                "--env-config", cdmEnvConfig,
                 "-p", COLLECTION_ID };
         executeExpectSuccess(argsInit);
 
@@ -139,6 +135,7 @@ public class CompleteMigrationIT extends AbstractCommandIT {
 
         String[] argsExport = new String[] {
                 "-w", projPath.toString(),
+                "--env-config", chompbConfigPath,
                 "export",
                 "-p", CDM_PASSWORD };
         executeExpectSuccess(argsExport);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/DescriptionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/DescriptionsCommandIT.java
@@ -15,24 +15,9 @@
  */
 package edu.unc.lib.boxc.migration.cdm;
 
-import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.MODS_V3_NS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.time.Instant;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
-
-import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
-import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
+import edu.unc.lib.boxc.common.xml.SecureXMLFactory;
+import edu.unc.lib.boxc.migration.cdm.services.DescriptionsService;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.output.Format;
@@ -40,13 +25,20 @@ import org.jdom2.output.XMLOutputter;
 import org.junit.Before;
 import org.junit.Test;
 
-import edu.unc.lib.boxc.common.xml.SecureXMLFactory;
-import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
-import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
-import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
-import edu.unc.lib.boxc.migration.cdm.services.DescriptionsService;
-import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
-import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.MODS_V3_NS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author bbpennel
@@ -54,18 +46,10 @@ import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 public class DescriptionsCommandIT extends AbstractCommandIT {
     private final static Pattern GENERATED_PATH_PATTERN = Pattern.compile(
             ".*Description file generated at: ([^\\s]+).*", Pattern.DOTALL);
-    private final static String COLLECTION_ID = "my_coll";
-
-    private MigrationProject project;
-    private CdmIndexService indexService;
-    private CdmFieldService fieldService;
-    private SipServiceHelper testHelper;
 
     @Before
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                baseDir, COLLECTION_ID, null, USERNAME);
-        testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
+        initProjectAndHelper();
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommandIT.java
@@ -15,39 +15,29 @@
  */
 package edu.unc.lib.boxc.migration.cdm;
 
-import static org.junit.Assert.assertEquals;
+import edu.unc.lib.boxc.migration.cdm.model.DestinationsInfo;
+import edu.unc.lib.boxc.migration.cdm.model.DestinationsInfo.DestinationMapping;
+import edu.unc.lib.boxc.migration.cdm.services.DestinationsService;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
 
-import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Test;
-
-import edu.unc.lib.boxc.migration.cdm.model.DestinationsInfo;
-import edu.unc.lib.boxc.migration.cdm.model.DestinationsInfo.DestinationMapping;
-import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
-import edu.unc.lib.boxc.migration.cdm.services.DestinationsService;
-import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
-import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
-import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author bbpennel
  */
 public class DestinationsCommandIT extends AbstractCommandIT {
-    private final static String COLLECTION_ID = "my_coll";
     private final static String DEST_UUID = "3f3c5bcf-d5d6-46ad-87ec-bcdf1f06b19e";
-
-    private MigrationProject project;
-    private SipServiceHelper testHelper;
 
     @Before
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                baseDir, COLLECTION_ID, null, USERNAME);
-        testHelper = new SipServiceHelper(project, tmpFolder.getRoot().toPath());
+        initProjectAndHelper();
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommandIT.java
@@ -15,45 +15,29 @@
  */
 package edu.unc.lib.boxc.migration.cdm;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
+import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
-import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
-import org.junit.Before;
-import org.junit.Test;
-
-import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
-import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
-import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
-import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
-import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author bbpennel
  */
 public class GroupMappingCommandIT extends AbstractCommandIT {
-    private final static String COLLECTION_ID = "my_coll";
-
-    private MigrationProject project;
-    private CdmIndexService indexService;
-    private SipServiceHelper testHelper;
-
     @Before
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                baseDir, COLLECTION_ID, null, USERNAME);
-        testHelper = new SipServiceHelper(project, tmpFolder.getRoot().toPath());
+        initProjectAndHelper();
     }
 
     @Test
@@ -94,7 +78,7 @@ public class GroupMappingCommandIT extends AbstractCommandIT {
                 "group_mapping", "sync" };
         executeExpectSuccess(args2);
 
-        indexService = new CdmIndexService();
+        var indexService = new CdmIndexService();
         indexService.setProject(project);
         Connection conn = null;
         try {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/IndexRedirectCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/IndexRedirectCommandIT.java
@@ -15,54 +15,27 @@
  */
 package edu.unc.lib.boxc.migration.cdm;
 
-import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
-import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
-import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
-import edu.unc.lib.boxc.migration.cdm.services.RedirectMappingIndexService;
-import edu.unc.lib.boxc.migration.cdm.services.RedirectMappingIndexServiceTest;
 import edu.unc.lib.boxc.migration.cdm.services.SipService;
 import edu.unc.lib.boxc.migration.cdm.test.RedirectMappingHelper;
-import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
-import org.apache.commons.io.FileUtils;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.sql.Connection;
-import java.sql.Statement;
-
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author snluong
  */
 public class IndexRedirectCommandIT  extends AbstractCommandIT {
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
-
-    private static final String PROJECT_NAME = "proj";
-    private static final String USERNAME = "migr_user";
     private static final String DEST_UUID = "7a33f5e6-f0ca-461c-8df0-c76c62198b17";
-    private MigrationProject project;
     private SipService sipsService;
-    private SipServiceHelper testHelper;
     private RedirectMappingHelper redirectMappingHelper;
     private Path propertiesPath;
 
     @Before
     public void setup() throws Exception {
-        tmpFolder.create();
-        project = MigrationProjectFactory.createMigrationProject(
-                baseDir, PROJECT_NAME, null, USERNAME);
-        testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
+        initProjectAndHelper();
 
         Files.createDirectories(project.getExportPath());
         sipsService = testHelper.createSipsService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommandIT.java
@@ -91,7 +91,8 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
                 "-w", baseDir.toString(),
                 "--env-config", chompbConfigPath,
                 "init",
-                "-p", COLLECTION_ID };
+                "-p", COLLECTION_ID,
+                "-e", "test" };
         executeExpectSuccess(initArgs);
 
         MigrationProject project = MigrationProjectFactory.loadMigrationProject(baseDir.resolve(COLLECTION_ID));
@@ -111,7 +112,8 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
                 "-w", projDir.toString(),
                 "--env-config", chompbConfigPath,
                 "init",
-                "-c", COLLECTION_ID };
+                "-c", COLLECTION_ID,
+                "-e", "test"};
         executeExpectSuccess(initArgs);
 
         MigrationProject project = MigrationProjectFactory.loadMigrationProject(projDir);
@@ -129,7 +131,8 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
                 "-w", baseDir.toString(),
                 "--env-config", chompbConfigPath,
                 "init",
-                "-p", "unknowncoll" };
+                "-p", "unknowncoll",
+                "-e", "test" };
         executeExpectFailure(initArgs);
 
         assertOutputContains("No collection with ID 'unknowncoll' found on server");
@@ -145,7 +148,8 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
                 "-w", projDir.toString(),
                 "--env-config", chompbConfigPath,
                 "init",
-                "-c", COLLECTION_ID };
+                "-c", COLLECTION_ID,
+                "-e", "test" };
         executeExpectSuccess(initArgs);
 
         // Run it a second time, should cause a failure
@@ -182,7 +186,8 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
         String[] initArgs = new String[] {
                 "-w", baseDir.toString(),
                 "init",
-                "-p", COLLECTION_ID };
+                "-p", COLLECTION_ID,
+                "-e", "test" };
         executeExpectFailure(initArgs);
 
         assertOutputContains("Must provide an env-config option");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommandIT.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.unc.lib.boxc.migration.cdm.services.ChompbConfigService;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
@@ -62,7 +63,6 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
     public WireMockRule wireMockRule = new WireMockRule(options().port(CdmEnvironmentHelper.TEST_HTTP_PORT));
 
     private CdmFieldService fieldService;
-    private String cdmEnvConfig;
 
     @Before
     public void setUp() throws Exception {
@@ -82,19 +82,15 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
                         .withHeader("Content-Type", "text/json")
                         .withBody(validRespBody)));
 
-        var cdmEnvPath = tmpFolder.getRoot().toPath().resolve("cdm_envs.json");
-        var envMapping = CdmEnvironmentHelper.getTestMapping();
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.writeValue(Files.newOutputStream(cdmEnvPath), envMapping);
-        cdmEnvConfig = cdmEnvPath.toString();
+        setupChompbConfig();
     }
 
     @Test
     public void initValidProjectTest() throws Exception {
         String[] initArgs = new String[] {
                 "-w", baseDir.toString(),
+                "--env-config", chompbConfigPath,
                 "init",
-                "--env-config", cdmEnvConfig,
                 "-p", COLLECTION_ID };
         executeExpectSuccess(initArgs);
 
@@ -113,8 +109,8 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
         Files.createDirectory(projDir);
         String[] initArgs = new String[] {
                 "-w", projDir.toString(),
+                "--env-config", chompbConfigPath,
                 "init",
-                "--env-config", cdmEnvConfig,
                 "-c", COLLECTION_ID };
         executeExpectSuccess(initArgs);
 
@@ -131,8 +127,8 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
     public void initCdmCollectioNotFoundTest() throws Exception {
         String[] initArgs = new String[] {
                 "-w", baseDir.toString(),
+                "--env-config", chompbConfigPath,
                 "init",
-                "--env-config", cdmEnvConfig,
                 "-p", "unknowncoll" };
         executeExpectFailure(initArgs);
 
@@ -147,8 +143,8 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
         Files.createDirectory(projDir);
         String[] initArgs = new String[] {
                 "-w", projDir.toString(),
+                "--env-config", chompbConfigPath,
                 "init",
-                "--env-config", cdmEnvConfig,
                 "-c", COLLECTION_ID };
         executeExpectSuccess(initArgs);
 
@@ -170,8 +166,8 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
     public void initUnknownEnvTest() throws Exception {
         String[] initArgs = new String[] {
                 "-w", baseDir.toString(),
+                "--env-config", chompbConfigPath,
                 "init",
-                "--env-config", cdmEnvConfig,
                 "-e", "what",
                 "-p", COLLECTION_ID };
         executeExpectFailure(initArgs);
@@ -189,7 +185,7 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
                 "-p", COLLECTION_ID };
         executeExpectFailure(initArgs);
 
-        assertOutputContains("Must provide and env-config option");
+        assertOutputContains("Must provide an env-config option");
 
         assertProjectDirectoryNotCreate();
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/ProjectPropertiesCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/ProjectPropertiesCommandIT.java
@@ -30,16 +30,11 @@ import edu.unc.lib.boxc.migration.cdm.services.ProjectPropertiesService;
 public class ProjectPropertiesCommandIT extends AbstractCommandIT {
     private static final String PROJECT_NAME = "gilmer";
 
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
-
-    private MigrationProject project;
     private ProjectPropertiesService propertiesService;
 
     @Before
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                baseDir, PROJECT_NAME, null, "user");
+        initProject();
         propertiesService = new ProjectPropertiesService();
         propertiesService.setProject(project);
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/SipsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/SipsCommandIT.java
@@ -15,14 +15,10 @@
  */
 package edu.unc.lib.boxc.migration.cdm;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-
+import edu.unc.lib.boxc.deposit.impl.model.DepositDirectoryManager;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationSip;
+import edu.unc.lib.boxc.model.api.rdf.Cdr;
+import edu.unc.lib.boxc.model.api.rdf.CdrDeposit;
 import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
@@ -31,29 +27,23 @@ import org.apache.jena.vocabulary.RDF;
 import org.junit.Before;
 import org.junit.Test;
 
-import edu.unc.lib.boxc.deposit.impl.model.DepositDirectoryManager;
-import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
-import edu.unc.lib.boxc.migration.cdm.model.MigrationSip;
-import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
-import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
-import edu.unc.lib.boxc.model.api.rdf.Cdr;
-import edu.unc.lib.boxc.model.api.rdf.CdrDeposit;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author bbpennel
  */
 public class SipsCommandIT extends AbstractCommandIT {
-    private final static String COLLECTION_ID = "my_coll";
     private final static String DEST_UUID = "3f3c5bcf-d5d6-46ad-87ec-bcdf1f06b19e";
-
-    private MigrationProject project;
-    private SipServiceHelper testHelper;
 
     @Before
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                baseDir, COLLECTION_ID, null, USERNAME);
-        testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
+        initProjectAndHelper();
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
@@ -15,41 +15,27 @@
  */
 package edu.unc.lib.boxc.migration.cdm;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Instant;
 
-import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
-import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
-import org.junit.Before;
-import org.junit.Test;
-
-import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
-import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
-import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author bbpennel
  */
 public class SourceFilesCommandIT extends AbstractCommandIT {
-    private final static String COLLECTION_ID = "my_coll";
-
-    private MigrationProject project;
     private Path basePath;
-    private SipServiceHelper testHelper;
 
     @Before
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                baseDir, COLLECTION_ID, null, USERNAME);
+        initProjectAndHelper();
         basePath = tmpFolder.newFolder().toPath();
-        testHelper = new SipServiceHelper(project, tmpFolder.getRoot().toPath());
     }
 
     @Test
@@ -115,7 +101,7 @@ public class SourceFilesCommandIT extends AbstractCommandIT {
         executeExpectSuccess(args);
 
         assertFalse(Files.exists(project.getSourceFilesMappingPath()));
-        assertOutputContains("25,276_182_E.tif," + srcPath1.toString() + ",");
+        assertOutputContains("25,276_182_E.tif," + srcPath1 + ",");
         assertOutputContains("26,276_183_E.tif,,");
         assertOutputContains("27,276_203_E.tif,,");
     }
@@ -161,8 +147,8 @@ public class SourceFilesCommandIT extends AbstractCommandIT {
                 "-b", basePath.toString()};
         executeExpectSuccess(args2);
 
-        assertOutputContains("25,276_182_E.tif," + srcPath1.toString() + ",");
-        assertOutputContains("26,276_183_E.tif," + srcPath2.toString() + ",");
+        assertOutputContains("25,276_182_E.tif," + srcPath1 + ",");
+        assertOutputContains("26,276_183_E.tif," + srcPath2 + ",");
         assertOutputContains("27,276_203_E.tif,,");
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/StatusCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/StatusCommandIT.java
@@ -15,45 +15,32 @@
  */
 package edu.unc.lib.boxc.migration.cdm;
 
-import static java.nio.charset.StandardCharsets.US_ASCII;
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Instant;
-import java.util.List;
-
+import edu.unc.lib.boxc.migration.cdm.options.SipGenerationOptions;
+import edu.unc.lib.boxc.migration.cdm.options.SourceFileMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
+import edu.unc.lib.boxc.migration.cdm.services.SipService;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
 
-import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
-import edu.unc.lib.boxc.migration.cdm.options.SipGenerationOptions;
-import edu.unc.lib.boxc.migration.cdm.options.SourceFileMappingOptions;
-import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
-import edu.unc.lib.boxc.migration.cdm.services.SipService;
-import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
-import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.Instant;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 /**
  * @author bbpennel
  */
 public class StatusCommandIT extends AbstractCommandIT {
-    private final static String COLLECTION_ID = "my_coll";
-    private final static String PROJECT_ID = "my_proj";
     private final static String DEST_UUID = "3f3c5bcf-d5d6-46ad-87ec-bcdf1f06b19e";
-
-    private MigrationProject project;
-    private SipServiceHelper testHelper;
 
     @Before
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                baseDir, PROJECT_ID, COLLECTION_ID, USERNAME);
-        testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
+        initProjectAndHelper();
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
@@ -68,7 +68,7 @@ public class CdmExportServiceTest {
         initMocks(this);
         tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         fieldService = new CdmFieldService();
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
@@ -56,6 +56,7 @@ public class CdmExportServiceTest {
     private MigrationProject project;
     private CdmFieldService fieldService;
     private CdmExportService service;
+    private ChompbConfigService.ChompbConfig chompbConfig;
     private ExportStateService exportStateService;
     @Mock
     private CdmFileRetrievalService cdmFileRetrievalService;
@@ -67,7 +68,7 @@ public class CdmExportServiceTest {
         initMocks(this);
         tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
         fieldService = new CdmFieldService();
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);
@@ -77,6 +78,9 @@ public class CdmExportServiceTest {
         service.setCdmFieldService(fieldService);
         service.setExportStateService(exportStateService);
         service.setFileRetrievalService(cdmFileRetrievalService);
+        var chompbConfig = new ChompbConfigService.ChompbConfig();
+        chompbConfig.setCdmEnvironments(CdmEnvironmentHelper.getTestMapping());
+        service.setChompbConfig(chompbConfig);
 
         // Trigger population of desc.all file
         doAnswer(new Answer<Void>() {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
@@ -15,55 +15,35 @@
  */
 package edu.unc.lib.boxc.migration.cdm.services;
 
-import static java.nio.charset.StandardCharsets.ISO_8859_1;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
-
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import edu.unc.lib.boxc.migration.cdm.options.CdmExportOptions;
-import edu.unc.lib.boxc.migration.cdm.services.export.ExportStateService;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpEntity;
-import org.apache.http.StatusLine;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
 import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo.CdmFieldEntry;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.options.CdmExportOptions;
+import edu.unc.lib.boxc.migration.cdm.services.export.ExportStateService;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
  * @author bbpennel
@@ -87,7 +67,7 @@ public class CdmExportServiceTest {
         initMocks(this);
         tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user");
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
         fieldService = new CdmFieldService();
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
@@ -30,6 +30,7 @@ import java.nio.file.NoSuchFileException;
 import java.util.List;
 import java.util.Optional;
 
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -70,7 +71,7 @@ public class CdmFieldServiceTest {
         initMocks(this);
         tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user");
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
         service = new CdmFieldService();
         service.setHttpClient(httpClient);
         service.setCdmBaseUri(CDM_BASE_URL);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
@@ -71,7 +71,7 @@ public class CdmFieldServiceTest {
         initMocks(this);
         tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
         service = new CdmFieldService();
         service.setHttpClient(httpClient);
         service.setCdmBaseUri(CDM_BASE_URL);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
@@ -71,7 +71,7 @@ public class CdmFieldServiceTest {
         initMocks(this);
         tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         service = new CdmFieldService();
         service.setHttpClient(httpClient);
         service.setCdmBaseUri(CDM_BASE_URL);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
@@ -62,7 +62,7 @@ public class CdmIndexServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
         Files.createDirectories(project.getExportPath());
 
         fieldService = new CdmFieldService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
@@ -62,7 +62,7 @@ public class CdmIndexServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
         fieldService = new CdmFieldService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
@@ -20,10 +20,10 @@ import edu.unc.lib.boxc.migration.cdm.exceptions.StateAlreadyExistsException;
 import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -62,7 +62,7 @@ public class CdmIndexServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user");
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
         Files.createDirectories(project.getExportPath());
 
         fieldService = new CdmFieldService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsServiceTest.java
@@ -66,7 +66,7 @@ public class DescriptionsServiceTest {
     @Before
     public void setup() throws Exception {
         basePath = tmpFolder.newFolder().toPath();
-        project = MigrationProjectFactory.createMigrationProject(basePath, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
+        project = MigrationProjectFactory.createMigrationProject(basePath, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getDescriptionsPath());
         service = new DescriptionsService();
         service.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsServiceTest.java
@@ -66,7 +66,7 @@ public class DescriptionsServiceTest {
     @Before
     public void setup() throws Exception {
         basePath = tmpFolder.newFolder().toPath();
-        project = MigrationProjectFactory.createMigrationProject(basePath, PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
+        project = MigrationProjectFactory.createMigrationProject(basePath, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
         Files.createDirectories(project.getDescriptionsPath());
         service = new DescriptionsService();
         service.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsServiceTest.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -65,7 +66,7 @@ public class DescriptionsServiceTest {
     @Before
     public void setup() throws Exception {
         basePath = tmpFolder.newFolder().toPath();
-        project = MigrationProjectFactory.createMigrationProject(basePath, PROJECT_NAME, null, "user");
+        project = MigrationProjectFactory.createMigrationProject(basePath, PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
         Files.createDirectories(project.getDescriptionsPath());
         service = new DescriptionsService();
         service.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldAssessmentTemplateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldAssessmentTemplateServiceTest.java
@@ -53,7 +53,7 @@ public class FieldAssessmentTemplateServiceTest {
     public void setup() throws Exception {
         tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         fieldService = new CdmFieldService();
 
         service = new FieldAssessmentTemplateService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldAssessmentTemplateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldAssessmentTemplateServiceTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,7 +53,7 @@ public class FieldAssessmentTemplateServiceTest {
     public void setup() throws Exception {
         tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user");
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
         fieldService = new CdmFieldService();
 
         service = new FieldAssessmentTemplateService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldAssessmentTemplateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldAssessmentTemplateServiceTest.java
@@ -53,7 +53,7 @@ public class FieldAssessmentTemplateServiceTest {
     public void setup() throws Exception {
         tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
         fieldService = new CdmFieldService();
 
         service = new FieldAssessmentTemplateService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldUrlAssessmentServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldUrlAssessmentServiceTest.java
@@ -71,7 +71,7 @@ public class FieldUrlAssessmentServiceTest {
     public void setup() throws Exception {
         tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
         var testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidServiceTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.fail;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,7 +45,7 @@ public class FindingAidServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user");
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
 
         fieldService = new CdmFieldService();
         service = new FindingAidService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidServiceTest.java
@@ -45,7 +45,7 @@ public class FindingAidServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
 
         fieldService = new CdmFieldService();
         service = new FindingAidService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidServiceTest.java
@@ -45,7 +45,7 @@ public class FindingAidServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
 
         fieldService = new CdmFieldService();
         service = new FindingAidService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
@@ -66,7 +66,7 @@ public class GroupMappingServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
         Files.createDirectories(project.getExportPath());
 
         fieldService = new CdmFieldService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
@@ -15,33 +15,6 @@
  */
 package edu.unc.lib.boxc.migration.cdm.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
-import java.nio.file.Paths;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.Statement;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
-import edu.unc.lib.boxc.migration.cdm.test.OutputHelper;
-import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
 import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.exceptions.StateAlreadyExistsException;
 import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
@@ -50,7 +23,30 @@ import edu.unc.lib.boxc.migration.cdm.model.GroupMappingInfo.GroupMapping;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
 import edu.unc.lib.boxc.migration.cdm.options.GroupMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
+import edu.unc.lib.boxc.migration.cdm.test.OutputHelper;
+import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author bbpennel
@@ -70,7 +66,7 @@ public class GroupMappingServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user");
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
         Files.createDirectories(project.getExportPath());
 
         fieldService = new CdmFieldService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
@@ -67,7 +67,7 @@ public class GroupMappingServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
         fieldService = new CdmFieldService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactoryTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactoryTest.java
@@ -49,7 +49,7 @@ public class MigrationProjectFactoryTest {
     @Rule
     public final TemporaryFolder tmpFolder = new TemporaryFolder();
     private Path projectsBase;
-    private CdmEnvironment testEnv = CdmEnvironmentHelper.getTestEnv();
+    private String testEnv = CdmEnvironmentHelper.DEFAULT_ENV;
 
     @Before
     public void setup() throws Exception {
@@ -234,9 +234,6 @@ public class MigrationProjectFactoryTest {
         assertEquals("Project name did not match expected value", expName, properties.getName());
         assertEquals("CDM Collection ID did not match expected value", expCollId, properties.getCdmCollectionId());
         assertNotNull("Created date not set", properties.getCreatedDate());
-        var cdmEnv = properties.getCdmEnvironment();
-        assertEquals(42222, cdmEnv.getSshPort());
-        assertEquals("localhost", cdmEnv.getSshHost());
-        assertEquals("http://localhost:46888", cdmEnv.getHttpBaseUrl());
+        assertEquals("test", properties.getCdmEnvironment());
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactoryTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactoryTest.java
@@ -26,7 +26,6 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import edu.unc.lib.boxc.migration.cdm.model.CdmEnvironment;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,7 +48,7 @@ public class MigrationProjectFactoryTest {
     @Rule
     public final TemporaryFolder tmpFolder = new TemporaryFolder();
     private Path projectsBase;
-    private String testEnv = CdmEnvironmentHelper.DEFAULT_ENV;
+    private String testEnv = CdmEnvironmentHelper.DEFAULT_ENV_ID;
 
     @Before
     public void setup() throws Exception {
@@ -234,6 +233,6 @@ public class MigrationProjectFactoryTest {
         assertEquals("Project name did not match expected value", expName, properties.getName());
         assertEquals("CDM Collection ID did not match expected value", expCollId, properties.getCdmCollectionId());
         assertNotNull("Created date not set", properties.getCreatedDate());
-        assertEquals("test", properties.getCdmEnvironment());
+        assertEquals("test", properties.getCdmEnvironmentId());
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactoryTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactoryTest.java
@@ -26,6 +26,8 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import edu.unc.lib.boxc.migration.cdm.model.CdmEnvironment;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,6 +49,7 @@ public class MigrationProjectFactoryTest {
     @Rule
     public final TemporaryFolder tmpFolder = new TemporaryFolder();
     private Path projectsBase;
+    private CdmEnvironment testEnv = CdmEnvironmentHelper.getTestEnv();
 
     @Before
     public void setup() throws Exception {
@@ -57,7 +60,7 @@ public class MigrationProjectFactoryTest {
     @Test
     public void createNoUserTest() throws Exception {
         try {
-            MigrationProjectFactory.createMigrationProject(projectsBase, null, null, null);
+            MigrationProjectFactory.createMigrationProject(projectsBase, null, null, null, testEnv);
             fail();
         } catch (IllegalArgumentException e) {
             // Expected
@@ -68,7 +71,7 @@ public class MigrationProjectFactoryTest {
     @Test
     public void createWithNameTest() throws Exception {
         MigrationProject project = MigrationProjectFactory
-                .createMigrationProject(projectsBase, PROJ_NAME, null, USERNAME);
+                .createMigrationProject(projectsBase, PROJ_NAME, null, USERNAME, testEnv);
 
         assertNotNull(project);
         assertEquals(projectsBase.resolve(PROJ_NAME), project.getProjectPath());
@@ -83,7 +86,7 @@ public class MigrationProjectFactoryTest {
         Files.createDirectory(projectsBase.resolve(PROJ_NAME));
 
         MigrationProject project = MigrationProjectFactory
-                .createMigrationProject(projectsBase, PROJ_NAME, null, USERNAME);
+                .createMigrationProject(projectsBase, PROJ_NAME, null, USERNAME, testEnv);
 
         assertNotNull(project);
         assertEquals(projectsBase.resolve(PROJ_NAME), project.getProjectPath());
@@ -97,7 +100,7 @@ public class MigrationProjectFactoryTest {
         Files.createFile(projectsBase.resolve(PROJ_NAME));
         try {
             // Create file at expected project path
-            MigrationProjectFactory.createMigrationProject(projectsBase, PROJ_NAME, null, USERNAME);
+            MigrationProjectFactory.createMigrationProject(projectsBase, PROJ_NAME, null, USERNAME, testEnv);
             fail();
         } catch (InvalidProjectStateException e) {
             assertTrue(e.getMessage().contains("already exists and is not a directory"));
@@ -107,7 +110,7 @@ public class MigrationProjectFactoryTest {
     @Test
     public void createWithNameAndCollectionTest() throws Exception {
         MigrationProject project = MigrationProjectFactory
-                .createMigrationProject(projectsBase, PROJ_NAME, COLL_ID, USERNAME);
+                .createMigrationProject(projectsBase, PROJ_NAME, COLL_ID, USERNAME, testEnv);
 
         assertNotNull(project);
         assertEquals(projectsBase.resolve(PROJ_NAME), project.getProjectPath());
@@ -123,7 +126,7 @@ public class MigrationProjectFactoryTest {
         Files.createDirectory(projectPath);
 
         MigrationProject project = MigrationProjectFactory
-                .createMigrationProject(projectPath, null, null, USERNAME);
+                .createMigrationProject(projectPath, null, null, USERNAME, testEnv);
 
         assertNotNull(project);
         assertEquals(projectPath, project.getProjectPath());
@@ -139,7 +142,7 @@ public class MigrationProjectFactoryTest {
         Files.createDirectory(projectPath);
 
         MigrationProject project = MigrationProjectFactory
-                .createMigrationProject(projectPath, null, COLL_ID, USERNAME);
+                .createMigrationProject(projectPath, null, COLL_ID, USERNAME, testEnv);
 
         assertNotNull(project);
         assertEquals(projectPath, project.getProjectPath());
@@ -151,11 +154,11 @@ public class MigrationProjectFactoryTest {
     @Test
     public void createProjectAlreadyExistsTest() throws Exception {
         MigrationProject project = MigrationProjectFactory
-                .createMigrationProject(projectsBase, PROJ_NAME, null, USERNAME);
+                .createMigrationProject(projectsBase, PROJ_NAME, null, USERNAME, testEnv);
 
         try {
             // Create file at expected project path
-            MigrationProjectFactory.createMigrationProject(projectsBase, PROJ_NAME, COLL_ID, USERNAME);
+            MigrationProjectFactory.createMigrationProject(projectsBase, PROJ_NAME, COLL_ID, USERNAME, testEnv);
             fail();
         } catch (InvalidProjectStateException e) {
             assertTrue(e.getMessage().contains("directory already contains a migration project"));
@@ -199,7 +202,7 @@ public class MigrationProjectFactoryTest {
     public void loadValidProject() throws Exception {
         Path projectPath = projectsBase.resolve(PROJ_NAME);
         MigrationProject projectCreated = MigrationProjectFactory
-                .createMigrationProject(projectsBase, PROJ_NAME, COLL_ID, USERNAME);
+                .createMigrationProject(projectsBase, PROJ_NAME, COLL_ID, USERNAME, testEnv);
 
         MigrationProject projectLoaded = MigrationProjectFactory.loadMigrationProject(projectPath);
 
@@ -231,5 +234,9 @@ public class MigrationProjectFactoryTest {
         assertEquals("Project name did not match expected value", expName, properties.getName());
         assertEquals("CDM Collection ID did not match expected value", expCollId, properties.getCdmCollectionId());
         assertNotNull("Created date not set", properties.getCreatedDate());
+        var cdmEnv = properties.getCdmEnvironment();
+        assertEquals(42222, cdmEnv.getSshPort());
+        assertEquals("localhost", cdmEnv.getSshHost());
+        assertEquals("http://localhost:46888", cdmEnv.getHttpBaseUrl());
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ProjectPropertiesServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ProjectPropertiesServiceTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,7 +51,7 @@ public class ProjectPropertiesServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user");
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
         service = new ProjectPropertiesService();
         service.setProject(project);
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ProjectPropertiesServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ProjectPropertiesServiceTest.java
@@ -51,7 +51,7 @@ public class ProjectPropertiesServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         service = new ProjectPropertiesService();
         service.setProject(project);
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ProjectPropertiesServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ProjectPropertiesServiceTest.java
@@ -51,7 +51,7 @@ public class ProjectPropertiesServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
         service = new ProjectPropertiesService();
         service.setProject(project);
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingIndexServiceTest.java
@@ -64,7 +64,7 @@ public class RedirectMappingIndexServiceTest {
     public void setup() throws Exception {
         tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
         redirectMappingHelper = new RedirectMappingHelper(project);
         redirectMappingHelper.createRedirectMappingsTableInDb();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingIndexServiceTest.java
@@ -64,7 +64,7 @@ public class RedirectMappingIndexServiceTest {
     public void setup() throws Exception {
         tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
         testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
         redirectMappingHelper = new RedirectMappingHelper(project);
         redirectMappingHelper.createRedirectMappingsTableInDb();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingIndexServiceTest.java
@@ -17,6 +17,7 @@ package edu.unc.lib.boxc.migration.cdm.services;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.RedirectMappingHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import org.apache.commons.csv.CSVFormat;
@@ -63,7 +64,7 @@ public class RedirectMappingIndexServiceTest {
     public void setup() throws Exception {
         tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user");
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
         testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
         redirectMappingHelper = new RedirectMappingHelper(project);
         redirectMappingHelper.createRedirectMappingsTableInDb();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -80,7 +80,7 @@ public class SipServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.getTestEnv());
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV);
 
         testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
         service = testHelper.createSipsService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -22,7 +22,7 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationSip;
 import edu.unc.lib.boxc.migration.cdm.options.GroupMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.options.SipGenerationOptions;
-import edu.unc.lib.boxc.migration.cdm.options.SourceFileMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import edu.unc.lib.boxc.model.api.rdf.Cdr;
 import edu.unc.lib.boxc.model.api.rdf.CdrAcl;
@@ -40,7 +40,6 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.RDF;
 import org.jdom2.Document;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -81,7 +80,7 @@ public class SipServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME);
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.getTestEnv());
 
         testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
         service = testHelper.createSipsService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -80,7 +80,7 @@ public class SipServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
 
         testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
         service = testHelper.createSipsService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
@@ -29,6 +29,7 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.List;
 
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.OutputHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import org.junit.Before;
@@ -66,7 +67,7 @@ public class SourceFileServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user");
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
         Files.createDirectories(project.getExportPath());
 
         basePath = tmpFolder.newFolder().toPath();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -33,7 +32,6 @@ import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.OutputHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -67,7 +65,7 @@ public class SourceFileServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
         basePath = tmpFolder.newFolder().toPath();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
@@ -67,7 +67,7 @@ public class SourceFileServiceTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
         Files.createDirectories(project.getExportPath());
 
         basePath = tmpFolder.newFolder().toPath();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportProgressServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportProgressServiceTest.java
@@ -37,7 +37,7 @@ public class ExportProgressServiceTest extends AbstractOutputTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);
         exportProgressService = new ExportProgressService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportProgressServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportProgressServiceTest.java
@@ -18,6 +18,7 @@ package edu.unc.lib.boxc.migration.cdm.services.export;
 import edu.unc.lib.boxc.migration.cdm.AbstractOutputTest;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -36,7 +37,7 @@ public class ExportProgressServiceTest extends AbstractOutputTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user");
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);
         exportProgressService = new ExportProgressService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportProgressServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportProgressServiceTest.java
@@ -37,7 +37,7 @@ public class ExportProgressServiceTest extends AbstractOutputTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);
         exportProgressService = new ExportProgressService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
@@ -52,7 +52,7 @@ public class ExportStateServiceTest {
     public void setup() throws Exception {
         tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
         Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
@@ -52,7 +52,7 @@ public class ExportStateServiceTest {
     public void setup() throws Exception {
         tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
@@ -19,22 +19,21 @@ import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static edu.unc.lib.boxc.migration.cdm.services.export.ExportState.ProgressState;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static edu.unc.lib.boxc.migration.cdm.services.export.ExportState.ProgressState;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -53,7 +52,7 @@ public class ExportStateServiceTest {
     public void setup() throws Exception {
         tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user");
+                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.getTestEnv());
         Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusServiceTest.java
@@ -51,7 +51,7 @@ public class DestinationsStatusServiceTest extends AbstractOutputTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
 
         testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
         statusService = new DestinationsStatusService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusServiceTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -50,7 +51,7 @@ public class DestinationsStatusServiceTest extends AbstractOutputTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME);
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.getTestEnv());
 
         testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
         statusService = new DestinationsStatusService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusServiceTest.java
@@ -51,7 +51,7 @@ public class DestinationsStatusServiceTest extends AbstractOutputTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.getTestEnv());
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV);
 
         testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
         statusService = new DestinationsStatusService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusServiceTest.java
@@ -52,7 +52,7 @@ public class SourceFilesStatusServiceTest extends AbstractOutputTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
 
         testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
         statusService = new SourceFilesStatusService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusServiceTest.java
@@ -52,7 +52,7 @@ public class SourceFilesStatusServiceTest extends AbstractOutputTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.getTestEnv());
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV);
 
         testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
         statusService = new SourceFilesStatusService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusServiceTest.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
 
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -51,7 +52,7 @@ public class SourceFilesStatusServiceTest extends AbstractOutputTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME);
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.getTestEnv());
 
         testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
         statusService = new SourceFilesStatusService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/CdmEnvironmentHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/CdmEnvironmentHelper.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.migration.cdm.test;
+
+import edu.unc.lib.boxc.migration.cdm.model.CdmEnvironment;
+
+import java.nio.file.Paths;
+import java.util.Map;
+
+/**
+ * Test helpers for working with cdm environment
+ *
+ * @author bbpennel
+ */
+public class CdmEnvironmentHelper {
+    public static final int TEST_HTTP_PORT = 46888;
+    public static final String TEST_BASE_URL = "http://localhost:" + TEST_HTTP_PORT;
+    public static final int TEST_SSH_PORT = 42222;
+    public static final String TEST_SSH_HOST = "localhost";
+
+    private CdmEnvironmentHelper() {
+    }
+
+    /**
+     * @return environment mapping containing test environment
+     */
+    public static Map<String, CdmEnvironment> getTestMapping() {
+        return Map.of("test", getTestEnv());
+    }
+
+    /**
+     * @return CdmEnvironment for a test environment
+     */
+    public static CdmEnvironment getTestEnv() {
+        var testEnv = new CdmEnvironment();
+        testEnv.setHttpBaseUrl(TEST_BASE_URL);
+        testEnv.setSshPort(TEST_SSH_PORT);
+        testEnv.setSshHost(TEST_SSH_HOST);
+        testEnv.setSshDownloadBasePath(Paths.get("src/test/resources/descriptions").toString());
+        return testEnv;
+    }
+}

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/CdmEnvironmentHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/CdmEnvironmentHelper.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.boxc.migration.cdm.test;
 
 import edu.unc.lib.boxc.migration.cdm.model.CdmEnvironment;
+import edu.unc.lib.boxc.migration.cdm.services.ChompbConfigService;
 
 import java.nio.file.Paths;
 import java.util.Map;
@@ -30,6 +31,7 @@ public class CdmEnvironmentHelper {
     public static final String TEST_BASE_URL = "http://localhost:" + TEST_HTTP_PORT;
     public static final int TEST_SSH_PORT = 42222;
     public static final String TEST_SSH_HOST = "localhost";
+    public static final String DEFAULT_ENV = "test";
 
     private CdmEnvironmentHelper() {
     }
@@ -38,7 +40,7 @@ public class CdmEnvironmentHelper {
      * @return environment mapping containing test environment
      */
     public static Map<String, CdmEnvironment> getTestMapping() {
-        return Map.of("test", getTestEnv());
+        return Map.of(DEFAULT_ENV, getTestEnv());
     }
 
     /**

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/CdmEnvironmentHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/CdmEnvironmentHelper.java
@@ -16,7 +16,6 @@
 package edu.unc.lib.boxc.migration.cdm.test;
 
 import edu.unc.lib.boxc.migration.cdm.model.CdmEnvironment;
-import edu.unc.lib.boxc.migration.cdm.services.ChompbConfigService;
 
 import java.nio.file.Paths;
 import java.util.Map;
@@ -31,7 +30,7 @@ public class CdmEnvironmentHelper {
     public static final String TEST_BASE_URL = "http://localhost:" + TEST_HTTP_PORT;
     public static final int TEST_SSH_PORT = 42222;
     public static final String TEST_SSH_HOST = "localhost";
-    public static final String DEFAULT_ENV = "test";
+    public static final String DEFAULT_ENV_ID = "test";
 
     private CdmEnvironmentHelper() {
     }
@@ -40,7 +39,7 @@ public class CdmEnvironmentHelper {
      * @return environment mapping containing test environment
      */
     public static Map<String, CdmEnvironment> getTestMapping() {
-        return Map.of(DEFAULT_ENV, getTestEnv());
+        return Map.of(DEFAULT_ENV_ID, getTestEnv());
     }
 
     /**

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DescriptionsValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DescriptionsValidatorTest.java
@@ -25,6 +25,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -53,7 +54,7 @@ public class DescriptionsValidatorTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME);
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.getTestEnv());
 
         validator = new DescriptionsValidator();
         validator.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DescriptionsValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DescriptionsValidatorTest.java
@@ -54,7 +54,7 @@ public class DescriptionsValidatorTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.getTestEnv());
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV);
 
         validator = new DescriptionsValidator();
         validator.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DescriptionsValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DescriptionsValidatorTest.java
@@ -54,7 +54,7 @@ public class DescriptionsValidatorTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
 
         validator = new DescriptionsValidator();
         validator.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DestinationsValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DestinationsValidatorTest.java
@@ -51,7 +51,7 @@ public class DestinationsValidatorTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
 
         validator = new DestinationsValidator();
         validator.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DestinationsValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DestinationsValidatorTest.java
@@ -51,7 +51,7 @@ public class DestinationsValidatorTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.getTestEnv());
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV);
 
         validator = new DestinationsValidator();
         validator.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DestinationsValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DestinationsValidatorTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -50,7 +51,7 @@ public class DestinationsValidatorTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME);
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.getTestEnv());
 
         validator = new DestinationsValidator();
         validator.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/SourceFilesValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/SourceFilesValidatorTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -52,7 +53,7 @@ public class SourceFilesValidatorTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME);
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.getTestEnv());
 
         validator = new SourceFilesValidator();
         validator.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/SourceFilesValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/SourceFilesValidatorTest.java
@@ -53,7 +53,7 @@ public class SourceFilesValidatorTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV);
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
 
         validator = new SourceFilesValidator();
         validator.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/SourceFilesValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/SourceFilesValidatorTest.java
@@ -53,7 +53,7 @@ public class SourceFilesValidatorTest {
     @Before
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.getTestEnv());
+                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV);
 
         validator = new SourceFilesValidator();
         validator.setProject(project);


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3665

* CDM environment is now specified by providing a `-e` option during the `init` command
* Partially migrated application configuration over to a json file rather than passing in via environment variables/options, to accomodate the need for providing info about multiple CDM servers
    * the CLIMain parent command provides access to the application configuration for any commands that need it
    * Removed a number of options that are now covered by the config
    * Moved to a static port for mock web server so that the port could be included in test config files
* Some consolidation of common steps in ITs into parent class, in part ot make it easier to provide new config
* Restart export if trying to resume and still in downloading desc.all phase, rather than blocking user from proceeding.