### PR TITLE
BXC-3943 - Indexing failures

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmIndexCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmIndexCommand.java
@@ -45,6 +45,10 @@ public class CdmIndexCommand implements Callable<Integer> {
 
             indexService.createDatabase(force);
             indexService.indexAll();
+            // Display any warning messages to user
+            if (!indexService.getIndexingWarnings().isEmpty()) {
+                indexService.getIndexingWarnings().forEach(msg -> outputLogger.info(msg));
+            }
             outputLogger.info("Indexed project {} in {}s", project.getProjectName(),
                     (System.nanoTime() - start) / 1e9);
             return 0;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
@@ -14,6 +14,7 @@ import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
 import org.slf4j.Logger;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -53,6 +54,7 @@ public class CdmIndexService {
     private CdmFieldService fieldService;
 
     private String recordInsertSqlTemplate;
+    private List<String> indexingWarnings = new ArrayList<>();
 
     /**
      * Indexes all exported CDM records for this project
@@ -231,6 +233,10 @@ public class CdmIndexService {
                         childStmt.executeUpdate();
                     }
                 }
+            } catch (FileNotFoundException e) {
+                var msg = "CPD file referenced by object " + cpdId + " in desc.all was not found, skipping: " + cpdPath;
+                indexingWarnings.add(msg);
+                log.warn(msg);
             } catch (JDOMException | IOException e) {
                 throw new MigrationException("Failed to parse CPD file " + cpdPath, e);
             } catch (SQLException e) {
@@ -370,6 +376,12 @@ public class CdmIndexService {
         } catch (IOException e) {
             log.error("Failed to delete index", e);
         }
+    }
 
+    /**
+     * @return Warning messages generated while indexing
+     */
+    public List<String> getIndexingWarnings() {
+        return indexingWarnings;
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
@@ -14,9 +14,7 @@ import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
 import org.slf4j.Logger;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.sql.Connection;
@@ -30,6 +28,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.slf4j.LoggerFactory.getLogger;
@@ -48,6 +47,8 @@ public class CdmIndexService {
     public static final String ENTRY_TYPE_COMPOUND_OBJECT = "cpd_object";
     public static final String ENTRY_TYPE_COMPOUND_CHILD = "cpd_child";
     public static final List<String> MIGRATION_FIELDS = Arrays.asList(PARENT_ID_FIELD, ENTRY_TYPE_FIELD);
+    private static final Pattern TAG_MATCHER = Pattern.compile("<([^>]+)>(([^<]|<(?!/))*)</([^>]+)>");
+    private static final Pattern CONTROL_PATTERN = Pattern.compile("[\\p{Cntrl}&&[^\r\n\t]]");
 
     private MigrationProject project;
     private CdmFieldService fieldService;
@@ -70,35 +71,31 @@ public class CdmIndexService {
 
         var cpdToIdMap = new HashMap<String, String>();
 
-        SAXBuilder builder = SecureXMLFactory.createSAXBuilder();
         var descAllPath = CdmFileRetrievalService.getDescAllPath(project);
         try (
                 var conn = openDbConnection();
                 var lineStream = Files.lines(descAllPath);
         ) {
             // Compile the lines belonging to a record, wrap in record tags
-            var recordBuilder = new StringBuilder("<record>");
+            var recordBuilder = new StringBuilder();
             var incompleteRecord = false;
             for (var line: (Iterable<String>) lineStream::iterator) {
-                // Ampersands are not escaped in CDM's pseudo-XML, which causes problems when building XML
-                recordBuilder.append(line.replaceAll("&", "&amp;"));
+                recordBuilder.append(line);
                 incompleteRecord = true;
                 // reached the end of a record
                 if (line.contains(CLOSE_CDM_ID_TAG)) {
-                    recordBuilder.append("</record>");
-                    Document doc = builder.build(new ByteArrayInputStream(
-                            recordBuilder.toString().getBytes(StandardCharsets.UTF_8)));
+                    Document doc = buildDocument(recordBuilder.toString());
                     // Store details about where info about compound children can be found
                     recordIfCompoundObject(doc, cpdToIdMap);
                     indexDocument(doc, conn, fieldInfo);
                     // reset the record builder for the next record
-                    recordBuilder = new StringBuilder("<record>");
+                    recordBuilder = new StringBuilder();
                     incompleteRecord = false;
                 }
             }
             if (incompleteRecord) {
                 throw new MigrationException("Failed to parse desc.all file, incomplete record with body:\n" +
-                        recordBuilder.toString());
+                        recordBuilder);
             }
             // Assign type information to objects, based on compound object status
             assignObjectTypeDetails(conn, cpdToIdMap);
@@ -106,12 +103,22 @@ public class CdmIndexService {
             throw new MigrationException("Failed to read export files", e);
         } catch (SQLException e) {
             throw new MigrationException("Failed to update database", e);
-        } catch (JDOMException e) {
-            throw new MigrationException("Failed to parse export file", e);
         }
 
         project.getProjectProperties().setIndexedDate(Instant.now());
         ProjectPropertiesSerialization.write(project);
+    }
+
+    protected Document buildDocument(String body) {
+        // Trim out control characters, aside from newlines, carriage returns and tabs
+        body = CONTROL_PATTERN.matcher(body).replaceAll("");
+        var matcher = TAG_MATCHER.matcher(body);
+        var rootEl = new Element("record");
+        var doc = new Document().setRootElement(rootEl);
+        while (matcher.find()) {
+            rootEl.addContent(new Element(matcher.group(1)).setText(matcher.group(2)));
+        }
+        return doc;
     }
 
     private void assertCollectionExported() {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmIndexCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmIndexCommandIT.java
@@ -97,6 +97,30 @@ public class CdmIndexCommandIT extends AbstractCommandIT {
         assertTrue(Files.notExists(project.getIndexPath()), "Index file should be cleaned up");
     }
 
+    @Test
+    public void indexWithWarningsTest() throws Exception {
+        initProject();
+        Files.createDirectories(project.getExportPath());
+
+        Files.copy(Paths.get("src/test/resources/descriptions/mini_keepsakes/index/description/desc.all"),
+                CdmFileRetrievalService.getDescAllPath(project));
+        Files.createDirectories(CdmFileRetrievalService.getExportedCpdsPath(project));
+        Files.copy(Paths.get("src/test/resources/descriptions/mini_keepsakes/image/620.cpd"),
+                CdmFileRetrievalService.getExportedCpdsPath(project).resolve("620.cpd"));
+        Files.copy(Paths.get("src/test/resources/keepsakes_fields.csv"), project.getFieldsPath());
+        setExportedDate();
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "index"};
+        executeExpectSuccess(args);
+
+        assertTrue(Files.exists(project.getIndexPath()));
+        assertDateIndexedPresent();
+
+        assertOutputContains("CPD file referenced by object 604 in desc.all was not found");
+    }
+
     private void setExportedDate() throws Exception {
         project.getProjectProperties().setExportedDate(Instant.now());
         ProjectPropertiesSerialization.write(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
@@ -8,6 +8,8 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 import org.apache.commons.io.FileUtils;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -385,6 +387,62 @@ public class CdmIndexServiceTest {
         assertEquals("Maps", rootEl.getChildText("subjec"));
         assertEquals("Test  Title", rootEl.getChildText("titla"));
         assertEquals("0", rootEl.getChildText("dmrecord"));
+    }
+
+    @Test
+    public void buildDocumentWithLongFieldTest() throws Exception {
+        var body = "<title>Fencing with Fidel</title>\n" +
+                "<subjec></subjec>\n" +
+                "<descri></descri>\n" +
+                "<creato></creato>\n" +
+                "<publis></publis>\n" +
+                "<contri></contri>\n" +
+                "<date></date>\n" +
+                "<type></type>\n" +
+                "<format></format>\n" +
+                "<identi></identi>\n" +
+                "<source></source>\n" +
+                "<langua></langua>\n" +
+                "<relati></relati>\n" +
+                "<covera></covera>\n" +
+                "<rights></rights>\n" +
+                "<audien></audien>\n" +
+                "<full>page 6\n" +
+                "which is the traditional diplomatic memoir, does not give the reader the flavor of life in\n" +
+                "the Foreign Service. For me, it was the more peripheral experiences and the human\n" +
+                "interaction of policy development and implementation that provided flavor.\n" +
+                "I was in the Foreign Service for 31 years. ttwas my entire adult life until I retired. I\n" +
+                "married immediately after graduation from Princeton and was in the Service that\n" +
+                "September. A1f but five of those years were spent abroad, always in Latin America.\n" +
+                "I served from Argentina to Mexico, in the Andes, \" throughout Central America and\n" +
+                "twice in the Caribbean. Although after retirement 1 continued working in the foreign\n" +
+                "affairs field at the CIA and at the Department of Labor, I have always considered the\n" +
+                "Foreign Service to be my career.\n" +
+                "This is not a retelling of my career and of the times in which it was rooted: Rather, it Is\n" +
+                "a ' selective1 memoir because it omits much of the actual work I did as an economist\n" +
+                "and executive. And I do not directly discuss the policies that stiaped U. S. relations\n" +
+                "with the countries in which I served. What I have selected for inclusion are those\n" +
+                "experiences that strike me as providing insights into the peoples and eultures of Latin\n" +
+                "America, and into the personalities of diplomats themselves, including myself,\n" +
+                "insights as perceived initially by a very callow young American who, one hopes,\n" +
+                "matured as thedecades passed. I tiave also selected many incidents in which my\n" +
+                "wife, Sue, was involved. For us, the Foreign Service definitely was a Twofer4\n" +
+                "arrangement; the Department of State got two for the price of one wttenihey hired\n" +
+                "me and I married Sue. Sue and I shared a career.\n" +
+                "All of the situations I describe in this memoir, ™ matter how strange and foreign,\n" +
+                "happened to me. IVe tried to describe them accurately. But I admit to some literary^M<</full>\n" +
+                "<fullrs></fullrs>\n" +
+                "<find>9.pdfpage</find>\n" +
+                "<dmaccess></dmaccess>\n" +
+                "<dmoclcno></dmoclcno>\n" +
+                "<dmcreated>2009-07-28</dmcreated>\n" +
+                "<dmmodified>2009-07-28</dmmodified>\n" +
+                "<dmrecord>7</dmrecord>";
+        var rootEl = service.buildDocument(body).getRootElement();
+        assertEquals("record", rootEl.getName());
+        assertEquals(1843, rootEl.getChildText("full").length());
+        assertEquals("Fencing with Fidel", rootEl.getChildText("title"));
+        assertEquals("7", rootEl.getChildText("dmrecord"));
     }
 
     private void assertDateIndexedPresent() throws Exception {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
@@ -329,6 +329,64 @@ public class CdmIndexServiceTest {
         }
     }
 
+    @Test
+    public void buildDocumentNormalTest() throws Exception {
+        var body = "<subjec>Maps</subjec>\n" +
+                   "<titla>Test\n\nTitle</titla>\n" +
+                   "<dmrecord>0</dmrecord>\n";
+        var rootEl = service.buildDocument(body).getRootElement();
+        assertEquals("record", rootEl.getName());
+        assertEquals("Maps", rootEl.getChildText("subjec"));
+        assertEquals("Test\n\nTitle", rootEl.getChildText("titla"));
+        assertEquals("0", rootEl.getChildText("dmrecord"));
+    }
+
+    @Test
+    public void buildDocumentGreaterLessThanInContentTest() throws Exception {
+        var body = "<subjec>Maps></subjec>\n" +
+                   "<titla>Test < Title</titla>\n" +
+                   "<dmrecord>0</dmrecord>\n";
+        var rootEl = service.buildDocument(body).getRootElement();
+        assertEquals("record", rootEl.getName());
+        assertEquals("Maps>", rootEl.getChildText("subjec"));
+        assertEquals("Test < Title", rootEl.getChildText("titla"));
+    }
+
+    @Test
+    public void buildDocumentAmpersandInContentTest() throws Exception {
+        var body = "<subjec>M&ps</subjec>\n" +
+                   "<titla>Test & Title</titla>\n" +
+                   "<dmrecord>0</dmrecord>\n";
+        var rootEl = service.buildDocument(body).getRootElement();
+        assertEquals("record", rootEl.getName());
+        assertEquals("M&ps", rootEl.getChildText("subjec"));
+        assertEquals("Test & Title", rootEl.getChildText("titla"));
+    }
+
+    @Test
+    public void buildDocumentUnmatchedClosingTagTest() throws Exception {
+        var body = "<subjec>Maps</subjec>\n" +
+                "<titla>Test Weird Closing Title</transc>\n" +
+                "<dmrecord>0</dmrecord>\n";
+        var rootEl = service.buildDocument(body).getRootElement();
+        assertEquals("record", rootEl.getName());
+        assertEquals("Maps", rootEl.getChildText("subjec"));
+        assertEquals("Test Weird Closing Title", rootEl.getChildText("titla"));
+        assertEquals("0", rootEl.getChildText("dmrecord"));
+    }
+
+    @Test
+    public void buildDocumentInvalidUnicodeTest() throws Exception {
+        var body = "<subjec>Maps</subjec>\n" +
+                   "<titla>Test " + Character.toString(0xb) + " Title</titla>\n" +
+                   "<dmrecord>0</dmrecord>\n";
+        var rootEl = service.buildDocument(body).getRootElement();
+        assertEquals("record", rootEl.getName());
+        assertEquals("Maps", rootEl.getChildText("subjec"));
+        assertEquals("Test  Title", rootEl.getChildText("titla"));
+        assertEquals("0", rootEl.getChildText("dmrecord"));
+    }
+
     private void assertDateIndexedPresent() throws Exception {
         MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
         assertNotNull(props.getIndexedDate());


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3943

* Since CDM doesn't escape reserved XML characters, added a preprocessing step that identifies tags versus contents, then reconstructs the document using JDOM's API so that the content gets XML escaped.
    * (sorry for the 2008 looking state machine, I tried using a regex but it threw StackOverflowErrors for long fields)
* Some collections reference CPD files that don't exist, so rather than failing the whole thing, it skips the special CPD processing for affected records and logs a warning
* Removes unwanted control characters which cause XML parsing to fail