### PR TITLE
WIP: BXC-3683 - Add descriptions to child of compounds/groups

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
@@ -230,6 +230,10 @@ public class SipService {
 
                     SourceFileMapping sourceMapping = getSourceFileMapping(cdmId);
                     PID filePid = addFileObject(cdmId, cdmCreated, sourceMapping);
+                    var childDescPath = getDescriptionPath(cdmId, true);
+                    if (childDescPath != null) {
+                        copyDescriptionToSip(filePid, childDescPath);
+                    }
 
                     childPids.add(filePid);
                 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -28,6 +28,7 @@ import edu.unc.lib.boxc.model.api.rdf.Cdr;
 import edu.unc.lib.boxc.model.api.rdf.CdrAcl;
 import edu.unc.lib.boxc.model.api.rdf.CdrDeposit;
 import edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -476,8 +477,11 @@ public class SipServiceTest {
         assertEquals(2, depBagChildren.size());
 
         Resource workResc1 = testHelper.getResourceByCreateTime(depBagChildren, "2005-11-23");
-        testHelper.assertGroupedWorkPopulatedInSip(workResc1, dirManager, model, "grp:groupa:group1", false,
+        Bag work1Bag = testHelper.assertGroupedWorkPopulatedInSip(workResc1, dirManager, model, "grp:groupa:group1", false,
                 stagingLocs.get(0), stagingLocs.get(1));
+        // Assert that children of grouped work have descriptions added (only second file as a description)
+        Resource work1File2Resc = testHelper.findChildByStagingLocation(work1Bag, stagingLocs.get(1));
+        testHelper.assertModsPresentWithCdmId(dirManager, PIDs.get(work1File2Resc.getURI()), "26");
         Resource workResc3 = testHelper.getResourceByCreateTime(depBagChildren, "2005-12-08");
         testHelper.assertObjectPopulatedInSip(workResc3, dirManager, model, stagingLocs.get(2), null, "27");
 
@@ -516,8 +520,12 @@ public class SipServiceTest {
         assertEquals(2, depBagChildren.size());
 
         Resource workResc1 = testHelper.getResourceByCreateTime(depBagChildren, "2005-11-23");
-        testHelper.assertGroupedWorkPopulatedInSip(workResc1, dirManager, model, "grp:groupa:group1", true,
+        Bag work1Bag = testHelper.assertGroupedWorkPopulatedInSip(workResc1, dirManager, model, "grp:groupa:group1", true,
                 stagingLocs.get(0), accessLocs.get(0), stagingLocs.get(1), null);
+        // Assert that children of grouped work have descriptions added (only second file has a description)
+        Resource work1File2Resc = testHelper.findChildByStagingLocation(work1Bag, stagingLocs.get(1));
+        testHelper.assertModsPresentWithCdmId(dirManager, PIDs.get(work1File2Resc.getURI()), "26");
+
         Resource workResc3 = testHelper.getResourceByCreateTime(depBagChildren, "2005-12-08");
         testHelper.assertObjectPopulatedInSip(workResc3, dirManager, model,
                 stagingLocs.get(2), accessLocs.get(1), "27");
@@ -555,12 +563,20 @@ public class SipServiceTest {
         Resource workResc1 = testHelper.getResourceByCreateTime(depBagChildren, "2012-05-18");
         testHelper.assertObjectPopulatedInSip(workResc1, dirManager, model, stagingLocs.get(0), null, "216");
         Resource workResc2 = testHelper.getResourceByCreateTime(depBagChildren, "2014-01-17");
-        testHelper.assertGroupedWorkPopulatedInSip(workResc2, dirManager, model, "604", false,
+        Bag work2Bag = testHelper.assertGroupedWorkPopulatedInSip(workResc2, dirManager, model, "604", false,
                 stagingLocs.get(1), stagingLocs.get(2));
+        // Verify that the children of the compound object have descriptions added
+        Resource work2File1Resc = testHelper.findChildByStagingLocation(work2Bag, stagingLocs.get(1));
+        testHelper.assertModsPresentWithCdmId(dirManager, PIDs.get(work2File1Resc.getURI()), "602");
+        Resource work2File2Resc = testHelper.findChildByStagingLocation(work2Bag, stagingLocs.get(2));
+        testHelper.assertModsPresentWithCdmId(dirManager, PIDs.get(work2File2Resc.getURI()), "603");
         Resource workResc3 = testHelper.getResourceByCreateTime(depBagChildren, "2014-02-17");
-        testHelper.assertGroupedWorkPopulatedInSip(workResc3, dirManager, model, "607", false,
+        Bag work3Bag = testHelper.assertGroupedWorkPopulatedInSip(workResc3, dirManager, model, "607", false,
                 stagingLocs.get(3), stagingLocs.get(4));
-
+        Resource work3File1Resc = testHelper.findChildByStagingLocation(work3Bag, stagingLocs.get(3));
+        testHelper.assertModsPresentWithCdmId(dirManager, PIDs.get(work3File1Resc.getURI()), "605");
+        Resource work3File2Resc = testHelper.findChildByStagingLocation(work3Bag, stagingLocs.get(4));
+        testHelper.assertModsPresentWithCdmId(dirManager, PIDs.get(work3File2Resc.getURI()), "606");
         assertPersistedSipInfoMatches(sip);
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
@@ -182,10 +182,12 @@ public class SipServiceHelper {
      * @param filePaths if withAccessCopies is false, then this is a list of staging paths. Otherwise,
      *      this array should alternate between staging and access paths, staging first. If there is no
      *       access path for an object, then null must be provided.
+     * @return the Bag resource representing the grouped work in the SIP's RDF model
      * @throws Exception
      */
-    public void assertGroupedWorkPopulatedInSip(Resource objResc, DepositDirectoryManager dirManager, Model depModel,
-            String cdmId, boolean withAccessCopies, Path... filePaths) throws Exception {
+    public Bag assertGroupedWorkPopulatedInSip(Resource objResc, DepositDirectoryManager dirManager,
+                                                         Model depModel, String cdmId, boolean withAccessCopies,
+                                                         Path... filePaths) throws Exception {
         List<Path> stagingPaths;
         List<Path> accessPaths = null;
         if (withAccessCopies) {
@@ -210,11 +212,7 @@ public class SipServiceHelper {
 
         for (int i = 0; i < stagingPaths.size(); i++) {
             Path stagingPath = stagingPaths.get(i);
-            String stagingUri = stagingPath.toUri().toString();
-            Resource fileObjResc = workChildren.stream().map(RDFNode::asResource)
-                .filter(c -> c.getProperty(CdrDeposit.hasDatastreamOriginal).getResource()
-                    .hasLiteral(CdrDeposit.stagingLocation, stagingUri))
-                .findFirst().get();
+            Resource fileObjResc = findChildByStagingLocation(workChildren, stagingPath);
             assertTrue(fileObjResc.hasProperty(RDF.type, Cdr.FileObject));
 
             Resource origResc = fileObjResc.getProperty(CdrDeposit.hasDatastreamOriginal).getResource();
@@ -239,6 +237,24 @@ public class SipServiceHelper {
         assertMigrationEventPresent(dirManager, workPid);
 
         assertModsPresentWithCdmId(dirManager, workPid, cdmId);
+        return workBag;
+    }
+
+    public Resource findChildByStagingLocation(Bag workBag, Path stagingPath) {
+        return findChildByStagingLocation(workBag.iterator().toList(), stagingPath);
+    }
+
+    /**
+     * @param workChildren
+     * @param stagingPath
+     * @return resource of child from the provided list which has a stagingLocation matching the provided value
+     */
+    public Resource findChildByStagingLocation(List<RDFNode> workChildren, Path stagingPath) {
+        String stagingUri = stagingPath.toUri().toString();
+        return workChildren.stream().map(RDFNode::asResource)
+                .filter(c -> c.getProperty(CdrDeposit.hasDatastreamOriginal).getResource()
+                        .hasLiteral(CdrDeposit.stagingLocation, stagingUri))
+                .findFirst().get();
     }
 
     public Resource getResourceByCreateTime(List<RDFNode> depBagChildren, String createTime) {

--- a/src/test/resources/mods_collections/grouped_mods.xml
+++ b/src/test/resources/mods_collections/grouped_mods.xml
@@ -5,10 +5,6 @@
         <mods:identifier type="local" displayLabel="CONTENTdm number">grp:groupa:group1</mods:identifier>
     </mods:mods>
     <mods:mods>
-        <mods:titleInfo><mods:title>Redoubt C</mods:title></mods:titleInfo>
-        <mods:identifier type="local" displayLabel="CONTENTdm number">25</mods:identifier>
-    </mods:mods>
-    <mods:mods>
         <mods:titleInfo><mods:title>Plan of Battery McIntosh</mods:title></mods:titleInfo>
         <mods:identifier>276/183</mods:identifier>
         <mods:identifier type="local" displayLabel="CONTENTdm number">26</mods:identifier>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3693

* Add descriptions to files in compound/group works when present, but make it optional. 
* Verify that they get added in tests
* Adjust test mods document to have one fileObject that does not have a MODS record to ensure that it is optional.