### PR TITLE
Bxc 3881 postmigration object type report

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
@@ -2,7 +2,6 @@ package edu.unc.lib.boxc.migration.cdm;
 
 import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
 import edu.unc.lib.boxc.migration.cdm.services.ChompbConfigService;
-import edu.unc.lib.boxc.migration.cdm.services.MigrationTypeReportService;
 import edu.unc.lib.boxc.migration.cdm.util.BannerUtility;
 import edu.unc.lib.boxc.migration.cdm.util.CLIConstants;
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
@@ -2,6 +2,7 @@ package edu.unc.lib.boxc.migration.cdm;
 
 import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
 import edu.unc.lib.boxc.migration.cdm.services.ChompbConfigService;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationTypeReportService;
 import edu.unc.lib.boxc.migration.cdm.util.BannerUtility;
 import edu.unc.lib.boxc.migration.cdm.util.CLIConstants;
 import org.apache.commons.lang3.StringUtils;
@@ -36,7 +37,8 @@ import java.util.concurrent.Callable;
         GroupMappingCommand.class,
         IndexRedirectCommand.class,
         ProjectPropertiesCommand.class,
-        VerifyPostMigrationCommand.class
+        VerifyPostMigrationCommand.class,
+        MigrationTypeReportCommand.class
     })
 public class CLIMain implements Callable<Integer> {
     @Option(names = { "-w", "--work-dir" },

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/MigrationTypeReportCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/MigrationTypeReportCommand.java
@@ -1,0 +1,47 @@
+package edu.unc.lib.boxc.migration.cdm;
+
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationTypeReportService;
+import picocli.CommandLine;
+
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+
+/**
+ * @author krwong
+ */
+@CommandLine.Command(name = "report_migration_types",
+        description = "Counts new migrated works and files")
+public class MigrationTypeReportCommand implements Callable<Integer> {
+    @CommandLine.ParentCommand
+    private CLIMain parentCommand;
+    private MigrationTypeReportService typeReportService;
+    private MigrationProject project;
+
+
+    public void init() throws Exception {
+        Path currentPath = parentCommand.getWorkingDirectory();
+        project = MigrationProjectFactory.loadMigrationProject(currentPath);
+        typeReportService = new MigrationTypeReportService();
+        typeReportService.setProject(project);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        try {
+            long start = System.nanoTime();
+            init();
+            String numWorks = String.valueOf(typeReportService.countWorks());
+            String numFiles = String.valueOf(typeReportService.countFiles());
+            outputLogger.info("Number of Works: {}", numWorks);
+            outputLogger.info("Number of Files: {}", numFiles);
+            return 0;
+        } catch (Exception e) {
+            outputLogger.info("Encountered an error while counting new objects", e);
+        }
+        return 1;
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/MigrationTypeReportCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/MigrationTypeReportCommand.java
@@ -5,7 +5,6 @@ import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationTypeReportService;
 import picocli.CommandLine;
 
-import java.io.FileNotFoundException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/MigrationTypeReportCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/MigrationTypeReportCommand.java
@@ -3,6 +3,7 @@ package edu.unc.lib.boxc.migration.cdm;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationTypeReportService;
+import org.slf4j.Logger;
 import picocli.CommandLine;
 
 import java.nio.file.NoSuchFileException;
@@ -10,6 +11,7 @@ import java.nio.file.Path;
 import java.util.concurrent.Callable;
 
 import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * @author krwong
@@ -17,6 +19,7 @@ import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
 @CommandLine.Command(name = "report_migration_types",
         description = "Counts new migrated works and files")
 public class MigrationTypeReportCommand implements Callable<Integer> {
+    private static final Logger log = getLogger(MigrationTypeReportCommand.class);
     @CommandLine.ParentCommand
     private CLIMain parentCommand;
     private MigrationTypeReportService typeReportService;
@@ -42,6 +45,7 @@ public class MigrationTypeReportCommand implements Callable<Integer> {
             outputLogger.info("Cannot generate migration types report. Post migration report not found: {}",
                     e.getMessage());
         } catch (Exception e) {
+            log.error("Encountered an error while counting new objects", e);
             outputLogger.info("Encountered an error while counting new objects: {}", e.getMessage());
         }
         return 1;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/MigrationTypeReportCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/MigrationTypeReportCommand.java
@@ -5,6 +5,8 @@ import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationTypeReportService;
 import picocli.CommandLine;
 
+import java.io.FileNotFoundException;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 
@@ -34,13 +36,14 @@ public class MigrationTypeReportCommand implements Callable<Integer> {
         try {
             long start = System.nanoTime();
             init();
-            String numWorks = String.valueOf(typeReportService.countWorks());
-            String numFiles = String.valueOf(typeReportService.countFiles());
-            outputLogger.info("Number of Works: {}", numWorks);
-            outputLogger.info("Number of Files: {}", numFiles);
+            outputLogger.info("Number of Works: {}", typeReportService.countWorks());
+            outputLogger.info("Number of Files: {}", typeReportService.countFiles());
             return 0;
+        } catch (NoSuchFileException e) {
+            outputLogger.info("Cannot generate migration types report. Post migration report not found: {}",
+                    e.getMessage());
         } catch (Exception e) {
-            outputLogger.info("Encountered an error while counting new objects", e);
+            outputLogger.info("Encountered an error while counting new objects: {}", e.getMessage());
         }
         return 1;
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationTypeReportService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationTypeReportService.java
@@ -2,6 +2,7 @@ package edu.unc.lib.boxc.migration.cdm.services;
 
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.util.PostMigrationReportConstants;
+import edu.unc.lib.boxc.model.api.ResourceType;
 import org.apache.commons.csv.CSVParser;
 import org.slf4j.Logger;
 
@@ -24,11 +25,13 @@ public class MigrationTypeReportService {
      * @return count new works
      */
     public long countWorks() throws IOException {
-        var csvParser = openCsvParser();
-        long numWorks = csvParser.stream()
-                .map(row -> row.get("boxc_obj_type"))
-                .filter(f -> f.toLowerCase().contains("work"))
-                .count();
+        long numWorks;
+        try (var csvParser = openCsvParser()) {
+            numWorks = csvParser.stream()
+                    .map(row -> row.get("boxc_obj_type"))
+                    .filter(f -> f.toLowerCase().contains("work") || f.contains(ResourceType.Work.name()))
+                    .count();
+        }
         return numWorks;
     }
 
@@ -36,11 +39,13 @@ public class MigrationTypeReportService {
      * @return count new files
      */
     public long countFiles() throws IOException {
-        var csvParser = openCsvParser();
-        long numFiles = csvParser.stream()
-                .map(row -> row.get("boxc_obj_type"))
-                .filter(f -> f.toLowerCase().contains("file"))
-                .count();
+        long numFiles;
+        try (var csvParser = openCsvParser()) {
+            numFiles = csvParser.stream()
+                    .map(row -> row.get("boxc_obj_type"))
+                    .filter(f -> f.toLowerCase().contains("file") || f.contains(ResourceType.File.name()))
+                    .count();
+        }
         return numFiles;
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationTypeReportService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationTypeReportService.java
@@ -1,0 +1,56 @@
+package edu.unc.lib.boxc.migration.cdm.services;
+
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.util.PostMigrationReportConstants;
+import org.apache.commons.csv.CSVParser;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Service for counting new migrated objects in box-c (works and files)
+ * @author krwong
+ */
+public class MigrationTypeReportService {
+    private static final Logger log = getLogger(MigrationTypeReportService.class);
+
+    private MigrationProject project;
+
+    /**
+     * @return count new works
+     */
+    public long countWorks() throws IOException {
+        var csvParser = openCsvParser();
+        long numWorks = csvParser.stream()
+                .map(row -> row.get("boxc_obj_type"))
+                .filter(f -> f.toLowerCase().contains("work"))
+                .count();
+        return numWorks;
+    }
+
+    /**
+     * @return count new files
+     */
+    public long countFiles() throws IOException {
+        var csvParser = openCsvParser();
+        long numFiles = csvParser.stream()
+                .map(row -> row.get("boxc_obj_type"))
+                .filter(f -> f.toLowerCase().contains("file"))
+                .count();
+        return numFiles;
+    }
+
+    private CSVParser openCsvParser() throws IOException {
+        Reader reader = Files.newBufferedReader(project.getPostMigrationReportPath());
+        return new CSVParser(reader, PostMigrationReportConstants.CSV_PARSER_FORMAT);
+    }
+
+    public void setProject(MigrationProject project) {
+        this.project = project;
+    }
+
+}

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/MigrationTypeReportCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/MigrationTypeReportCommandIT.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import static org.junit.Assert.assertFalse;
+
 /**
  * @author krwong
  */
@@ -30,5 +32,17 @@ public class MigrationTypeReportCommandIT extends AbstractCommandIT {
 
         assertOutputContains("Number of Works: 1");
         assertOutputContains("Number of Files: 1");
+    }
+
+    @Test
+    public void noReportTest() throws Exception {
+        initProject();
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "report_migration_types" };
+        executeExpectFailure(args);
+
+        assertOutputContains("Cannot generate migration types report. Post migration report not found");
+        assertFalse(Files.exists(project.getPostMigrationReportPath()));
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/MigrationTypeReportCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/MigrationTypeReportCommandIT.java
@@ -1,0 +1,34 @@
+package edu.unc.lib.boxc.migration.cdm;
+
+import edu.unc.lib.boxc.migration.cdm.services.MigrationTypeReportService;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ * @author krwong
+ */
+public class MigrationTypeReportCommandIT extends AbstractCommandIT {
+    private MigrationTypeReportService typeReportService;
+
+    @Before
+    public void setup() throws Exception {
+        typeReportService = new MigrationTypeReportService();
+    }
+
+    @Test
+    public void generateMigrationTypeReportTest() throws Exception {
+        initProject();
+        Files.copy(Paths.get("src/test/resources/post_migration_report.csv"), project.getPostMigrationReportPath());
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "report_migration_types" };
+        executeExpectSuccess(args);
+
+        assertOutputContains("Number of Works: 1");
+        assertOutputContains("Number of Files: 1");
+    }
+}

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationTypeReportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationTypeReportServiceTest.java
@@ -1,0 +1,78 @@
+package edu.unc.lib.boxc.migration.cdm.services;
+
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
+import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author krwong
+ */
+public class MigrationTypeReportServiceTest {
+    private static final String BOXC_BASE_URL = "http://localhost:46887/bxc/record/";
+    private static final String BOXC_ID_1 = "bb3b83d7-2962-4604-a7d0-9afcb4ec99b1";
+    private static final String BOXC_ID_2 = "91c08272-260f-40f1-bb7c-78854d504368";
+    private static final String BOXC_ID_3 = "f9d7262c-3cfb-4d27-8ecc-b9df9ac2f950";
+    private static final String BOXC_URL_1 = BOXC_BASE_URL + BOXC_ID_1;
+    private static final String BOXC_URL_2 = BOXC_BASE_URL + BOXC_ID_2;
+    private static final String BOXC_URL_3 = BOXC_BASE_URL + BOXC_ID_3;
+    private static final String CDM_URL_1 = "http://localhost/cdm/singleitem/collection/proj/id/25";
+    private static final String CDM_URL_2 = "http://localhost/cdm/singleitem/collection/proj/id/26";
+    private static final String CDM_URL_3 = "http://localhost/cdm/singleitem/collection/proj/id/27";
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private SipServiceHelper testHelper;
+    private MigrationProject project;
+    private PostMigrationReportService reportGenerator;
+    private MigrationTypeReportService service;
+
+    @Before
+    public void setup() throws Exception {
+        tmpFolder.create();
+        project = MigrationProjectFactory.createMigrationProject(
+                tmpFolder.getRoot().toPath(), "proj", null, "user",
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
+        testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
+        reportGenerator = new PostMigrationReportService();
+        reportGenerator.setProject(project);
+        reportGenerator.setChompbConfig(testHelper.getChompbConfig());
+        service = new MigrationTypeReportService();
+        service.setProject(project);
+    }
+
+    @Test
+    public void reportCountWorksTest() throws Exception {
+        reportGenerator.init();
+        reportGenerator.addRow("25", CDM_URL_1, "Work", BOXC_URL_1, "Redoubt C",
+                null, "", "", 1);
+        reportGenerator.addRow("26", CDM_URL_2, "File", BOXC_URL_2, "A file",
+                null, BOXC_URL_1, "Redoubt C", null);
+        reportGenerator.closeCsv();
+
+        long numWorks = service.countWorks();
+        assertEquals(1, numWorks);
+    }
+
+    @Test
+    public void reportCountFilesTest() throws Exception {
+        reportGenerator.init();
+        reportGenerator.addRow("25", CDM_URL_1, "Work", BOXC_URL_1, "Redoubt C",
+                null, "", "", 1);
+        reportGenerator.addRow("26", CDM_URL_2, "File", BOXC_URL_2, "A file",
+                null, BOXC_URL_1, "Redoubt C", null);
+        reportGenerator.addRow("27", CDM_URL_3, "File", BOXC_URL_3, "A file",
+                null, BOXC_URL_1, "Redoubt C", null);
+        reportGenerator.closeCsv();
+
+        long numFiles = service.countFiles();
+        assertEquals(2, numFiles);
+    }
+
+}

--- a/src/test/resources/post_migration_report.csv
+++ b/src/test/resources/post_migration_report.csv
@@ -1,0 +1,3 @@
+cdm_id,cdm_url,boxc_obj_type,boxc_url,boxc_title,verified,boxc_parent_work_url,boxc_parent_work_title,children_count
+25,cdm_url_1,Work,boxc_url_1,Redoubt C,null,"","",1
+26,cdm_url_2,File,boxc_url_2,A file,null,boxc_url_1,Redoubt C, null


### PR DESCRIPTION
[https://jira.lib.unc.edu/browse/BXC-3881](https://jira.lib.unc.edu/browse/BXC-3881)

- add new `report_migration_types` command to output the counts of new migrated works and files, will only run after post_migration_report.csv is generated