### PR TITLE
Bxc 3835 new destination mapping command

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommand.java
@@ -133,8 +133,7 @@ public class DestinationsCommand {
         initialize();
         var destinationMappingExists = Files.exists(project.getDestinationMappingsPath());
         if (!destinationMappingExists) {
-          outputLogger.info("FAIL: Destination mapping at path " + project.getDestinationMappingsPath()
-                  + " does not exist");
+          outputLogger.info("FAIL: Destination mapping at path {} does not exist", project.getDestinationMappingsPath());
           return 1;
         }
         try {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommand.java
@@ -128,8 +128,16 @@ public class DestinationsCommand {
 
     @Command(name = "add",
             description = "Add custom destination for individual CDM ID or list of IDs")
-    public int add() {
-        return 0;
+    public int add(@Mixin DestinationMappingOptions options) throws Exception {
+        try {
+            validateOptions(options);
+            initialize();
+            destService.addMappings(options);
+            return 0;
+        } catch (MigrationException | IllegalArgumentException e) {
+            outputLogger.info("Cannot add mappings: {}", e.getMessage());
+            return 1;
+        }
     }
 
     private void validateOptions(DestinationMappingOptions options) {
@@ -139,6 +147,9 @@ public class DestinationsCommand {
         }
         if (options.getDefaultCollection() != null && StringUtils.isBlank(options.getDefaultCollection())) {
             throw new IllegalArgumentException("Default collection must not be blank");
+        }
+        if (options.getCdmId() != null && StringUtils.isBlank(options.getCdmId())) {
+            throw new IllegalArgumentException("CDM ID must not be blank");
         }
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommand.java
@@ -27,7 +27,7 @@ import org.slf4j.Logger;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
-import edu.unc.lib.boxc.migration.cdm.options.GenerateDestinationMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.options.DestinationMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
 import edu.unc.lib.boxc.migration.cdm.services.DestinationsService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
@@ -53,7 +53,7 @@ public class DestinationsCommand {
 
     @Command(name = "generate",
             description = "Generate the destination mapping file for this project")
-    public int generate(@Mixin GenerateDestinationMappingOptions options) throws Exception {
+    public int generate(@Mixin DestinationMappingOptions options) throws Exception {
         long start = System.nanoTime();
 
         try {
@@ -126,7 +126,13 @@ public class DestinationsCommand {
         }
     }
 
-    private void validateOptions(GenerateDestinationMappingOptions options) {
+    @Command(name = "add",
+            description = "Add custom destination for individual CDM ID or list of IDs")
+    public int add() {
+        return 0;
+    }
+
+    private void validateOptions(DestinationMappingOptions options) {
         // For now, the only kind of mapping is a default, so fail if not set
         if (StringUtils.isBlank(options.getDefaultDestination())) {
             throw new IllegalArgumentException("Must provide a default destination");

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommand.java
@@ -133,7 +133,8 @@ public class DestinationsCommand {
         initialize();
         var destinationMappingExists = Files.exists(project.getDestinationMappingsPath());
         if (!destinationMappingExists) {
-          outputLogger.info("FAIL: Destination mapping at path {} does not exist", project.getDestinationMappingsPath());
+          outputLogger.info("FAIL: Destination mapping at path {} does not exist",
+                  project.getDestinationMappingsPath());
           return 1;
         }
         try {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommand.java
@@ -130,6 +130,7 @@ public class DestinationsCommand {
     @Command(name = "add",
             description = "Add custom destination for individual CDM ID or list of IDs")
     public int add(@Mixin DestinationMappingOptions options) throws Exception {
+        initialize();
         var destinationMappingExists = Files.exists(project.getDestinationMappingsPath());
         if (!destinationMappingExists) {
           outputLogger.info("FAIL: Destination mapping at path " + project.getDestinationMappingsPath()
@@ -138,7 +139,6 @@ public class DestinationsCommand {
         }
         try {
             validateOptions(options);
-            initialize();
             destService.addMappings(options);
             return 0;
         } catch (MigrationException | IllegalArgumentException e) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommand.java
@@ -19,6 +19,7 @@ import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -129,6 +130,12 @@ public class DestinationsCommand {
     @Command(name = "add",
             description = "Add custom destination for individual CDM ID or list of IDs")
     public int add(@Mixin DestinationMappingOptions options) throws Exception {
+        var destinationMappingExists = Files.exists(project.getDestinationMappingsPath());
+        if (!destinationMappingExists) {
+          outputLogger.info("FAIL: Destination mapping at path " + project.getDestinationMappingsPath()
+                  + " does not exist");
+          return 1;
+        }
         try {
             validateOptions(options);
             initialize();

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/DestinationMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/DestinationMappingOptions.java
@@ -18,10 +18,15 @@ package edu.unc.lib.boxc.migration.cdm.options;
 import picocli.CommandLine.Option;
 
 /**
- * Destination mapping generation options
+ * Destination mapping options
  * @author bbpennel
  */
-public class GenerateDestinationMappingOptions {
+public class DestinationMappingOptions {
+    @Option(names = {"-id", "--cdm-id"},
+            description = {
+                    "CDM ID(s) going to a specific box-c deposit destination in this migration project.",
+                    "Must be a CDM ID or a comma-delimited list of CDM IDs"})
+    private String cdmId;
 
     @Option(names = {"-dd", "--default-dest"},
             description = {
@@ -36,7 +41,7 @@ public class GenerateDestinationMappingOptions {
                     "The default will be used during SIP generation for objects if they do not have explicit mappings.",
                     "If this is populated, a new collection will be created and used "
                             + "as the destination for objects mapped to the default destination.",
-                    "Can be any value that uniquely identifies objects that belong in this destiantion.",})
+                    "Can be any value that uniquely identifies objects that belong in this destination.",})
     private String defaultCollection;
 
     @Option(names = { "-f", "--force"},
@@ -66,4 +71,8 @@ public class GenerateDestinationMappingOptions {
     public void setForce(boolean force) {
         this.force = force;
     }
+
+    public String getCdmId() { return cdmId; }
+
+    public void setCdmId(String cdmId) { this.cdmId = cdmId; }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/DestinationMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/DestinationMappingOptions.java
@@ -72,7 +72,11 @@ public class DestinationMappingOptions {
         this.force = force;
     }
 
-    public String getCdmId() { return cdmId; }
+    public String getCdmId() {
+        return cdmId;
+    }
 
-    public void setCdmId(String cdmId) { this.cdmId = cdmId; }
+    public void setCdmId(String cdmId) {
+        this.cdmId = cdmId;
+    }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DestinationsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DestinationsService.java
@@ -137,6 +137,11 @@ public class DestinationsService {
         }
     }
 
+    /**
+     * Adds custom CDM ID mapping(s) to destination mappings file
+     * @param options
+     * @throws Exception
+     */
     public void addMappings(DestinationMappingOptions options) throws Exception {
         assertProjectStateValid();
         DestinationsValidator.assertValidDestination(options.getDefaultDestination());
@@ -148,9 +153,13 @@ public class DestinationsService {
                 CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.Builder.create().build());
         ) {
             if (options.getDefaultDestination() != null) {
-                csvPrinter.printRecord(options.getCdmId(),
-                        options.getDefaultDestination(),
-                        options.getDefaultCollection());
+                // value passed in for cdm ID might be a comma-delimited list, so split it first and loop through
+                var cdmIds = options.getCdmId().split(",");
+                for (String cdmId : cdmIds) {
+                    csvPrinter.printRecord(cdmId,
+                            options.getDefaultDestination(),
+                            options.getDefaultCollection());
+                }
             }
         }
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DestinationsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DestinationsService.java
@@ -149,7 +149,9 @@ public class DestinationsService {
         Path destinationMappingsPath = project.getDestinationMappingsPath();
 
         try (
-                BufferedWriter writer = Files.newBufferedWriter(destinationMappingsPath, StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+                BufferedWriter writer = Files.newBufferedWriter(destinationMappingsPath,
+                                                                StandardOpenOption.APPEND,
+                                                                StandardOpenOption.CREATE);
                 CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.Builder.create().build());
         ) {
             if (options.getDefaultDestination() != null) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DestinationsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DestinationsService.java
@@ -23,6 +23,7 @@ import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.util.List;
 
@@ -133,6 +134,24 @@ public class DestinationsService {
                 mappings.add(mapping);
             }
             return info;
+        }
+    }
+
+    public void addMappings(DestinationMappingOptions options) throws Exception {
+        assertProjectStateValid();
+        DestinationsValidator.assertValidDestination(options.getDefaultDestination());
+
+        Path destinationMappingsPath = project.getDestinationMappingsPath();
+
+        try (
+                BufferedWriter writer = Files.newBufferedWriter(destinationMappingsPath, StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+                CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.Builder.create().build());
+        ) {
+            if (options.getDefaultDestination() != null) {
+                csvPrinter.printRecord(options.getCdmId(),
+                        options.getDefaultDestination(),
+                        options.getDefaultCollection());
+            }
         }
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DestinationsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DestinationsService.java
@@ -38,7 +38,7 @@ import edu.unc.lib.boxc.migration.cdm.exceptions.StateAlreadyExistsException;
 import edu.unc.lib.boxc.migration.cdm.model.DestinationsInfo;
 import edu.unc.lib.boxc.migration.cdm.model.DestinationsInfo.DestinationMapping;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
-import edu.unc.lib.boxc.migration.cdm.options.GenerateDestinationMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.options.DestinationMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 import edu.unc.lib.boxc.migration.cdm.validators.DestinationsValidator;
 
@@ -55,7 +55,7 @@ public class DestinationsService {
      * Generate a destination mapping file for the project using the provided options
      * @param options
      */
-    public void generateMapping(GenerateDestinationMappingOptions options) throws IOException {
+    public void generateMapping(DestinationMappingOptions options) throws IOException {
         assertProjectStateValid();
         DestinationsValidator.assertValidDestination(options.getDefaultDestination());
         ensureMappingState(options.isForce());

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommandIT.java
@@ -251,7 +251,7 @@ public class DestinationsCommandIT extends AbstractCommandIT {
                 "-dd", CUSTOM_DEST_ID};
         executeExpectSuccess(args2);
 
-        assertCustomIdMappingAdded("25", 2);
+        assertCustomIdMappingAdded(getMappings(), "25", 1);
     }
     @Test
     public void addMultipleCdmIdCustomDestination() throws Exception {
@@ -271,9 +271,11 @@ public class DestinationsCommandIT extends AbstractCommandIT {
                 "-dd", CUSTOM_DEST_ID};
         executeExpectSuccess(args2);
 
-        assertCustomIdMappingAdded("25", 4);
-        assertCustomIdMappingAdded("26", 4);
-        assertCustomIdMappingAdded("27", 4);
+        var mappings = getMappings();
+        assertMappingCount(mappings, 4);
+        assertCustomIdMappingAdded(mappings, "25", 1);
+        assertCustomIdMappingAdded(mappings, "26", 2);
+        assertCustomIdMappingAdded(mappings, "27", 3);
     }
 
     @Test
@@ -306,7 +308,7 @@ public class DestinationsCommandIT extends AbstractCommandIT {
                 "-w", project.getProjectPath().toString(),
                 "destinations", "add",
                 "-dd", CUSTOM_DEST_ID,
-                "-id"};
+                "-id", ""};
         executeExpectFailure(args2);
         assertOutputContains("CDM ID must not be blank");
     }
@@ -341,7 +343,7 @@ public class DestinationsCommandIT extends AbstractCommandIT {
 
     private void assertDefaultMapping(String expectedDest, String expectedColl) throws Exception {
         var mappings = getMappings();
-        assertEquals(1, mappings.size());
+        assertMappingCount(mappings, 1);
         DestinationMapping mapping = mappings.get(0);
         assertEquals(DestinationsInfo.DEFAULT_ID, mapping.getId());
         assertEquals(expectedDest, mapping.getDestination());
@@ -353,12 +355,14 @@ public class DestinationsCommandIT extends AbstractCommandIT {
         return info.getMappings();
     }
 
-    private void assertCustomIdMappingAdded(String id, int count) throws IOException {
-        var mappings = getMappings();
-        assertEquals(count, mappings.size());
-        DestinationMapping mapping = mappings.get(count - 1);
+    private void assertCustomIdMappingAdded(List<DestinationMapping> mappings, String id, int index) {
+        DestinationMapping mapping = mappings.get(index);
         assertEquals(id, mapping.getId());
         assertEquals(CUSTOM_DEST_ID, mapping.getDestination());
+    }
+
+    private void assertMappingCount(List<DestinationMapping> mappings, int count) {
+        assertEquals(count, mappings.size());
     }
 
     private void setIndexedDate() throws Exception {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommandIT.java
@@ -305,10 +305,10 @@ public class DestinationsCommandIT extends AbstractCommandIT {
         String[] args2 = new String[] {
                 "-w", project.getProjectPath().toString(),
                 "destinations", "add",
-                "-id",
-                "-dd", CUSTOM_DEST_ID};
+                "-dd", CUSTOM_DEST_ID,
+                "-id"};
         executeExpectFailure(args2);
-        assertOutputContains("Must provide a CDM ID");
+        assertOutputContains("CDM ID must not be blank");
     }
 
     @Test
@@ -356,7 +356,7 @@ public class DestinationsCommandIT extends AbstractCommandIT {
     private void assertCustomIdMappingAdded(String id, int count) throws IOException {
         var mappings = getMappings();
         assertEquals(count, mappings.size());
-        DestinationMapping mapping = mappings.get(0);
+        DestinationMapping mapping = mappings.get(count - 1);
         assertEquals(id, mapping.getId());
         assertEquals(CUSTOM_DEST_ID, mapping.getDestination());
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
@@ -27,7 +27,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,7 +37,6 @@ import java.util.stream.Collectors;
 
 import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
 import edu.unc.lib.boxc.migration.cdm.services.ChompbConfigService;
-import edu.unc.lib.boxc.migration.cdm.services.RedirectMappingIndexService;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
@@ -53,7 +51,7 @@ import edu.unc.lib.boxc.common.xml.SecureXMLFactory;
 import edu.unc.lib.boxc.deposit.impl.model.DepositDirectoryManager;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationSip;
-import edu.unc.lib.boxc.migration.cdm.options.GenerateDestinationMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.options.DestinationMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.options.SourceFileMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.services.AccessFileService;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
@@ -297,7 +295,7 @@ public class SipServiceHelper {
     }
 
     public void generateDefaultDestinationsMapping(String defDest, String defColl) throws Exception {
-        GenerateDestinationMappingOptions options = new GenerateDestinationMappingOptions();
+        DestinationMappingOptions options = new DestinationMappingOptions();
         options.setDefaultDestination(defDest);
         options.setDefaultCollection(defColl);
         destinationsService.generateMapping(options);


### PR DESCRIPTION
This PR adds the ability to add a custom destination mapping by specifying a CDM ID (or comma-delimited list of IDs). It will add a new row to the destination mappings file specifying the CDM ID, the destination mapping and collection (if included).

https://jira.lib.unc.edu/browse/BXC-3835