### PR TITLE
Bxc 3921 chompb status bug

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsService.java
@@ -97,7 +97,8 @@ public class DescriptionsService {
                 expandModsCollectionFile(path, idsWithMods, dryRun);
             }
         }
-        if (!idsWithMods.isEmpty()) {
+        // date should only be set if it's not a dry run
+        if (!idsWithMods.isEmpty() && !dryRun) {
             project.getProjectProperties().setDescriptionsExpandedDate(Instant.now());
             ProjectPropertiesSerialization.write(project);
         }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/StatusCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/StatusCommandIT.java
@@ -364,7 +364,21 @@ public class StatusCommandIT extends AbstractCommandIT {
     }
 
     @Test
-    public void reportDescriptionNotExpanded() {
+    public void reportDescriptionNotExpanded() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        String newCollId = "00123test";
+        testHelper.generateDefaultDestinationsMapping(DEST_UUID, newCollId);
+        Files.copy(Paths.get("src/test/resources/mods_collections/gilmer_mods1.xml"),
+                project.getDescriptionsPath().resolve("gilmer_mods1.xml"));
 
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "status" };
+        executeExpectSuccess(args);
+
+        assertOutputContains("Descriptions");
+        assertOutputMatches(".*MODS Files: +1\n.*");
+        assertOutputMatches(".*Last Expanded: +Not completed.*");
+        assertOutputMatches(".*Object MODS Records: +3 \\(100.0%\\).*");
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/StatusCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/StatusCommandIT.java
@@ -29,7 +29,7 @@ public class StatusCommandIT extends AbstractCommandIT {
     }
 
     @Test
-    public void reportUninitalized() throws Exception {
+    public void reportUninitialized() throws Exception {
         String[] args = new String[] {
                 "-w", baseDir.toString(),
                 "status" };
@@ -39,7 +39,7 @@ public class StatusCommandIT extends AbstractCommandIT {
     }
 
     @Test
-    public void reportInitalized() throws Exception {
+    public void reportInitialized() throws Exception {
         Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
 
         String[] args = new String[] {
@@ -361,5 +361,10 @@ public class StatusCommandIT extends AbstractCommandIT {
         assertOutputMatches(".*Submission Information Packages\n +Last Generated: +[0-9\\-T:]+.*");
         assertOutputMatches(".*Number of SIPs: +1\n.*");
         assertOutputMatches(".*SIPs Submitted: +0\n.*");
+    }
+
+    @Test
+    public void reportDescriptionNotExpanded() {
+
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsServiceTest.java
@@ -191,6 +191,16 @@ public class DescriptionsServiceTest {
         assertDatePresent();
     }
 
+    @Test
+    public void expandDescriptionsDryRun() throws Exception {
+        Files.copy(Paths.get("src/test/resources/mods_collections/gilmer_mods1.xml"),
+                project.getDescriptionsPath().resolve("gilmer_mods1.xml"));
+        Set<String> idsWithMods = service.expandDescriptions(true);
+
+        assertEquals(3, idsWithMods.size());
+        assertDateNotPresent();
+    }
+
     private void assertModsPopulated(String expectedTitle, String expectedId) throws Exception {
         Path path = service.getExpandedDescriptionFilePath(expectedId);
         Document modsDoc = SecureXMLFactory.createSAXBuilder().build(path.toFile());


### PR DESCRIPTION
This PR addresses the bug that sets a descriptions expanded timestamp when descriptions have not been expanded. Now the Lase Expanded part of the report says "Not Completed" when the project is in this state. Previously, it would have a timestamp which was inaccurate.
https://jira.lib.unc.edu/browse/BXC-3921

`Descriptions`
`MODS Files:           1`
 `New Collections MODS: 0`
 `Last Expanded:        Not completed`
 `Object MODS Records:  3 (100.0%)`