### PR TITLE
BXC-3838 - Enable generation of empty source_files.csv mapping file

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommand.java
@@ -144,8 +144,12 @@ public class SourceFilesCommand {
     }
 
     private void validateOptions(SourceFileMappingOptions options) {
+        // If populating a blank mapping then other arguments not needed.
+        if (options.isPopulateBlank()) {
+            return;
+        }
         if (options.getBasePath() == null) {
-            throw new IllegalArgumentException("Must provide a base path");
+            throw new IllegalArgumentException("Must provide a base path or provide the --blank flag");
         }
         if (StringUtils.isBlank(options.getExportField())) {
             throw new IllegalArgumentException("Must provide an export field");

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/SourceFileMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/SourceFileMappingOptions.java
@@ -94,6 +94,11 @@ public class SourceFileMappingOptions {
             description = "Overwrite mapping file if one already exists")
     private boolean force;
 
+    @Option(names = { "-B", "--blank"},
+            description = "Populate a blank source mapping file. Entries will be added for each object as per normal,"
+                    + " but without attempting to map them to any files")
+    private boolean populateBlank;
+
     public Path getBasePath() {
         return basePath;
     }
@@ -164,5 +169,13 @@ public class SourceFileMappingOptions {
 
     public void setForce(boolean force) {
         this.force = force;
+    }
+
+    public boolean isPopulateBlank() {
+        return populateBlank;
+    }
+
+    public void setPopulateBlank(boolean populateBlank) {
+        this.populateBlank = populateBlank;
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
@@ -301,6 +301,18 @@ public class SourceFilesCommandIT extends AbstractCommandIT {
         assertOutputMatches(".*Unmapped Objects: +0.*");
     }
 
+    @Test
+    public void generateBlankSucceedsTest() throws Exception {
+        indexExportSamples();
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "source_files", "generate",
+                "-B"};
+        executeExpectSuccess(args);
+
+        assertTrue(Files.exists(project.getSourceFilesMappingPath()));
+    }
+
     private void indexExportSamples() throws Exception {
         testHelper.indexExportData("mini_gilmer");
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
@@ -540,6 +540,53 @@ public class SourceFileServiceTest {
         assertMappedDatePresent();
     }
 
+    @Test
+    public void generateBlankTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        SourceFileMappingOptions options = new SourceFileMappingOptions();
+        options.setPopulateBlank(true);
+
+        service.generateMapping(options);
+
+        SourceFilesInfo info = service.loadMappings();
+        assertMappingPresent(info, "25", "", null);
+        assertMappingPresent(info, "26", "", null);
+        assertMappingPresent(info, "27", "", null);
+
+        assertMappedDatePresent();
+    }
+
+    @Test
+    public void generateRespectsForceFlagTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        SourceFileMappingOptions options = new SourceFileMappingOptions();
+        options.setPopulateBlank(true);
+
+        service.generateMapping(options);
+
+        SourceFilesInfo info = service.loadMappings();
+        assertMappingPresent(info, "25", "", null);
+        assertMappingPresent(info, "26", "", null);
+        assertMappingPresent(info, "27", "", null);
+        assertEquals(3, info.getMappings().size());
+
+        try {
+            service.generateMapping(options);
+            fail();
+        } catch (MigrationException e) {
+            assertTrue(e.getMessage().contains("Cannot create mapping, a file already exists"));
+        }
+
+        options.setForce(true);
+        service.generateMapping(options);
+
+        SourceFilesInfo info2 = service.loadMappings();
+        assertMappingPresent(info2, "25", "", null);
+        assertMappingPresent(info2, "26", "", null);
+        assertMappingPresent(info2, "27", "", null);
+        assertEquals(3, info2.getMappings().size());
+    }
+
     private void assertMappingPresent(SourceFilesInfo info, String cdmid, String matchingVal, Path sourcePath,
             Path... potentialPaths) {
         List<SourceFileMapping> mappings = info.getMappings();


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3838

Add flag to allow for generation of source file mappings without doing any actual mapping