### PR TITLE
Bxc 2878 upgrade to junit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,14 @@
     <description>Utilities for migrating content from CDM to Box-c</description>
     <properties>
         <picocli.version>4.6.1</picocli.version>
-        <wiremock.version>2.27.2</wiremock.version>
+        <wiremock.version>2.35.0</wiremock.version>
         <sqlite-jdbc.version>3.36.0.1</sqlite-jdbc.version>
         <poi.version>5.1.0</poi.version>
         <log4j-to-slf4j.version>2.17.1</log4j-to-slf4j.version>
         <build-tools.path></build-tools.path>
         <mysql.version>8.0.28</mysql.version>
         <csv.version>1.9.0</csv.version>
+        <junit.jupiter.version>5.9.0</junit.jupiter.version>
     </properties>
 
     <build>
@@ -180,8 +181,28 @@
         </dependency>
         <!-- Testing -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.junit.vintage</groupId>-->
+<!--            <artifactId>junit-vintage-engine</artifactId>-->
+<!--            <version>${junit.jupiter.version}</version>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -192,12 +192,6 @@
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.junit.vintage</groupId>-->
-<!--            <artifactId>junit-vintage-engine</artifactId>-->
-<!--            <version>${junit.jupiter.version}</version>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <build-tools.path></build-tools.path>
         <mysql.version>8.0.28</mysql.version>
         <csv.version>1.9.0</csv.version>
-        <junit.jupiter.version>5.9.0</junit.jupiter.version>
+        <junit.jupiter.version>5.9.2</junit.jupiter.version>
     </properties>
 
     <build>

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractCommandIT.java
@@ -60,7 +60,7 @@ public class AbstractCommandIT extends AbstractOutputTest {
     }
 
     protected void setupChompbConfig() throws IOException {
-        var configPath = tmpFolder.getRoot().resolve("config.json");
+        var configPath = tmpFolder.resolve("config.json");
         var config = new ChompbConfigService.ChompbConfig();
         config.setCdmEnvironments(CdmEnvironmentHelper.getTestMapping());
         config.setBxcEnvironments(BxcEnvironmentHelper.getTestMapping());

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractCommandIT.java
@@ -7,15 +7,15 @@ import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import picocli.CommandLine;
 
 import java.io.IOException;
 import java.nio.file.Files;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -34,20 +34,19 @@ public class AbstractCommandIT extends AbstractOutputTest {
     protected MigrationProject project;
     protected String chompbConfigPath;
 
-    @After
+    @AfterEach
     public void resetProps() {
         System.setProperty("user.name", initialUser);
     }
 
-    @Before
+    @BeforeEach
     public void baseSetUp() throws Exception {
         System.setProperty("user.name", USERNAME);
         migrationCommand = new CommandLine(new CLIMain());
-        tmpFolder.create();
     }
 
     protected void initTestHelper() throws IOException {
-        testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
+        testHelper = new SipServiceHelper(project, tmpFolder);
     }
 
     protected void initProject() throws IOException {
@@ -61,7 +60,7 @@ public class AbstractCommandIT extends AbstractOutputTest {
     }
 
     protected void setupChompbConfig() throws IOException {
-        var configPath = tmpFolder.getRoot().toPath().resolve("config.json");
+        var configPath = tmpFolder.getRoot().resolve("config.json");
         var config = new ChompbConfigService.ChompbConfig();
         config.setCdmEnvironments(CdmEnvironmentHelper.getTestMapping());
         config.setBxcEnvironments(BxcEnvironmentHelper.getTestMapping());

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractOutputTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractOutputTest.java
@@ -1,7 +1,8 @@
 package edu.unc.lib.boxc.migration.cdm;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.awaitility.Awaitility.await;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -13,33 +14,31 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.awaitility.core.ConditionTimeoutException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 
 /**
  * @author bbpennel
  */
 public class AbstractOutputTest {
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
     protected Path baseDir;
 
     protected final PrintStream originalOut = System.out;
     protected final ByteArrayOutputStream out = new ByteArrayOutputStream();
     protected String output;
 
-    @After
+    @AfterEach
     public void resetOut() {
         System.setOut(originalOut);
     }
 
-    @Before
+    @BeforeEach
     public void setupOutput() throws Exception {
-        tmpFolder.create();
-        baseDir = tmpFolder.getRoot().toPath();
+        baseDir = tmpFolder.getRoot();
 
         out.reset();
         System.setOut(new PrintStream(out));
@@ -52,13 +51,13 @@ public class AbstractOutputTest {
     }
 
     protected void assertOutputDoesNotContain(String expected) {
-        assertFalse("Expected output not to contain:\n" + expected
-                + "\nBut was:\n" + getOutput(), getOutput().contains(expected));
+        assertFalse(getOutput().contains(expected), "Expected output not to contain:\n" + expected
+                        + "\nBut was:\n" + getOutput());
     }
 
     protected void assertOutputContains(String expected) {
-        assertTrue("Expected output to contain:\n" + expected
-                + "\nBut was:\n" + getOutput(), getOutput().contains(expected));
+        assertTrue(getOutput().contains(expected), "Expected output to contain:\n" + expected
+                        + "\nBut was:\n" + getOutput());
     }
 
     /**
@@ -66,8 +65,8 @@ public class AbstractOutputTest {
      */
     protected void assertOutputMatches(String expected) {
         Matcher matcher = Pattern.compile(expected, Pattern.DOTALL).matcher(getOutput());
-        assertTrue("Expected output to match:\n" + expected
-                + "\nBut was:\n" + getOutput(), matcher.matches());
+        assertTrue(matcher.matches(), "Expected output to match:\n" + expected
+                        + "\nBut was:\n" + getOutput());
     }
 
     /**
@@ -93,8 +92,8 @@ public class AbstractOutputTest {
      */
     protected void assertOutputNotMatches(String expected) {
         Matcher matcher = Pattern.compile(expected, Pattern.DOTALL).matcher(getOutput());
-        assertFalse("Expected output not to match:\n" + expected
-                + "\nBut was:\n" + getOutput(), matcher.matches());
+        assertFalse(matcher.matches(), "Expected output not to match:\n" + expected
+                        + "\nBut was:\n" + getOutput());
     }
 
     protected String getOutput() {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractOutputTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractOutputTest.java
@@ -38,7 +38,7 @@ public class AbstractOutputTest {
 
     @BeforeEach
     public void setupOutput() throws Exception {
-        baseDir = tmpFolder.getRoot();
+        baseDir = tmpFolder;
 
         out.reset();
         System.setOut(new PrintStream(out));

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AccessFilesCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AccessFilesCommandIT.java
@@ -2,17 +2,17 @@ package edu.unc.lib.boxc.migration.cdm;
 
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author bbpennel
@@ -22,10 +22,10 @@ public class AccessFilesCommandIT extends AbstractCommandIT {
 
     private Path basePath;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         initProjectAndHelper();
-        basePath = tmpFolder.newFolder().toPath();
+        basePath = tmpFolder;
     }
 
     @Test
@@ -144,13 +144,13 @@ public class AccessFilesCommandIT extends AbstractCommandIT {
 
     private void assertUpdatedDatePresent() throws Exception {
         MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
-        assertNotNull("Updated timestamp must be set", props.getAccessFilesUpdatedDate());
-        assertNull("Source mapping timestamp must not be set", props.getSourceFilesUpdatedDate());
+        assertNotNull(props.getAccessFilesUpdatedDate(), "Updated timestamp must be set");
+        assertNull(props.getSourceFilesUpdatedDate(), "Source mapping timestamp must not be set");
     }
 
     private void assertUpdatedDateNotPresent() throws Exception {
         MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
-        assertNull("Updated timestamp must not be set", props.getAccessFilesUpdatedDate());
-        assertNull("Source mapping timestamp must not be set", props.getSourceFilesUpdatedDate());
+        assertNull(props.getAccessFilesUpdatedDate(), "Updated timestamp must not be set");
+        assertNull(props.getSourceFilesUpdatedDate(), "Source mapping timestamp must not be set");
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
@@ -11,17 +11,17 @@ import edu.unc.lib.boxc.migration.cdm.test.TestSshServer;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author bbpennel
@@ -34,7 +34,7 @@ public class CdmExportCommandIT extends AbstractCommandIT {
 
     private CdmFieldService fieldService;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         fieldService = new CdmFieldService();
         testSshServer = new TestSshServer();
@@ -42,7 +42,7 @@ public class CdmExportCommandIT extends AbstractCommandIT {
         setupChompbConfig();
     }
 
-    @After
+    @AfterEach
     public void cleanup() throws Exception {
         testSshServer.stopServer();
     }
@@ -65,7 +65,7 @@ public class CdmExportCommandIT extends AbstractCommandIT {
 
         MigrationProject project = MigrationProjectFactory.loadMigrationProject(projPath);
 
-        assertTrue("Export folder not created", Files.exists(project.getExportPath()));
+        assertTrue(Files.exists(project.getExportPath()), "Export folder not created");
         assertDescAllFilePresent(project, "/descriptions/gilmer/index/description/desc.all");
     }
 
@@ -78,7 +78,7 @@ public class CdmExportCommandIT extends AbstractCommandIT {
         executeExpectFailure(args);
 
         MigrationProject project = MigrationProjectFactory.loadMigrationProject(projPath);
-        assertFalse("Description folder should not be created", Files.exists(project.getExportPath()));
+        assertFalse(Files.exists(project.getExportPath()), "Description folder should not be created");
         assertOutputContains("Must provided a CDM username");
     }
 
@@ -92,7 +92,7 @@ public class CdmExportCommandIT extends AbstractCommandIT {
         executeExpectFailure(args);
 
         MigrationProject project = MigrationProjectFactory.loadMigrationProject(projPath);
-        assertFalse("Description folder should not be created", Files.exists(project.getExportPath()));
+        assertFalse(Files.exists(project.getExportPath()), "Description folder should not be created");
         assertOutputContains("Must provided a CDM password");
     }
 
@@ -105,7 +105,7 @@ public class CdmExportCommandIT extends AbstractCommandIT {
 
         MigrationProject project = MigrationProjectFactory.loadMigrationProject(projPath);
 
-        assertFalse("Export file should not be created", Files.exists(CdmFileRetrievalService.getDescAllPath(project)));
+        assertFalse(Files.exists(CdmFileRetrievalService.getDescAllPath(project)), "Export file should not be created");
         assertOutputContains("Failed to download desc.all file");
     }
 
@@ -145,7 +145,7 @@ public class CdmExportCommandIT extends AbstractCommandIT {
 
         MigrationProject project = MigrationProjectFactory.loadMigrationProject(projPath);
 
-        assertTrue("Export folder not created", Files.exists(project.getExportPath()));
+        assertTrue(Files.exists(project.getExportPath()), "Export folder not created");
         assertDescAllFilePresent(project, "/descriptions/mini_keepsakes/index/description/desc.all");
 
         assertCpdFilePresent(project, "617.cpd", "/descriptions/mini_keepsakes/image/617.cpd");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmFieldsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmFieldsCommandIT.java
@@ -8,15 +8,15 @@ import edu.unc.lib.boxc.migration.cdm.services.FieldAssessmentTemplateService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author bbpennel, snluong
@@ -26,14 +26,14 @@ public class CdmFieldsCommandIT extends AbstractCommandIT {
     private CdmFieldService fieldService;
     private FieldAssessmentTemplateService templateService;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         fieldService = new CdmFieldService();
         templateService = new FieldAssessmentTemplateService();
         templateService.setCdmFieldService(fieldService);
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         System.setOut(originalOut);
     }
@@ -93,7 +93,6 @@ public class CdmFieldsCommandIT extends AbstractCommandIT {
 
     @Test
     public void generateFieldsUrlReportTest() throws Exception {
-        tmpFolder.create();
         initProjectAndHelper();
         testHelper.indexExportData("mini_gilmer");
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmIndexCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmIndexCommandIT.java
@@ -4,7 +4,7 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -12,11 +12,11 @@ import java.nio.file.StandardCopyOption;
 import java.time.Instant;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author bbpennel
@@ -75,7 +75,7 @@ public class CdmIndexCommandIT extends AbstractCommandIT {
                 "-f"};
         executeExpectSuccess(argsForce);
         assertTrue(Files.exists(project.getIndexPath()));
-        assertNotEquals("Index should have changed size", indexSize, Files.size(project.getIndexPath()));
+        assertNotEquals(indexSize, Files.size(project.getIndexPath()), "Index should have changed size");
         assertDateIndexedPresent();
     }
 
@@ -94,7 +94,7 @@ public class CdmIndexCommandIT extends AbstractCommandIT {
         executeExpectFailure(args);
         assertOutputContains("Failed to parse desc.all file");
         assertDateIndexedNotPresent();
-        assertTrue("Index file should be cleaned up", Files.notExists(project.getIndexPath()));
+        assertTrue(Files.notExists(project.getIndexPath()), "Index file should be cleaned up");
     }
 
     private void setExportedDate() throws Exception {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CompleteMigrationIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CompleteMigrationIT.java
@@ -1,7 +1,6 @@
 package edu.unc.lib.boxc.migration.cdm;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import edu.unc.lib.boxc.deposit.api.RedisWorkerConstants.DepositField;
 import edu.unc.lib.boxc.deposit.impl.model.DepositDirectoryManager;
 import edu.unc.lib.boxc.deposit.impl.model.DepositStatusFactory;
@@ -21,7 +20,6 @@ import org.apache.jena.rdf.model.Resource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.embedded.RedisServer;
@@ -38,25 +36,19 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test which runs a single collection through a full set of migration steps
  * @author bbpennel
  */
+@WireMockTest(httpPort = CdmEnvironmentHelper.TEST_HTTP_PORT)
 public class CompleteMigrationIT extends AbstractCommandIT {
     private final static String COLLECTION_ID = "mini_gilmer";
     private final static String GROUPS = "my:admin:group";
     private final static String DEST_UUID = "3f3c5bcf-d5d6-46ad-87ec-bcdf1f06b19e";
     private final static int REDIS_PORT = 46380;
 
-//    @Rule
-//    public WireMockRule wireMockRule = new WireMockRule(options().port(CdmEnvironmentHelper.TEST_HTTP_PORT));
-    @RegisterExtension
-    static WireMockExtension wireMockRule = WireMockExtension.newInstance()
-            .options(wireMockConfig().port(CdmEnvironmentHelper.TEST_HTTP_PORT))
-            .build();
     private TestSshServer testSshServer;
     private Path filesBasePath;
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CompleteMigrationIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CompleteMigrationIT.java
@@ -1,7 +1,7 @@
 package edu.unc.lib.boxc.migration.cdm;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import edu.unc.lib.boxc.deposit.api.RedisWorkerConstants.DepositField;
 import edu.unc.lib.boxc.deposit.impl.model.DepositDirectoryManager;
 import edu.unc.lib.boxc.deposit.impl.model.DepositStatusFactory;
@@ -18,10 +18,10 @@ import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.embedded.RedisServer;
@@ -38,8 +38,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.junit.Assert.assertEquals;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test which runs a single collection through a full set of migration steps
@@ -51,8 +51,12 @@ public class CompleteMigrationIT extends AbstractCommandIT {
     private final static String DEST_UUID = "3f3c5bcf-d5d6-46ad-87ec-bcdf1f06b19e";
     private final static int REDIS_PORT = 46380;
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(options().port(CdmEnvironmentHelper.TEST_HTTP_PORT));
+//    @Rule
+//    public WireMockRule wireMockRule = new WireMockRule(options().port(CdmEnvironmentHelper.TEST_HTTP_PORT));
+    @RegisterExtension
+    static WireMockExtension wireMockRule = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(CdmEnvironmentHelper.TEST_HTTP_PORT))
+            .build();
     private TestSshServer testSshServer;
     private Path filesBasePath;
 
@@ -60,9 +64,9 @@ public class CompleteMigrationIT extends AbstractCommandIT {
     private DepositStatusFactory depositStatusFactory;
     private JedisPool jedisPool;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
-        filesBasePath = tmpFolder.newFolder().toPath();
+        filesBasePath = tmpFolder;
         String validRespBody = IOUtils.toString(this.getClass().getResourceAsStream("/cdm_fields_resp.json"),
                 StandardCharsets.UTF_8);
 
@@ -93,7 +97,7 @@ public class CompleteMigrationIT extends AbstractCommandIT {
         depositStatusFactory.setJedisPool(jedisPool);
     }
 
-    @After
+    @AfterEach
     public void after() throws Exception {
         System.clearProperty("REDIS_HOST");
         System.clearProperty("REDIS_PORT");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/DescriptionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/DescriptionsCommandIT.java
@@ -7,8 +7,8 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -21,9 +21,9 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.MODS_V3_NS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author bbpennel
@@ -32,7 +32,7 @@ public class DescriptionsCommandIT extends AbstractCommandIT {
     private final static Pattern GENERATED_PATH_PATTERN = Pattern.compile(
             ".*Description file generated at: ([^\\s]+).*", Pattern.DOTALL);
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         initProjectAndHelper();
     }
@@ -276,8 +276,8 @@ public class DescriptionsCommandIT extends AbstractCommandIT {
     }
 
     private void assertHasModsRecord(List<Element> modsEls, String cdmId) {
-        assertTrue("No mods record with cdm id " + cdmId,
-                modsEls.stream().anyMatch(modsEl -> cdmId.equals(modsEl.getChildText("identifier", MODS_V3_NS))));
+        assertTrue(modsEls.stream().anyMatch(modsEl -> cdmId.equals(modsEl.getChildText("identifier", MODS_V3_NS))),
+                "No mods record with cdm id " + cdmId);
     }
 
     private void indexExportSamples() throws Exception {
@@ -297,7 +297,7 @@ public class DescriptionsCommandIT extends AbstractCommandIT {
                 }
             }
         }
-        assertEquals("Unexpected number of expanded MODS files", expected, fileCount);
+        assertEquals(expected, fileCount, "Unexpected number of expanded MODS files");
     }
 
     private void setIndexedDate() throws Exception {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommandIT.java
@@ -5,15 +5,15 @@ import edu.unc.lib.boxc.migration.cdm.model.DestinationsInfo.DestinationMapping;
 import edu.unc.lib.boxc.migration.cdm.services.DestinationsService;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author bbpennel
@@ -22,7 +22,7 @@ public class DestinationsCommandIT extends AbstractCommandIT {
     private final static String DEST_UUID = "3f3c5bcf-d5d6-46ad-87ec-bcdf1f06b19e";
     private final static String CUSTOM_DEST_ID = "8dd13ef6-1011-4acc-9f2f-ac1cdf03d800";
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         initProjectAndHelper();
     }
@@ -160,7 +160,7 @@ public class DestinationsCommandIT extends AbstractCommandIT {
         assertOutputContains("FAIL: Destination mapping at path " + project.getDestinationMappingsPath()
                 + " is invalid");
         assertOutputContains("- Destination at line 3 has been previously mapped with a new collection");
-        assertEquals("Must only be two errors: " + output, 2, output.split("    - ").length);
+        assertEquals(2, output.split("    - ").length, "Must only be two errors: " + output);
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/ExportUnmappedSourceFilesIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/ExportUnmappedSourceFilesIT.java
@@ -7,18 +7,18 @@ import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
 import edu.unc.lib.boxc.migration.cdm.test.TestSshServer;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author bbpennel
@@ -27,7 +27,7 @@ public class ExportUnmappedSourceFilesIT extends AbstractCommandIT {
     private TestSshServer testSshServer;
     private Path basePath;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         defaultCollectionId = "mini_gilmer";
         testSshServer = new TestSshServer();
@@ -35,10 +35,10 @@ public class ExportUnmappedSourceFilesIT extends AbstractCommandIT {
         setupChompbConfig();
         initProjectAndHelper();
         testHelper.indexExportData("mini_gilmer");
-        basePath = tmpFolder.newFolder().toPath();
+        basePath = tmpFolder;
     }
 
-    @After
+    @AfterEach
     public void cleanup() throws Exception {
         testSshServer.stopServer();
     }
@@ -57,8 +57,8 @@ public class ExportUnmappedSourceFilesIT extends AbstractCommandIT {
         String[] args = exportArgs();
         executeExpectFailure(args);
 
-        assertFalse("Export dir should not be created",
-                Files.exists(CdmFileRetrievalService.getExportedSourceFilesPath(project)));
+        assertFalse(Files.exists(CdmFileRetrievalService.getExportedSourceFilesPath(project)),
+                "Export dir should not be created");
         assertOutputContains("Source files must be mapped");
     }
 
@@ -128,7 +128,7 @@ public class ExportUnmappedSourceFilesIT extends AbstractCommandIT {
         var exportedSourceFilesPath = CdmFileRetrievalService.getExportedSourceFilesPath(project);
         var mappingInfo = sourceFileService.loadMappings();
         var mapping1 = mappingInfo.getMappingByCdmId("25");
-        assertNull("Mapping for resource with missing file must be null", mapping1.getSourcePath());
+        assertNull(mapping1.getSourcePath(), "Mapping for resource with missing file must be null");
         var mapping2 = mappingInfo.getMappingByCdmId("26");
         assertEquals(localSourcePaths.get(0), mapping2.getSourcePath());
         var mapping3 = mappingInfo.getMappingByCdmId("27");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/ExportUnmappedSourceFilesIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/ExportUnmappedSourceFilesIT.java
@@ -74,7 +74,7 @@ public class ExportUnmappedSourceFilesIT extends AbstractCommandIT {
         executeExpectSuccess(args);
 
         var updatedContents = FileUtils.readFileToString(sourceMappingPath.toFile(), StandardCharsets.UTF_8);
-        assertEquals("Mapping contents must be unchanged", originalContents, updatedContents);
+        assertEquals(originalContents, updatedContents, "Mapping contents must be unchanged");
     }
 
     @Test
@@ -150,6 +150,6 @@ public class ExportUnmappedSourceFilesIT extends AbstractCommandIT {
         assertOutputContains("Authentication to server failed");
 
         var updatedContents = FileUtils.readFileToString(sourceMappingPath.toFile(), StandardCharsets.UTF_8);
-        assertEquals("Mapping contents must be unchanged", originalContents, updatedContents);
+        assertEquals(originalContents, updatedContents, "Mapping contents must be unchanged");
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommandIT.java
@@ -2,8 +2,8 @@ package edu.unc.lib.boxc.migration.cdm;
 
 import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
 import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.sql.Connection;
@@ -13,14 +13,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author bbpennel
  */
 public class GroupMappingCommandIT extends AbstractCommandIT {
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         initProjectAndHelper();
     }
@@ -166,8 +166,8 @@ public class GroupMappingCommandIT extends AbstractCommandIT {
             childIds.add(rs.getString(1));
         }
         List<String> expected = Arrays.asList(expectedFileCdmIds);
-        assertTrue("Expected parent ids set for file objects " + expected
-                + " but only was " + childIds, childIds.containsAll(expected));
+        assertTrue(childIds.containsAll(expected), "Expected parent ids set for file objects " + expected
+                        + " but only was " + childIds);
         assertEquals(expected.size(), childIds.size());
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/IndexRedirectCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/IndexRedirectCommandIT.java
@@ -3,8 +3,8 @@ package edu.unc.lib.boxc.migration.cdm;
 import edu.unc.lib.boxc.migration.cdm.services.SipService;
 import edu.unc.lib.boxc.migration.cdm.test.RedirectMappingHelper;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -18,7 +18,7 @@ public class IndexRedirectCommandIT  extends AbstractCommandIT {
     private RedirectMappingHelper redirectMappingHelper;
     private Path propertiesPath;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         initProjectAndHelper();
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommandIT.java
@@ -188,8 +188,10 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
 
     private void assertProjectDirectoryNotCreate() throws IOException {
         try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(baseDir)) {
-            assertFalse(dirStream.iterator().hasNext(),
-                    "Project directory should not have been created, so base dir should be empty");
+            for (Path path : dirStream) {
+                assertFalse(path.toFile().isDirectory(),
+                        "Project directory should not have been created, so base dir should not contain directories");
+            }
         }
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/MigrationTypeReportCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/MigrationTypeReportCommandIT.java
@@ -1,13 +1,13 @@
 package edu.unc.lib.boxc.migration.cdm;
 
 import edu.unc.lib.boxc.migration.cdm.services.MigrationTypeReportService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * @author krwong
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertFalse;
 public class MigrationTypeReportCommandIT extends AbstractCommandIT {
     private MigrationTypeReportService typeReportService;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         typeReportService = new MigrationTypeReportService();
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/ProjectPropertiesCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/ProjectPropertiesCommandIT.java
@@ -1,9 +1,7 @@
 package edu.unc.lib.boxc.migration.cdm;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
@@ -17,7 +15,7 @@ public class ProjectPropertiesCommandIT extends AbstractCommandIT {
 
     private ProjectPropertiesService propertiesService;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         initProject();
         propertiesService = new ProjectPropertiesService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/SipsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/SipsCommandIT.java
@@ -11,18 +11,18 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.RDF;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author bbpennel
@@ -30,14 +30,14 @@ import static org.junit.Assert.assertTrue;
 public class SipsCommandIT extends AbstractCommandIT {
     private final static String DEST_UUID = "3f3c5bcf-d5d6-46ad-87ec-bcdf1f06b19e";
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         initProjectAndHelper();
         setupChompbConfig();
         System.setProperty("ENV_CONFIG", chompbConfigPath);
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         System.clearProperty("ENV_CONFIG");
     }
@@ -215,7 +215,7 @@ public class SipsCommandIT extends AbstractCommandIT {
         Resource workResc2 = testHelper.getResourceByCreateTime(depBagChildren, "2005-11-24");
         testHelper.assertObjectPopulatedInSip(workResc2, dirManager, model, stagingLocs.get(1), null, "26");
         var work2ChildPid = retrieveOnlyWorkChildPid(workResc2);
-        assertFalse("No mods should be mapped for child", Files.exists(dirManager.getModsPath(work2ChildPid)));
+        assertFalse(Files.exists(dirManager.getModsPath(work2ChildPid)), "No mods should be mapped for child");
 
         Resource workResc3 = testHelper.getResourceByCreateTime(depBagChildren, "2005-12-08");
         testHelper.assertObjectPopulatedInSip(workResc3, dirManager, model, stagingLocs.get(2), null, "27");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
@@ -1,16 +1,16 @@
 package edu.unc.lib.boxc.migration.cdm;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author bbpennel
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertTrue;
 public class SourceFilesCommandIT extends AbstractCommandIT {
     private Path basePath;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         initProjectAndHelper();
         basePath = testHelper.getSourceFilesBasePath();
@@ -182,7 +182,7 @@ public class SourceFilesCommandIT extends AbstractCommandIT {
                 + " is invalid");
         assertOutputContains("- No path mapped at line 3");
         assertOutputContains("- No path mapped at line 4");
-        assertEquals("Must only be two errors: " + output, 3, output.split("    - ").length);
+        assertEquals(3, output.split("    - ").length, "Must only be two errors: " + output);
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/StatusCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/StatusCommandIT.java
@@ -6,8 +6,8 @@ import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
 import edu.unc.lib.boxc.migration.cdm.services.SipService;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -23,7 +23,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 public class StatusCommandIT extends AbstractCommandIT {
     private final static String DEST_UUID = "3f3c5bcf-d5d6-46ad-87ec-bcdf1f06b19e";
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         initProjectAndHelper();
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/SubmitSipsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/SubmitSipsCommandIT.java
@@ -14,9 +14,9 @@ import edu.unc.lib.boxc.model.api.ids.PIDMinter;
 import edu.unc.lib.boxc.model.fcrepo.ids.RepositoryPIDMinter;
 import edu.unc.lib.boxc.operations.impl.events.PremisLoggerFactoryImpl;
 import edu.unc.lib.boxc.persist.api.PackagingType;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.embedded.RedisServer;
@@ -29,8 +29,8 @@ import java.util.List;
 import java.util.Map;
 
 import static java.nio.file.StandardOpenOption.APPEND;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author bbpennel
@@ -55,7 +55,7 @@ public class SubmitSipsCommandIT extends AbstractCommandIT {
     private PIDMinter pidMinter;
     private PremisLoggerFactoryImpl premisLoggerFactory;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         initProjectAndHelper();
         redisServer = new RedisServer(REDIS_PORT);
@@ -76,7 +76,7 @@ public class SubmitSipsCommandIT extends AbstractCommandIT {
         depositStatusFactory.setJedisPool(jedisPool);
     }
 
-    @After
+    @AfterEach
     public void after() throws Exception {
         System.clearProperty("REDIS_HOST");
         System.clearProperty("REDIS_PORT");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/VerifyPostMigrationCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/VerifyPostMigrationCommandIT.java
@@ -1,13 +1,12 @@
 package edu.unc.lib.boxc.migration.cdm;
 
-import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import edu.unc.lib.boxc.migration.cdm.options.SipGenerationOptions;
 import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.http.HttpStatus;
 
 import java.nio.file.Files;
@@ -16,20 +15,14 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author bbpennel
  */
+@WireMockTest(httpPort = BxcEnvironmentHelper.TEST_HTTP_PORT)
 public class VerifyPostMigrationCommandIT extends AbstractCommandIT {
     private final static String DEST_UUID = "3f3c5bcf-d5d6-46ad-87ec-bcdf1f06b19e";
-//    @Rule
-//    public WireMockRule wireMockRule = new WireMockRule(options().port(BxcEnvironmentHelper.TEST_HTTP_PORT));
-    @RegisterExtension
-    static WireMockExtension wireMockRule = WireMockExtension.newInstance()
-            .options(wireMockConfig().port(BxcEnvironmentHelper.TEST_HTTP_PORT))
-            .build();
 
     @BeforeEach
     public void setup() throws Exception {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/VerifyPostMigrationCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/VerifyPostMigrationCommandIT.java
@@ -1,13 +1,13 @@
 package edu.unc.lib.boxc.migration.cdm;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import edu.unc.lib.boxc.migration.cdm.options.SipGenerationOptions;
 import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.http.HttpStatus;
 
 import java.nio.file.Files;
@@ -16,18 +16,22 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.junit.Assert.assertTrue;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author bbpennel
  */
 public class VerifyPostMigrationCommandIT extends AbstractCommandIT {
     private final static String DEST_UUID = "3f3c5bcf-d5d6-46ad-87ec-bcdf1f06b19e";
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(options().port(BxcEnvironmentHelper.TEST_HTTP_PORT));
+//    @Rule
+//    public WireMockRule wireMockRule = new WireMockRule(options().port(BxcEnvironmentHelper.TEST_HTTP_PORT));
+    @RegisterExtension
+    static WireMockExtension wireMockRule = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(BxcEnvironmentHelper.TEST_HTTP_PORT))
+            .build();
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         initProjectAndHelper();
         setupChompbConfig();
@@ -38,7 +42,7 @@ public class VerifyPostMigrationCommandIT extends AbstractCommandIT {
         testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         System.clearProperty("ENV_CONFIG");
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
@@ -52,7 +52,7 @@ public class CdmExportServiceTest {
     public void setup() throws Exception {
         initMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         fieldService = new CdmFieldService();
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
@@ -9,10 +9,9 @@ import edu.unc.lib.boxc.migration.cdm.services.export.ExportStateService;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -20,12 +19,13 @@ import org.mockito.stubbing.Answer;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -35,8 +35,8 @@ import static org.mockito.MockitoAnnotations.initMocks;
  */
 public class CdmExportServiceTest {
     private static final String PROJECT_NAME = "proj";
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
 
     private MigrationProject project;
     private CdmFieldService fieldService;
@@ -48,12 +48,11 @@ public class CdmExportServiceTest {
     private String descAllResourcePath = "/descriptions/gilmer/index/description/desc.all";
     private String descAllPath = "src/test/resources" + descAllResourcePath;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         initMocks(this);
-        tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         fieldService = new CdmFieldService();
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);
@@ -91,7 +90,7 @@ public class CdmExportServiceTest {
 
         service.exportAll(makeExportOptions());
 
-        assertTrue("Export folder not created", Files.exists(project.getExportPath()));
+        assertTrue(Files.exists(project.getExportPath()), "Export folder not created");
         assertExportedFileContentsMatch(descAllResourcePath);
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
@@ -298,10 +298,6 @@ public class CdmFieldServiceTest {
         }
     }
 
-//    @Test(expected = NoSuchFileException.class)
-//    public void loadMissingFieldsFileTest() throws Exception {
-//        service.loadFieldsFromProject(project);
-//    }
     @Test
     public void loadMissingFieldsFileTest() throws Exception {
         Assertions.assertThrows(NoSuchFileException.class, () -> {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
@@ -56,7 +56,7 @@ public class CdmFieldServiceTest {
     public void setup() throws Exception {
         initMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         service = new CdmFieldService();
         service.setHttpClient(httpClient);
         service.setCdmBaseUri(CDM_BASE_URL);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
@@ -8,13 +8,13 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.sql.Connection;
@@ -26,28 +26,28 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author bbpennel
  */
 public class CdmIndexServiceTest {
     private static final String PROJECT_NAME = "proj";
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
 
     private MigrationProject project;
     private CdmFieldService fieldService;
     private CdmIndexService service;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
         fieldService = new CdmFieldService();
@@ -350,7 +350,7 @@ public class CdmIndexServiceTest {
             Statement stmt = conn.createStatement();
             ResultSet rs = stmt.executeQuery("select count(*) from " + CdmIndexService.TB_NAME);
             rs.next();
-            assertEquals("Incorrect number of rows in database", expected, rs.getInt(1));
+            assertEquals(expected, rs.getInt(1), "Incorrect number of rows in database");
         } finally {
             CdmIndexService.closeDbConnection(conn);
         }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
@@ -47,7 +47,7 @@ public class CdmIndexServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
         fieldService = new CdmFieldService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsServiceTest.java
@@ -1,12 +1,12 @@
 package edu.unc.lib.boxc.migration.cdm.services;
 
 import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.MODS_V3_NS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
@@ -22,10 +22,9 @@ import org.apache.commons.io.FileUtils;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.output.XMLOutputter;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import edu.unc.lib.boxc.common.xml.SecureXMLFactory;
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
@@ -39,8 +38,8 @@ import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 public class DescriptionsServiceTest {
     private static final String PROJECT_NAME = "proj";
 
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
     private final static XMLOutputter xmlOutputter = new XMLOutputter();
 
     private MigrationProject project;
@@ -48,9 +47,9 @@ public class DescriptionsServiceTest {
 
     private Path basePath;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
-        basePath = tmpFolder.newFolder().toPath();
+        basePath = tmpFolder;
         project = MigrationProjectFactory.createMigrationProject(basePath, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getDescriptionsPath());
         service = new DescriptionsService();
@@ -139,7 +138,7 @@ public class DescriptionsServiceTest {
             service.expandDescriptions();
             fail();
         } catch (MigrationException e) {
-            assertTrue("Unexpected message: " + e.getMessage(), e.getMessage().contains("Unexpected close tag"));
+            assertTrue(e.getMessage().contains("Unexpected close tag"), "Unexpected message: " + e.getMessage());
         }
         assertFalse(Files.exists(project.getExpandedDescriptionsPath()));
         assertDateNotPresent();
@@ -165,7 +164,7 @@ public class DescriptionsServiceTest {
             service.expandDescriptions();
             fail();
         } catch (MigrationException e) {
-            assertTrue("Unexpected message: " + e.getMessage(), e.getMessage().contains("Unexpected EOF"));
+            assertTrue(e.getMessage().contains("Unexpected EOF"), "Unexpected message: " + e.getMessage());
         }
         assertFalse(Files.exists(project.getExpandedDescriptionsPath()));
         assertDateNotPresent();
@@ -213,7 +212,7 @@ public class DescriptionsServiceTest {
             .filter(e -> "local".equals(e.getAttributeValue("type")))
             .filter(e -> "CONTENTdm number".equals(e.getAttributeValue("displayLabel")))
             .findFirst();
-        assertTrue("Expected to find CDM number identifier field", idEl.isPresent());
+        assertTrue(idEl.isPresent(), "Expected to find CDM number identifier field");
         assertEquals(expectedId, idEl.get().getText());
     }
 
@@ -226,7 +225,7 @@ public class DescriptionsServiceTest {
                 }
             }
         }
-        assertEquals("Unexpected number of expanded MODS files", expected, fileCount);
+        assertEquals(expected, fileCount, "Unexpected number of expanded MODS files");
     }
 
     private void assertDatePresent() throws Exception {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldAssessmentTemplateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldAssessmentTemplateServiceTest.java
@@ -1,16 +1,15 @@
 package edu.unc.lib.boxc.migration.cdm.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -27,18 +26,17 @@ import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
  */
 public class FieldAssessmentTemplateServiceTest {
     private static final String PROJECT_NAME = "gilmer";
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
 
     private MigrationProject project;
     private CdmFieldService fieldService;
     private FieldAssessmentTemplateService service;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
-        tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         fieldService = new CdmFieldService();
 
         service = new FieldAssessmentTemplateService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldAssessmentTemplateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldAssessmentTemplateServiceTest.java
@@ -36,7 +36,7 @@ public class FieldAssessmentTemplateServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         fieldService = new CdmFieldService();
 
         service = new FieldAssessmentTemplateService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldUrlAssessmentServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldUrlAssessmentServiceTest.java
@@ -59,7 +59,7 @@ public class FieldUrlAssessmentServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
         var testHelper = new SipServiceHelper(project, tmpFolder);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldUrlAssessmentServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldUrlAssessmentServiceTest.java
@@ -5,10 +5,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.permanentRedirect;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.Reader;
 import java.nio.file.Files;
@@ -27,28 +25,22 @@ import org.apache.commons.csv.CSVRecord;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 
-import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 
 /**
  * @author krwong, snluong
  */
+@WireMockTest
 public class FieldUrlAssessmentServiceTest {
     private static final String PROJECT_NAME = "gilmer";
 
     @TempDir
     public Path tmpFolder;
-
-//    @Rule
-//    public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
-    @RegisterExtension
-    static WireMockExtension wireMockRule = WireMockExtension.newInstance()
-            .options(wireMockConfig().dynamicPort().dynamicHttpsPort())
-            .build();
 
     private MigrationProject project;
     private FieldUrlAssessmentService service;
@@ -57,7 +49,7 @@ public class FieldUrlAssessmentServiceTest {
     private String cdmBaseUrl;
 
     @BeforeEach
-    public void setup() throws Exception {
+    public void setup(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
                 tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
@@ -74,7 +66,7 @@ public class FieldUrlAssessmentServiceTest {
         service.setCdmFieldService(fieldService);
         service.setIndexService(indexService);
 
-        cdmBaseUrl = "http://localhost:" + wireMockRule.getPort();
+        cdmBaseUrl = "http://localhost:" + wmRuntimeInfo.getHttpPort();
         fieldService.setCdmBaseUri(cdmBaseUrl);
         addUrlsToDb();
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidServiceTest.java
@@ -2,35 +2,35 @@ package edu.unc.lib.boxc.migration.cdm.services;
 
 import static edu.unc.lib.boxc.migration.cdm.services.FindingAidService.CONTRI_FIELD;
 import static edu.unc.lib.boxc.migration.cdm.services.FindingAidService.DESCRI_FIELD;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class FindingAidServiceTest {
     private static final String PROJECT_NAME = "gilmer";
 
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
 
     private MigrationProject project;
     private CdmFieldService fieldService;
     private FindingAidService service;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
 
         fieldService = new CdmFieldService();
         service = new FindingAidService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidServiceTest.java
@@ -30,7 +30,7 @@ public class FindingAidServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
 
         fieldService = new CdmFieldService();
         service = new FindingAidService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
@@ -52,7 +52,7 @@ public class GroupMappingServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
         fieldService = new CdmFieldService();
@@ -64,7 +64,7 @@ public class GroupMappingServiceTest {
         service.setProject(project);
         service.setFieldService(fieldService);
 
-        testHelper = new SipServiceHelper(project, tmpFolder.getRoot());
+        testHelper = new SipServiceHelper(project, tmpFolder);
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
@@ -12,13 +12,13 @@ import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.OutputHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -28,11 +28,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author bbpennel
@@ -40,8 +40,8 @@ import static org.junit.Assert.fail;
 public class GroupMappingServiceTest {
     private static final String PROJECT_NAME = "proj";
 
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
 
     private MigrationProject project;
     private CdmIndexService indexService;
@@ -49,10 +49,10 @@ public class GroupMappingServiceTest {
     private GroupMappingService service;
     private SipServiceHelper testHelper;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
         fieldService = new CdmFieldService();
@@ -64,7 +64,7 @@ public class GroupMappingServiceTest {
         service.setProject(project);
         service.setFieldService(fieldService);
 
-        testHelper = new SipServiceHelper(project, tmpFolder.getRoot().toPath());
+        testHelper = new SipServiceHelper(project, tmpFolder.getRoot());
     }
 
     @Test
@@ -354,8 +354,8 @@ public class GroupMappingServiceTest {
             childIds.add(rs.getString(1));
         }
         List<String> expected = Arrays.asList(expectedFileCdmIds);
-        assertTrue("Expected work " + workId + " to contain children " + expected
-                + " but it contained " + childIds, childIds.containsAll(expected));
+        assertTrue(childIds.containsAll(expected), "Expected work " + workId + " to contain children " + expected
+                        + " but it contained " + childIds);
         assertEquals(expected.size(), childIds.size());
     }
 
@@ -379,8 +379,8 @@ public class GroupMappingServiceTest {
             parentIds.add(rs.getString(1));
         }
         var expected = Arrays.stream(expectedParents).map(this::asGroupKey).collect(Collectors.toList());
-        assertTrue("Expected parent ids " + expected + " but found " + parentIds, parentIds.containsAll(expected));
-        assertEquals("Expected parent ids " + expected + " but found " + parentIds, expected.size(), parentIds.size());
+        assertTrue(parentIds.containsAll(expected), "Expected parent ids " + expected + " but found " + parentIds);
+        assertEquals(expected.size(), parentIds.size(), "Expected parent ids " + expected + " but found " + parentIds);
     }
 
     /**
@@ -403,8 +403,8 @@ public class GroupMappingServiceTest {
     }
 
     private void assertExceptionContains(String expected, Exception e) {
-        assertTrue("Expected message exception to contain '" + expected + "', but was: " + e.getMessage(),
-                e.getMessage().contains(expected));
+        assertTrue(e.getMessage().contains(expected),
+                "Expected message exception to contain '" + expected + "', but was: " + e.getMessage());
     }
 
     private void assertMappingPresent(GroupMappingInfo info, String id, String expectedMatchedVal) {
@@ -418,10 +418,10 @@ public class GroupMappingServiceTest {
         Map<String, List<String>> groupedMappings = groupedInfo.getGroupedMappings();
         List<String> objIds = groupedMappings.get(asGroupKey(groupKey));
         List<String> expectedIds = Arrays.asList(cdmIds);
-        assertTrue("Expected group " + groupKey + " to contain " + expectedIds + " but contained " + objIds,
-                objIds.containsAll(expectedIds));
-        assertEquals("Expected group " + groupKey + " to contain " + expectedIds + " but contained " + objIds,
-                expectedIds.size(), objIds.size());
+        assertTrue(objIds.containsAll(expectedIds),
+                "Expected group " + groupKey + " to contain " + expectedIds + " but contained " + objIds);
+        assertEquals(expectedIds.size(), objIds.size(),
+                "Expected group " + groupKey + " to contain " + expectedIds + " but contained " + objIds);
     }
 
     private void assertMappedDatePresent() throws Exception {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactoryTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactoryTest.java
@@ -36,7 +36,7 @@ public class MigrationProjectFactoryTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        projectsBase = tmpFolder.getRoot();
+        projectsBase = tmpFolder;
     }
 
     @Test
@@ -213,8 +213,8 @@ public class MigrationProjectFactoryTest {
 
     private void assertPropertiesSet(MigrationProjectProperties properties, String expName, String expCollId) {
         assertEquals(USERNAME, properties.getCreator());
-        assertEquals("Project name did not match expected value", expName, properties.getName());
-        assertEquals("CDM Collection ID did not match expected value", expCollId, properties.getCdmCollectionId());
+        assertEquals(expName, properties.getName(), "Project name did not match expected value");
+        assertEquals(expCollId, properties.getCdmCollectionId(), "CDM Collection ID did not match expected value");
         assertNotNull(properties.getCreatedDate(), "Created date not set");
         assertEquals("test", properties.getCdmEnvironmentId());
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactoryTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactoryTest.java
@@ -1,10 +1,10 @@
 package edu.unc.lib.boxc.migration.cdm.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -12,10 +12,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
@@ -30,15 +29,14 @@ public class MigrationProjectFactoryTest {
     private static final String PROJ_NAME = "myproject";
     private static final String COLL_ID = "coll_12345";
 
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
     private Path projectsBase;
     private String testEnv = CdmEnvironmentHelper.DEFAULT_ENV_ID;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
-        tmpFolder.create();
-        projectsBase = tmpFolder.getRoot().toPath();
+        projectsBase = tmpFolder.getRoot();
     }
 
     @Test
@@ -178,7 +176,7 @@ public class MigrationProjectFactoryTest {
         }
         assertTrue(Files.exists(projectPath));
         try(DirectoryStream<Path> dirStream = Files.newDirectoryStream(projectPath)) {
-            assertFalse("Existing directory should remain empty", dirStream.iterator().hasNext());
+            assertFalse(dirStream.iterator().hasNext(), "Existing directory should remain empty");
         }
     }
 
@@ -196,15 +194,15 @@ public class MigrationProjectFactoryTest {
         assertReturnedPropertiesPopulated(projectLoaded, PROJ_NAME, COLL_ID);
         assertPropertiesFilePopulated(projectLoaded, PROJ_NAME, COLL_ID);
 
-        assertEquals("Expect created and loaded projects to have same timestamp",
-                projectCreated.getProjectProperties().getCreatedDate(),
-                projectLoaded.getProjectProperties().getCreatedDate());
+        assertEquals(projectCreated.getProjectProperties().getCreatedDate(),
+                projectLoaded.getProjectProperties().getCreatedDate(),
+                "Expect created and loaded projects to have same timestamp");
     }
 
     private void assertPropertiesFilePopulated(MigrationProject project, String expName, String expCollId)
             throws IOException {
         Path propertiesPath = project.getProjectPropertiesPath();
-        assertTrue("Properties object must exist", Files.exists(propertiesPath));
+        assertTrue(Files.exists(propertiesPath), "Properties object must exist");
         MigrationProjectProperties properties = ProjectPropertiesSerialization.read(propertiesPath);
         assertPropertiesSet(properties, expName, expCollId);
     }
@@ -217,7 +215,7 @@ public class MigrationProjectFactoryTest {
         assertEquals(USERNAME, properties.getCreator());
         assertEquals("Project name did not match expected value", expName, properties.getName());
         assertEquals("CDM Collection ID did not match expected value", expCollId, properties.getCdmCollectionId());
-        assertNotNull("Created date not set", properties.getCreatedDate());
+        assertNotNull(properties.getCreatedDate(), "Created date not set");
         assertEquals("test", properties.getCdmEnvironmentId());
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationTypeReportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationTypeReportServiceTest.java
@@ -37,7 +37,7 @@ public class MigrationTypeReportServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot(), "proj", null, "user",
+                tmpFolder, "proj", null, "user",
                 CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
         testHelper = new SipServiceHelper(project, tmpFolder);
         reportGenerator = new PostMigrationReportService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationTypeReportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationTypeReportServiceTest.java
@@ -4,12 +4,13 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-import static org.junit.Assert.assertEquals;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author krwong
@@ -25,21 +26,20 @@ public class MigrationTypeReportServiceTest {
     private static final String CDM_URL_1 = "http://localhost/cdm/singleitem/collection/proj/id/25";
     private static final String CDM_URL_2 = "http://localhost/cdm/singleitem/collection/proj/id/26";
     private static final String CDM_URL_3 = "http://localhost/cdm/singleitem/collection/proj/id/27";
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
 
     private SipServiceHelper testHelper;
     private MigrationProject project;
     private PostMigrationReportService reportGenerator;
     private MigrationTypeReportService service;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
-        tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), "proj", null, "user",
+                tmpFolder.getRoot(), "proj", null, "user",
                 CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
-        testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
+        testHelper = new SipServiceHelper(project, tmpFolder);
         reportGenerator = new PostMigrationReportService();
         reportGenerator.setProject(project);
         reportGenerator.setChompbConfig(testHelper.getChompbConfig());

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportServiceTest.java
@@ -38,7 +38,7 @@ public class PostMigrationReportServiceTest {
     public void setup() throws Exception {
         initMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot(), "proj", null, "user",
+                tmpFolder, "proj", null, "user",
                 CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
         testHelper = new SipServiceHelper(project, tmpFolder);
         descriptionsService = testHelper.getDescriptionsService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportServiceTest.java
@@ -4,11 +4,11 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static edu.unc.lib.boxc.migration.cdm.test.PostMigrationReportTestHelper.assertContainsRow;
@@ -26,22 +26,21 @@ public class PostMigrationReportServiceTest {
     private static final String BOXC_URL_1 = BOXC_BASE_URL + BOXC_ID_1;
     private static final String BOXC_URL_2 = BOXC_BASE_URL + BOXC_ID_2;
     private static final String BOXC_URL_3 = BOXC_BASE_URL + BOXC_ID_3;
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
 
     private MigrationProject project;
     private SipServiceHelper testHelper;
     private DescriptionsService descriptionsService;
     private PostMigrationReportService service;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         initMocks(this);
-        tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), "proj", null, "user",
+                tmpFolder.getRoot(), "proj", null, "user",
                 CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
-        testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
+        testHelper = new SipServiceHelper(project, tmpFolder);
         descriptionsService = testHelper.getDescriptionsService();
 
         service = new PostMigrationReportService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportVerifierTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportVerifierTest.java
@@ -52,7 +52,7 @@ public class PostMigrationReportVerifierTest {
     public void setup() throws Exception {
         initMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot(), "proj", null, "user",
+                tmpFolder, "proj", null, "user",
                 CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
         testHelper = new SipServiceHelper(project, tmpFolder);
         reportGenerator = new PostMigrationReportService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ProjectPropertiesServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ProjectPropertiesServiceTest.java
@@ -36,7 +36,7 @@ public class ProjectPropertiesServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         service = new ProjectPropertiesService();
         service.setProject(project);
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ProjectPropertiesServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ProjectPropertiesServiceTest.java
@@ -3,23 +3,23 @@ package edu.unc.lib.boxc.migration.cdm.services;
 import static edu.unc.lib.boxc.migration.cdm.services.ProjectPropertiesService.HOOK_ID;
 import static edu.unc.lib.boxc.migration.cdm.services.ProjectPropertiesService.COLLECTION_NUMBER;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author krwong
@@ -27,16 +27,16 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 public class ProjectPropertiesServiceTest {
     private static final String PROJECT_NAME = "gilmer";
 
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
 
     private MigrationProject project;
     private ProjectPropertiesService service;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         service = new ProjectPropertiesService();
         service.setProject(project);
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingIndexServiceTest.java
@@ -9,10 +9,9 @@ import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -26,9 +25,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author snluong
@@ -37,8 +36,8 @@ public class RedirectMappingIndexServiceTest {
     private static final String PROJECT_NAME = "proj";
     private static final String DEST_UUID = "7a33f5e6-f0ca-461c-8df0-c76c62198b17";
 
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
 
     private MigrationProject project;
     private RedirectMappingIndexService indexService;
@@ -46,13 +45,12 @@ public class RedirectMappingIndexServiceTest {
     private SipServiceHelper testHelper;
     private RedirectMappingHelper redirectMappingHelper;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
-        tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user",
+                tmpFolder.getRoot(), PROJECT_NAME, null, "user",
                 CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
-        testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
+        testHelper = new SipServiceHelper(project, tmpFolder);
         redirectMappingHelper = new RedirectMappingHelper(project);
         redirectMappingHelper.createRedirectMappingsTableInDb();
         Path sqliteDbPropertiesPath = redirectMappingHelper.createDbConnectionPropertiesFile(tmpFolder, "sqlite");
@@ -69,8 +67,8 @@ public class RedirectMappingIndexServiceTest {
             indexService.indexMapping();
             fail();
         } catch (InvalidProjectStateException e) {
-            assertTrue("Unexpected message: " + e.getMessage(),
-                    e.getMessage().contains("Must submit the collection prior to indexing"));
+            assertTrue(e.getMessage().contains("Must submit the collection prior to indexing"),
+                    "Unexpected message: " + e.getMessage());
         }
     }
 
@@ -104,7 +102,7 @@ public class RedirectMappingIndexServiceTest {
             Statement stmt = conn.createStatement();
             ResultSet count = stmt.executeQuery("select count(*) from redirect_mappings");
             count.next();
-            assertEquals("Incorrect number of rows in database", 4, count.getInt(1));
+            assertEquals(4, count.getInt(1), "Incorrect number of rows in database");
 
             ResultSet rs = stmt.executeQuery("select cdm_collection_id, cdm_object_id, " +
                     "boxc_object_id, boxc_file_id from redirect_mappings");
@@ -137,7 +135,7 @@ public class RedirectMappingIndexServiceTest {
             Statement stmt = conn.createStatement();
             ResultSet count = stmt.executeQuery("select count(*) from redirect_mappings");
             count.next();
-            assertEquals("Incorrect number of rows in database", 8, count.getInt(1));
+            assertEquals(8, count.getInt(1), "Incorrect number of rows in database");
 
             ResultSet rs = stmt.executeQuery("select cdm_object_id from redirect_mappings where " +
                     "cdm_object_id is not null and boxc_object_id is not null and boxc_file_id is null");
@@ -145,7 +143,7 @@ public class RedirectMappingIndexServiceTest {
                 cdmObjectIds.add(rs.getString("cdm_object_id"));
             }
 
-            assertEquals("compound objects aren't represented correctly", expectedIds, cdmObjectIds);
+            assertEquals(expectedIds, cdmObjectIds, "compound objects aren't represented correctly");
         } finally {
             CdmIndexService.closeDbConnection(conn);
         }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingIndexServiceTest.java
@@ -48,7 +48,7 @@ public class RedirectMappingIndexServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot(), PROJECT_NAME, null, "user",
+                tmpFolder, PROJECT_NAME, null, "user",
                 CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
         testHelper = new SipServiceHelper(project, tmpFolder);
         redirectMappingHelper = new RedirectMappingHelper(project);
@@ -107,14 +107,14 @@ public class RedirectMappingIndexServiceTest {
             ResultSet rs = stmt.executeQuery("select cdm_collection_id, cdm_object_id, " +
                     "boxc_object_id, boxc_file_id from redirect_mappings");
             rs.next();
-            assertEquals("cdm_collection_id value isn't accurate", row1.get(0),
-                    rs.getString("cdm_collection_id"));
-            assertEquals("cdm_object_id value isn't accurate", row1.get(1),
-                    rs.getString("cdm_object_id"));
-            assertEquals("boxc_object_id value isn't accurate", row1.get(2),
-                    rs.getString("boxc_object_id"));
-            assertEquals("boxc_file_id value isn't accurate", row1.get(3),
-                    rs.getString("boxc_file_id"));
+            assertEquals(row1.get(0), rs.getString("cdm_collection_id"),
+                    "cdm_collection_id value isn't accurate");
+            assertEquals(row1.get(1), rs.getString("cdm_object_id"),
+                    "cdm_object_id value isn't accurate");
+            assertEquals(row1.get(2), rs.getString("boxc_object_id"),
+                    "boxc_object_id value isn't accurate");
+            assertEquals(row1.get(3), rs.getString("boxc_file_id"),
+                    "boxc_file_id value isn't accurate");
         } finally {
             CdmIndexService.closeDbConnection(conn);
         }
@@ -155,9 +155,8 @@ public class RedirectMappingIndexServiceTest {
         indexService.setRedirectDbConnectionPath(mysqlPath);
         indexService.init();
 
-        assertEquals("generated connection string is incorrect",
-                "jdbc:mysql://root:password@localhost:3306/chomping_block",
-                indexService.generateConnectionString());
+        assertEquals("jdbc:mysql://root:password@localhost:3306/chomping_block",
+                indexService.generateConnectionString(), "generated connection string is incorrect");
     }
 
     private void generateCompoundObjectProject() throws Exception {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -27,10 +27,9 @@ import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.RDF;
 import org.jdom2.Document;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.BufferedWriter;
 import java.io.Reader;
@@ -45,11 +44,11 @@ import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.AUTHENTICATED_P
 import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.PUBLIC_PRINC;
 import static edu.unc.lib.boxc.migration.cdm.test.PostMigrationReportTestHelper.assertContainsRow;
 import static java.nio.file.StandardOpenOption.APPEND;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Matchers.anyString;
 
 /**
@@ -61,20 +60,20 @@ public class SipServiceTest {
     private static final String DEST_UUID = "bfe93126-849a-43a5-b9d9-391e18ffacc6";
     private static final String DEST_UUID2 = "8ae56bbc-400e-496d-af4b-3c585e20dba1";
 
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
 
     private MigrationProject project;
     private SipService service;
     private SipServiceHelper testHelper;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME,
+                tmpFolder, PROJECT_NAME, null, USERNAME,
                 CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
 
-        testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
+        testHelper = new SipServiceHelper(project, tmpFolder);
         service = testHelper.createSipsService();
     }
 
@@ -84,8 +83,8 @@ public class SipServiceTest {
             service.generateSips(makeOptions());
             fail();
         } catch (InvalidProjectStateException e) {
-            assertTrue("Unexpected message: " + e.getMessage(),
-                    e.getMessage().contains("Exported data must be indexed"));
+            assertTrue(e.getMessage().contains("Exported data must be indexed"),
+                    "Unexpected message: " + e.getMessage());
         }
     }
 
@@ -99,8 +98,8 @@ public class SipServiceTest {
             service.generateSips(makeOptions());
             fail();
         } catch (InvalidProjectStateException e) {
-            assertTrue("Unexpected message: " + e.getMessage(),
-                    e.getMessage().contains("Destinations must be mapped"));
+            assertTrue(e.getMessage().contains("Destinations must be mapped"),
+                    "Unexpected message: " + e.getMessage());
         }
     }
 
@@ -114,8 +113,8 @@ public class SipServiceTest {
             service.generateSips(makeOptions());
             fail();
         } catch (InvalidProjectStateException e) {
-            assertTrue("Unexpected message: " + e.getMessage(),
-                    e.getMessage().contains("Descriptions must be created"));
+            assertTrue(e.getMessage().contains("Descriptions must be created"),
+                    "Unexpected message: " + e.getMessage());
         }
     }
 
@@ -129,8 +128,8 @@ public class SipServiceTest {
             service.generateSips(makeOptions());
             fail();
         } catch (InvalidProjectStateException e) {
-            assertTrue("Unexpected message: " + e.getMessage(),
-                    e.getMessage().contains("Source files must be mapped"));
+            assertTrue(e.getMessage().contains("Source files must be mapped"),
+                    "Unexpected message: " + e.getMessage());
         }
     }
 
@@ -297,8 +296,8 @@ public class SipServiceTest {
             service.generateSips(makeOptions());
             fail();
         } catch (InvalidProjectStateException e) {
-            assertTrue("Unexpected message: " + e.getMessage(),
-                    e.getMessage().contains("no source file has been mapped"));
+            assertTrue(e.getMessage().contains("no source file has been mapped"),
+                    "Unexpected message: " + e.getMessage());
         }
     }
 
@@ -347,8 +346,8 @@ public class SipServiceTest {
             service.generateSips(makeOptions());
             fail();
         } catch (InvalidProjectStateException e) {
-            assertTrue("Unexpected message: " + e.getMessage(),
-                    e.getMessage().contains("does not have a MODS description"));
+            assertTrue(e.getMessage().contains("does not have a MODS description"),
+                    "Unexpected message: " + e.getMessage());
         }
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -53,7 +54,11 @@ public class SourceFileServiceTest {
                 tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
-        basePath = tmpFolder;
+        File testFolder = new File(String.valueOf(tmpFolder), "testFolder");
+        if (!testFolder.exists()){
+            testFolder.mkdirs();
+        }
+        basePath = testFolder.toPath();
         testHelper = new SipServiceHelper(project, basePath);
 
         service = testHelper.getSourceFileService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.OutputHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -49,7 +50,7 @@ public class SourceFileServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
         basePath = tmpFolder;

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
@@ -1,11 +1,11 @@
 package edu.unc.lib.boxc.migration.cdm.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -16,10 +16,9 @@ import java.util.List;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.OutputHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
@@ -36,8 +35,8 @@ import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 public class SourceFileServiceTest {
     private static final String PROJECT_NAME = "proj";
 
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
 
     private MigrationProject project;
     private CdmIndexService indexService;
@@ -47,13 +46,13 @@ public class SourceFileServiceTest {
 
     private Path basePath;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
-        basePath = tmpFolder.newFolder().toPath();
+        basePath = tmpFolder;
         testHelper = new SipServiceHelper(project, basePath);
 
         service = testHelper.getSourceFileService();
@@ -581,8 +580,8 @@ public class SourceFileServiceTest {
         assertEquals(matchingVal, mapping.getMatchingValue());
         if (potentialPaths.length > 0) {
             for (Path potentialPath : potentialPaths) {
-                assertTrue("Mapping did not contain expected potential path: " + potentialPath,
-                        mapping.getPotentialMatches().contains(potentialPath.toString()));
+                assertTrue(mapping.getPotentialMatches().contains(potentialPath.toString()),
+                        "Mapping did not contain expected potential path: " + potentialPath);
             }
         }
     }
@@ -597,8 +596,8 @@ public class SourceFileServiceTest {
     }
 
     private void assertExceptionContains(String expected, Exception e) {
-        assertTrue("Expected message exception to contain '" + expected + "', but was: " + e.getMessage(),
-                e.getMessage().contains(expected));
+        assertTrue(e.getMessage().contains(expected),
+                "Expected message exception to contain '" + expected + "', but was: " + e.getMessage());
     }
 
     private void setIndexedDate() throws Exception {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -17,7 +16,6 @@ import java.util.List;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.OutputHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -54,11 +52,8 @@ public class SourceFileServiceTest {
                 tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
-        File testFolder = new File(String.valueOf(tmpFolder), "testFolder");
-        if (!testFolder.exists()){
-            testFolder.mkdirs();
-        }
-        basePath = testFolder.toPath();
+        basePath = tmpFolder.resolve("testFolder");
+        Files.createDirectory(basePath);
         testHelper = new SipServiceHelper(project, basePath);
 
         service = testHelper.getSourceFileService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportProgressServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportProgressServiceTest.java
@@ -4,8 +4,8 @@ import edu.unc.lib.boxc.migration.cdm.AbstractOutputTest;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static edu.unc.lib.boxc.migration.cdm.services.export.ExportState.ProgressState;
 
@@ -19,10 +19,10 @@ public class ExportProgressServiceTest extends AbstractOutputTest {
     private ExportStateService exportStateService;
     private ExportProgressService exportProgressService;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);
         exportProgressService = new ExportProgressService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportProgressServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportProgressServiceTest.java
@@ -22,7 +22,7 @@ public class ExportProgressServiceTest extends AbstractOutputTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);
         exportProgressService = new ExportProgressService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
@@ -5,39 +5,38 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static edu.unc.lib.boxc.migration.cdm.services.export.ExportState.ProgressState;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author bbpennel
  */
 public class ExportStateServiceTest {
     private static final String PROJECT_NAME = "proj";
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
 
     private ExportStateService exportStateService;
     private MigrationProject project;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
-        tmpFolder.create();
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot().toPath(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);
@@ -118,7 +117,7 @@ public class ExportStateServiceTest {
         ExportState state = exportStateService.readState();
         assertFalse(state.isResuming());
         assertEquals(ProgressState.DOWNLOADING_CPD, state.getProgressState());
-        assertTrue("CPD export path must still exist", Files.isDirectory(cpdPath));
+        assertTrue(Files.isDirectory(cpdPath), "CPD export path must still exist");
     }
 
     @Test
@@ -135,7 +134,7 @@ public class ExportStateServiceTest {
         ExportState state = exportStateService.getState();
         assertFalse(state.isResuming());
         assertEquals(ProgressState.STARTING, state.getProgressState());
-        assertFalse("CPD export path must not exist", Files.isDirectory(cpdPath));
+        assertFalse(Files.isDirectory(cpdPath), "CPD export path must not exist");
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
@@ -36,7 +36,7 @@ public class ExportStateServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.getRoot(), PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusServiceTest.java
@@ -2,14 +2,13 @@ package edu.unc.lib.boxc.migration.cdm.status;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.time.Instant;
 
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import edu.unc.lib.boxc.migration.cdm.AbstractOutputTest;
 import edu.unc.lib.boxc.migration.cdm.model.DestinationsInfo;
@@ -18,6 +17,7 @@ import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author bbpennel
@@ -26,19 +26,19 @@ public class DestinationsStatusServiceTest extends AbstractOutputTest {
     private static final String PROJECT_NAME = "proj";
     private static final String USERNAME = "migr_user";
 
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
 
     private MigrationProject project;
     private SipServiceHelper testHelper;
     private DestinationsStatusService statusService;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder, PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
 
-        testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
+        testHelper = new SipServiceHelper(project, tmpFolder);
         statusService = new DestinationsStatusService();
         statusService.setProject(project);
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusServiceTest.java
@@ -1,6 +1,5 @@
 package edu.unc.lib.boxc.migration.cdm.status;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -28,7 +27,7 @@ public class SourceFilesStatusServiceTest extends AbstractOutputTest {
     private static final String USERNAME = "migr_user";
 
     @TempDir
-    public File tmpFolder;
+    public Path tmpFolder;
 
     private MigrationProject project;
     private SipServiceHelper testHelper;
@@ -37,9 +36,9 @@ public class SourceFilesStatusServiceTest extends AbstractOutputTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder, PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
 
-        testHelper = new SipServiceHelper(project, tmpFolder.toPath());
+        testHelper = new SipServiceHelper(project, tmpFolder);
         statusService = new SourceFilesStatusService();
         statusService.setProject(project);
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusServiceTest.java
@@ -1,5 +1,6 @@
 package edu.unc.lib.boxc.migration.cdm.status;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -7,10 +8,9 @@ import java.time.Instant;
 
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import edu.unc.lib.boxc.migration.cdm.AbstractOutputTest;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
@@ -27,19 +27,19 @@ public class SourceFilesStatusServiceTest extends AbstractOutputTest {
     private static final String PROJECT_NAME = "proj";
     private static final String USERNAME = "migr_user";
 
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public File tmpFolder;
 
     private MigrationProject project;
     private SipServiceHelper testHelper;
     private SourceFilesStatusService statusService;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder.toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
 
-        testHelper = new SipServiceHelper(project, tmpFolder.newFolder().toPath());
+        testHelper = new SipServiceHelper(project, tmpFolder.toPath());
         statusService = new SourceFilesStatusService();
         statusService.setProject(project);
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/PostMigrationReportTestHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/PostMigrationReportTestHelper.java
@@ -11,8 +11,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author bbpennel
@@ -38,7 +38,7 @@ public class PostMigrationReportTestHelper {
     public static void assertContainsRow(List<List<String>> rows, String cdmId, String cdmUrl, String objType,
                                          String bxcTitle, String verified, String parentTitle, String childCount) {
         var found = rows.stream().filter(r -> r.get(0).equals(cdmId)).findFirst().orElse(null);
-        assertNotNull("Did not find row for CDM id" + cdmId, found);
+        assertNotNull(found, "Did not find row for CDM id" + cdmId);
         assertEquals(cdmUrl, found.get(1));
         assertEquals(objType, found.get(2));
         assertEquals(bxcTitle, found.get(4));
@@ -52,7 +52,7 @@ public class PostMigrationReportTestHelper {
                                          String bxcUrl, String bxcTitle, String verified, String parentUrl,
                                          String parentTitle, String childCount) {
         var found = rows.stream().filter(r -> r.get(0).equals(cdmId)).findFirst().orElse(null);
-        assertNotNull("Did not find row for CDM id " + cdmId + ", rows were:\n" + rows, found);
+        assertNotNull(found, "Did not find row for CDM id " + cdmId + ", rows were:\n" + rows);
         assertEquals(Arrays.asList(cdmId, cdmUrl, objType, bxcUrl, bxcTitle, verified, parentUrl,
                 parentTitle, childCount), found);
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/RedirectMappingHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/RedirectMappingHelper.java
@@ -66,7 +66,7 @@ public class RedirectMappingHelper {
     }
 
     public Path createDbConnectionPropertiesFile(Path tempFolder, String dbType) throws IOException {
-        File propertiesFile = new File(String.valueOf(tempFolder.getRoot()), "redirect_db_connection.properties");
+        File propertiesFile = new File(String.valueOf(tempFolder), "redirect_db_connection.properties");
         OutputStream output = new FileOutputStream(propertiesFile);
 
         Properties prop = new Properties();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/RedirectMappingHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/RedirectMappingHelper.java
@@ -5,7 +5,6 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.options.SipGenerationOptions;
 import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
 import org.apache.commons.io.FileUtils;
-import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -66,8 +65,8 @@ public class RedirectMappingHelper {
         return options;
     }
 
-    public Path createDbConnectionPropertiesFile(TemporaryFolder tempFolder, String dbType) throws IOException {
-        File propertiesFile = new File(tempFolder.getRoot(), "redirect_db_connection.properties");
+    public Path createDbConnectionPropertiesFile(Path tempFolder, String dbType) throws IOException {
+        File propertiesFile = new File(String.valueOf(tempFolder.getRoot()), "redirect_db_connection.properties");
         OutputStream output = new FileOutputStream(propertiesFile);
 
         Properties prop = new Properties();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
@@ -1,10 +1,10 @@
 package edu.unc.lib.boxc.migration.cdm.test;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -348,16 +348,16 @@ public class SipServiceHelper {
                 .map(Statement::getSubject)
                 .filter(eResc -> eResc.hasProperty(RDF.type, Premis.Ingestion))
                 .collect(Collectors.toList());
-        assertEquals("Only one event should be present", 1, eventRescs.size());
+        assertEquals(1, eventRescs.size(), "Only one event should be present");
         Resource migrationEventResc = eventRescs.get(0);
-        assertTrue("Missing migration event note",
-                migrationEventResc.hasProperty(Premis.note, "Object migrated as a part of the CONTENTdm to Box-c 5 migration"));
+        assertTrue(migrationEventResc.hasProperty(Premis.note, "Object migrated as a part of the CONTENTdm to Box-c 5 migration"),
+                "Missing migration event note");
         Resource agentResc = migrationEventResc.getProperty(Premis.hasEventRelatedAgentExecutor).getResource();
-        assertNotNull("Migration agent not set", agentResc);
+        assertNotNull(agentResc, "Migration agent not set");
         assertEquals(AgentPids.forSoftware(SoftwareAgent.cdmToBxcMigrationUtil).getRepositoryPath(),
                 agentResc.getURI());
         Resource authResc = migrationEventResc.getProperty(Premis.hasEventRelatedAgentAuthorizor).getResource();
-        assertNotNull("Migration authorizer not set", authResc);
+        assertNotNull(authResc, "Migration authorizer not set");
     }
 
     public void assertModsPresentWithCdmId(DepositDirectoryManager dirManager, PID pid, String cdmId)
@@ -369,7 +369,7 @@ public class SipServiceHelper {
             .filter(e -> "local".equals(e.getAttributeValue("type"))
                     && DescriptionsService.CDM_NUMBER_LABEL.equals(e.getAttributeValue("displayLabel")))
             .findFirst().orElseGet(null);
-        assertNotNull("Did not find a CDM identifier field", cdmIdEl);
+        assertNotNull(cdmIdEl, "Did not find a CDM identifier field");
         assertEquals(cdmId, cdmIdEl.getText());
     }
 
@@ -380,7 +380,7 @@ public class SipServiceHelper {
     public MigrationSip extractSipFromOutput(String output) {
         MigrationSip sip = new MigrationSip();
         Matcher idMatcher = DEPOSIT_ID_PATTERN.matcher(output);
-        assertTrue("No id found, output was: " + output, idMatcher.matches());
+        assertTrue(idMatcher.matches(), "No id found, output was: " + output);
         String depositId = idMatcher.group(1);
 
         Matcher pathMatcher = SIP_PATH_PATTERN.matcher(output);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DescriptionsValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DescriptionsValidatorTest.java
@@ -2,10 +2,11 @@ package edu.unc.lib.boxc.migration.cdm.validators;
 
 import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.MODS_V3_NS;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -16,10 +17,9 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
@@ -30,16 +30,16 @@ import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 public class DescriptionsValidatorTest {
     private static final String PROJECT_NAME = "proj";
     private static final String USERNAME = "migr_user";
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
     private MigrationProject project;
     private DescriptionsValidator validator;
     private static XMLOutputter xmlOutputter = new XMLOutputter(Format.getPrettyFormat());
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder, PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
 
         validator = new DescriptionsValidator();
         validator.setProject(project);
@@ -139,12 +139,12 @@ public class DescriptionsValidatorTest {
 
     private void assertHasErrorMatching(List<String> errors, String expectedP) {
         Pattern pattern = Pattern.compile(expectedP, Pattern.DOTALL);
-        assertTrue("Expected error:\n" + expectedP + "\nBut the returned errors were:\n" + String.join("\n", errors),
-                errors.stream().anyMatch(e -> pattern.matcher(e).matches()));
+        assertTrue(errors.stream().anyMatch(e -> pattern.matcher(e).matches()),
+                "Expected error:\n" + expectedP + "\nBut the returned errors were:\n" + String.join("\n", errors));
     }
 
     private void assertErrorCount(List<String> errors, int expected) {
-        assertEquals("Unexpected number of errors:\n" + String.join("\n", errors) + "\n",
-                expected, errors.size());
+        assertEquals(expected, errors.size(),
+                "Unexpected number of errors:\n" + String.join("\n", errors) + "\n");
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DestinationsValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DestinationsValidatorTest.java
@@ -1,18 +1,19 @@
 package edu.unc.lib.boxc.migration.cdm.validators;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.List;
 
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.DestinationsInfo;
@@ -26,17 +27,17 @@ import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 public class DestinationsValidatorTest {
     private static final String PROJECT_NAME = "proj";
     private static final String USERNAME = "migr_user";
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
 
     private MigrationProject project;
     private DestinationsValidator validator;
     private DestinationsService destService;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder, PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
 
         validator = new DestinationsValidator();
         validator.setProject(project);
@@ -44,9 +45,11 @@ public class DestinationsValidatorTest {
         destService.setProject(project);
     }
 
-    @Test(expected = MigrationException.class)
+    @Test
     public void noMappingFileTest() throws Exception {
-        validator.validateMappings(false);
+        Assertions.assertThrows(MigrationException.class, () -> {
+            validator.validateMappings(false);
+        });
     }
 
     @Test
@@ -242,13 +245,13 @@ public class DestinationsValidatorTest {
     }
 
     private void assertHasError(List<String> errors, String expected) {
-        assertTrue("Expected error:\n" + expected + "\nBut the returned errors were:\n" + String.join("\n", errors),
-                errors.contains(expected));
+        assertTrue(errors.contains(expected),
+                "Expected error:\n" + expected + "\nBut the returned errors were:\n" + String.join("\n", errors));
     }
 
     private void assertHasErrorMatching(List<String> errors, String expectedP) {
-        assertTrue("Expected error:\n" + expectedP + "\nBut the returned errors were:\n" + String.join("\n", errors),
-                errors.stream().anyMatch(e -> e.matches(expectedP)));
+        assertTrue(errors.stream().anyMatch(e -> e.matches(expectedP)),
+                "Expected error:\n" + expectedP + "\nBut the returned errors were:\n" + String.join("\n", errors));
     }
 
     private String mappingBody(String... rows) {
@@ -262,7 +265,7 @@ public class DestinationsValidatorTest {
     }
 
     private void assertNumberErrors(List<String> errors, int expected) {
-        assertEquals("Incorrect number of errors:\n" + String.join("\n", errors),
-                expected, errors.size());
+        assertEquals(expected, errors.size(),
+                "Incorrect number of errors:\n" + String.join("\n", errors));
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/SourceFilesValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/SourceFilesValidatorTest.java
@@ -42,7 +42,7 @@ public class SourceFilesValidatorTest {
 
         validator = new SourceFilesValidator();
         validator.setProject(project);
-        testHelper = new SipServiceHelper(project, tmpFolder.getRoot());
+        testHelper = new SipServiceHelper(project, tmpFolder);
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/SourceFilesValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/SourceFilesValidatorTest.java
@@ -1,7 +1,7 @@
 package edu.unc.lib.boxc.migration.cdm.validators;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -11,16 +11,16 @@ import java.util.List;
 
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author bbpennel
@@ -28,27 +28,28 @@ import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 public class SourceFilesValidatorTest {
     private static final String PROJECT_NAME = "proj";
     private static final String USERNAME = "migr_user";
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    public Path tmpFolder;
 
     private MigrationProject project;
     private SourceFilesValidator validator;
     private SipServiceHelper testHelper;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder.newFolder().toPath(), PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder, PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
 
         validator = new SourceFilesValidator();
         validator.setProject(project);
-        testHelper = new SipServiceHelper(project, tmpFolder.getRoot().toPath());
+        testHelper = new SipServiceHelper(project, tmpFolder.getRoot());
     }
 
-
-    @Test(expected = MigrationException.class)
+    @Test
     public void noMappingFileTest() throws Exception {
-        validator.validateMappings(false);
+        Assertions.assertThrows(MigrationException.class, () -> {
+            validator.validateMappings(false);
+        });
     }
 
     @Test
@@ -199,8 +200,8 @@ public class SourceFilesValidatorTest {
     }
 
     private void assertHasError(List<String> errors, String expected) {
-        assertTrue("Expected error:\n" + expected + "\nBut the returned errors were:\n" + String.join("\n", errors),
-                errors.contains(expected));
+        assertTrue(errors.contains(expected),
+                "Expected error:\n" + expected + "\nBut the returned errors were:\n" + String.join("\n", errors));
     }
 
     private String mappingBody(String... rows) {
@@ -214,7 +215,7 @@ public class SourceFilesValidatorTest {
     }
 
     private void assertNumberErrors(List<String> errors, int expected) {
-        assertEquals("Incorrect number of errors:\n" + String.join("\n", errors),
-                expected, errors.size());
+        assertEquals(expected, errors.size(),
+                "Incorrect number of errors:\n" + String.join("\n", errors));
     }
 }


### PR DESCRIPTION
[https://jira.lib.unc.edu/browse/BXC-2878](https://jira.lib.unc.edu/browse/BXC-2878)

- added junit 5 dependencies to pom.xml
- modified junit-related imports
- changed @ Test annotations for specifying expectations to assertThrows
- changed other annotations (@ Before to @ BeforeEach, @ After to @ AfterEach, etc)
- create temporary folders using @ TempDir instead of @ Rule
- changed wiremock rules to @ WireMockTest
- modified some tests so they work in junit 5
- changed the order of parameters in assertions (output message is last parameter)