### PR TITLE
Bxc 3959 monograph support

### DIFF
--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
@@ -152,6 +152,21 @@ public class CdmExportCommandIT extends AbstractCommandIT {
         assertCpdFilePresent(project, "620.cpd", "/descriptions/mini_keepsakes/image/620.cpd");
     }
 
+    @Test
+    public void exportValidProjectWithMonographCompoundsTest() throws Exception {
+        Path projPath = createProject("monograph");
+
+        String[] args = exportArgs(projPath);
+        executeExpectSuccess(args);
+
+        MigrationProject project = MigrationProjectFactory.loadMigrationProject(projPath);
+
+        assertTrue(Files.exists(project.getExportPath()), "Export folder not created");
+        assertDescAllFilePresent(project, "/descriptions/monograph/index/description/desc.all");
+
+        assertCpdFilePresent(project, "196.cpd", "/descriptions/monograph/image/196.cpd");
+    }
+
     private void assertDescAllFilePresent(MigrationProject project, String expectedContentPath) throws Exception {
         assertEquals(IOUtils.toString(getClass().getResourceAsStream(expectedContentPath), StandardCharsets.UTF_8),
                 FileUtils.readFileToString(CdmFileRetrievalService.getDescAllPath(project).toFile(), StandardCharsets.UTF_8));

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
@@ -368,6 +368,67 @@ public class CdmIndexServiceTest {
     }
 
     @Test
+    public void indexExportWithMonographCompoundObjectsTest() throws Exception {
+        Files.copy(Paths.get("src/test/resources/descriptions/monograph/index/description/desc.all"),
+                CdmFileRetrievalService.getDescAllPath(project));
+        Files.createDirectories(CdmFileRetrievalService.getExportedCpdsPath(project));
+        Files.copy(Paths.get("src/test/resources/descriptions/monograph/image/196.cpd"),
+                CdmFileRetrievalService.getExportedCpdsPath(project).resolve("196.cpd"));
+        Files.copy(Paths.get("src/test/resources/monograph_fields.csv"), project.getFieldsPath());
+        setExportedDate();
+
+        service.createDatabase(false);
+        service.indexAll();
+
+        assertDateIndexedPresent();
+        assertRowCount(4);
+
+        CdmFieldInfo fieldInfo = fieldService.loadFieldsFromProject(project);
+        List<String> allFields = fieldInfo.listAllExportFields();
+        allFields.addAll(CdmIndexService.MIGRATION_FIELDS);
+
+        Connection conn = service.openDbConnection();
+        try {
+            Statement stmt = conn.createStatement();
+            ResultSet rs = stmt.executeQuery("select " + String.join(",", allFields)
+                    + " from " + CdmIndexService.TB_NAME + " order by " + CdmFieldInfo.CDM_ID + " asc");
+            rs.next();
+            assertEquals(192, rs.getInt(CdmFieldInfo.CDM_ID));
+            assertEquals("2007-12-13", rs.getString(CdmFieldInfo.CDM_CREATED));
+            assertEquals("2008-12-16", rs.getString(CdmFieldInfo.CDM_MODIFIED));
+            assertEquals("Page 1", rs.getString("title"));
+            assertEquals(CdmIndexService.ENTRY_TYPE_COMPOUND_CHILD, rs.getString(CdmIndexService.ENTRY_TYPE_FIELD));
+            assertEquals("195", rs.getString(CdmIndexService.PARENT_ID_FIELD));
+
+            rs.next();
+            assertEquals(193, rs.getInt(CdmFieldInfo.CDM_ID));
+            assertEquals("2007-12-13", rs.getString(CdmFieldInfo.CDM_CREATED));
+            assertEquals("2008-12-18", rs.getString(CdmFieldInfo.CDM_MODIFIED));
+            assertEquals("Page 2", rs.getString("title"));
+            assertEquals(CdmIndexService.ENTRY_TYPE_COMPOUND_CHILD, rs.getString(CdmIndexService.ENTRY_TYPE_FIELD));
+            assertEquals("195", rs.getString(CdmIndexService.PARENT_ID_FIELD));
+
+            rs.next();
+            assertEquals(194, rs.getInt(CdmFieldInfo.CDM_ID));
+            assertEquals("2007-12-13", rs.getString(CdmFieldInfo.CDM_CREATED));
+            assertEquals("2008-12-16", rs.getString(CdmFieldInfo.CDM_MODIFIED));
+            assertEquals("Page 3", rs.getString("title"));
+            assertEquals(CdmIndexService.ENTRY_TYPE_COMPOUND_CHILD, rs.getString(CdmIndexService.ENTRY_TYPE_FIELD));
+            assertEquals("195", rs.getString(CdmIndexService.PARENT_ID_FIELD));
+
+            rs.next();
+            assertEquals(195, rs.getInt(CdmFieldInfo.CDM_ID));
+            assertEquals("2020-12-10", rs.getString(CdmFieldInfo.CDM_CREATED));
+            assertEquals("2020-12-10", rs.getString(CdmFieldInfo.CDM_MODIFIED));
+            assertEquals("Map of the Surveys for Atlantic and N. Carolina R-Road", rs.getString("title"));
+            assertEquals(CdmIndexService.ENTRY_TYPE_COMPOUND_OBJECT, rs.getString(CdmIndexService.ENTRY_TYPE_FIELD));
+            assertNull(rs.getString(CdmIndexService.PARENT_ID_FIELD));
+        } finally {
+            CdmIndexService.closeDbConnection(conn);
+        }
+    }
+
+    @Test
     public void indexExportReservedWordFieldTest() throws Exception {
         Files.copy(Paths.get("src/test/resources/descriptions/03883/index/description/desc.all"),
                 CdmFileRetrievalService.getDescAllPath(project));

--- a/src/test/resources/descriptions/monograph/image/196.cpd
+++ b/src/test/resources/descriptions/monograph/image/196.cpd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cpd>
+  <type>Monograph</type>
+  <node>
+    <nodetitle>Map of the Surveys for Atlantic and N. Carolina R-Road</nodetitle>
+    <page>
+      <pagetitle>Page 1</pagetitle>
+      <pagefile>193.jp2</pagefile>
+      <pageptr>192</pageptr>
+    </page>
+    <page>
+      <pagetitle>Page 2</pagetitle>
+      <pagefile>194.jp2</pagefile>
+      <pageptr>193</pageptr>
+    </page>
+    <page>
+      <pagetitle>Page 3</pagetitle>
+      <pagefile>195.jp2</pagefile>
+      <pageptr>194</pageptr>
+    </page>
+  </node>
+</cpd>

--- a/src/test/resources/descriptions/monograph/index/description/desc.all
+++ b/src/test/resources/descriptions/monograph/index/description/desc.all
@@ -1,3 +1,82 @@
+<mapid>MC_170_A8814_1853g</mapid>
+<collec></collec>
+<title>Page 1</title>
+<altern></altern>
+<date></date>
+<displa></displa>
+<conten></conten>
+<contea></contea>
+<creato></creato>
+<creata></creata>
+<placeo></placeo>
+<publis></publis>
+<captio></captio>
+<abstra></abstra>
+<histor></histor>
+<biblio></biblio>
+<biblia></biblia>
+<ispart></ispart>
+<oclc></oclc>
+<relate></relate>
+<subjec></subjec>
+<subjea></subjea>
+<subjeb></subjeb>
+<subjed></subjed>
+<subjef></subjef>
+<subjeh></subjeh>
+<subjee></subjee>
+<spatia></spatia>
+<placen></placen>
+<westbo></westbo>
+<eastbo></eastbo>
+<northb></northb>
+<southb></southb>
+<scale></scale>
+<projec></projec>
+<size></size>
+<mapsiz></mapsiz>
+<mapsia></mapsia>
+<physic></physic>
+<format>Maps</format>
+<langua></langua>
+<imagef></imagef>
+<images>1</images>
+<path>\\digitalarchive.lib.unc.edu\ncc\NCMaps\State Archives\</path>
+<rawsca>MC_170_A8814_1853_sh1_400dpi.tif</rawsca>
+<digita></digita>
+<hardwa></hardwa>
+<softwa></softwa>
+<pixela></pixela>
+<pixelb></pixelb>
+<bitdep></bitdep>
+<colors></colors>
+<filefo></filefo>
+<creatb></creatb>
+<collea></collea>
+<digitb></digitb>
+<host></host>
+<sponso>North Carolina Maps is made possible by the Institute of Museum and Library Services under the provisions of the Library Services and Technology Act as administered by the State Library of North Carolina.</sponso>
+<callnu></callnu>
+<additi></additi>
+<call></call>
+<citati></citati>
+<copyri></copyri>
+<usager></usager>
+<cdmid>Image</cdmid>
+<source></source>
+<tile></tile>
+<tiled></tiled>
+<addita></addita>
+<verify></verify>
+<fullrs></fullrs>
+<find>193.jp2</find>
+<dmaccess></dmaccess>
+<dmimage></dmimage>
+<dmad1></dmad1>
+<dmad2></dmad2>
+<dmoclcno></dmoclcno>
+<dmcreated>2007-12-13</dmcreated>
+<dmmodified>2008-12-16</dmmodified>
 <dmrecord>192</dmrecord>
 <mapid>MC_170_A8814_1853g</mapid>
 <collec></collec>
@@ -237,80 +316,3 @@
 <dmcreated>2020-12-10</dmcreated>
 <dmmodified>2020-12-10</dmmodified>
 <dmrecord>195</dmrecord>
-<mapid>MC_041_1850g</mapid>
-<collec>State Archives of North Carolina</collec>
-<title>A map of Gates County, [North Carolina]</title>
-<altern></altern>
-<date>1850</date>
-<displa>circa 1850</displa>
-<conten>1850</conten>
-<contea>circa 1850</contea>
-<creato></creato>
-<creata></creata>
-<placeo></placeo>
-<publis></publis>
-<captio></captio>
-<abstra>Manuscript map shows townships, churches, ferries, mineral springs, rivers, and canals.  Townships shown include Renaldson, Hall, Piney Woods, Holly, and Mintonsville.</abstra>
-<histor></histor>
-<biblio></biblio>
-<biblia></biblia>
-<ispart></ispart>
-<oclc></oclc>
-<relate></relate>
-<subjec>County Maps</subjec>
-<subjea>Manuscript</subjea>
-<subjeb>Canals;Creeks and Streams;Places of Worship;Roads;Swamps;Townships</subjeb>
-<subjed>Gates County (N.C.)--Maps.</subjed>
-<subjef></subjef>
-<subjeh></subjeh>
-<subjee></subjee>
-<spatia>United States, North Carolina, Eastern Region, Gates County</spatia>
-<placen>Gates County (N.C.)</placen>
-<westbo>-76.95</westbo>
-<eastbo>-76.45</eastbo>
-<northb>36.55</northb>
-<southb>36.283333</southb>
-<scale>Scale not given.</scale>
-<projec></projec>
-<size>36 x 53 cm.</size>
-<mapsiz></mapsiz>
-<mapsia></mapsia>
-<physic>Paper</physic>
-<format>Maps</format>
-<langua>English</langua>
-<imagef></imagef>
-<images></images>
-<path>\\digitalarchive.lib.unc.edu\ncc\NCMaps\State Archives\</path>
-<rawsca>MC_041_1850g.tif</rawsca>
-<digita></digita>
-<hardwa></hardwa>
-<softwa></softwa>
-<pixela></pixela>
-<pixelb></pixelb>
-<bitdep></bitdep>
-<colors></colors>
-<filefo></filefo>
-<creatb></creatb>
-<collea></collea>
-<digitb>North Carolina Maps</digitb>
-<host>North Carolina Department of Cultural Resources</host>
-<sponso>North Carolina Maps is made possible by the Institute of Museum and Library Services under the provisions of the Library Services and Technology Act as administered by the State Library of North Carolina.</sponso>
-<callnu>MC.041.1850g;MARS Id: 3.1.1.38.1</callnu>
-<additi></additi>
-<call></call>
-<citati></citati>
-<copyri></copyri>
-<usager>This item is presented courtesy of the State Archives of North Carolina, for research and educational purposes. Prior permission from the State Archives is required for any commercial use.</usager>
-<cdmid>Image</cdmid>
-<source></source>
-<tile></tile>
-<tiled></tiled>
-<addita></addita>
-<verify></verify>
-<fullrs>Volume8\MC_041_1850g.TIF</fullrs>
-<dmoclcno></dmoclcno>
-<find>197.jp2</find>
-<dmaccess></dmaccess>
-<dmimage></dmimage>
-<dmcreated>2007-12-14</dmcreated>
-<dmmodified>2020-12-10</dmmodified>

--- a/src/test/resources/descriptions/monograph/index/description/desc.all
+++ b/src/test/resources/descriptions/monograph/index/description/desc.all
@@ -1,0 +1,316 @@
+<dmrecord>192</dmrecord>
+<mapid>MC_170_A8814_1853g</mapid>
+<collec></collec>
+<title>Page 2</title>
+<altern></altern>
+<date></date>
+<displa></displa>
+<conten></conten>
+<contea></contea>
+<creato></creato>
+<creata></creata>
+<placeo></placeo>
+<publis></publis>
+<captio></captio>
+<abstra></abstra>
+<histor></histor>
+<biblio></biblio>
+<biblia></biblia>
+<ispart></ispart>
+<oclc></oclc>
+<relate></relate>
+<subjec></subjec>
+<subjea></subjea>
+<subjeb></subjeb>
+<subjed></subjed>
+<subjef></subjef>
+<subjeh></subjeh>
+<subjee></subjee>
+<spatia></spatia>
+<placen></placen>
+<westbo></westbo>
+<eastbo></eastbo>
+<northb></northb>
+<southb></southb>
+<scale></scale>
+<projec></projec>
+<size></size>
+<mapsiz></mapsiz>
+<mapsia></mapsia>
+<physic></physic>
+<format>Maps</format>
+<langua></langua>
+<imagef></imagef>
+<images>2</images>
+<path>\\digitalarchive.lib.unc.edu\ncc\NCMaps\State Archives\</path>
+<rawsca>MC_170_A8814_1853_sh2_400dpi.tif</rawsca>
+<digita></digita>
+<hardwa></hardwa>
+<softwa></softwa>
+<pixela></pixela>
+<pixelb></pixelb>
+<bitdep></bitdep>
+<colors></colors>
+<filefo></filefo>
+<creatb></creatb>
+<collea></collea>
+<digitb></digitb>
+<host></host>
+<sponso>North Carolina Maps is made possible by the Institute of Museum and Library Services under the provisions of the Library Services and Technology Act as administered by the State Library of North Carolina.</sponso>
+<callnu></callnu>
+<additi></additi>
+<call></call>
+<citati></citati>
+<copyri></copyri>
+<usager></usager>
+<cdmid>Image</cdmid>
+<source></source>
+<tile></tile>
+<tiled></tiled>
+<addita></addita>
+<verify></verify>
+<fullrs></fullrs>
+<find>194.jp2</find>
+<dmaccess></dmaccess>
+<dmimage></dmimage>
+<dmad1></dmad1>
+<dmad2></dmad2>
+<dmoclcno></dmoclcno>
+<dmcreated>2007-12-13</dmcreated>
+<dmmodified>2008-12-18</dmmodified>
+<dmrecord>193</dmrecord>
+<mapid>MC_170_A8814_1853g</mapid>
+<collec></collec>
+<title>Page 3</title>
+<altern></altern>
+<date></date>
+<displa></displa>
+<conten></conten>
+<contea></contea>
+<creato></creato>
+<creata></creata>
+<placeo></placeo>
+<publis></publis>
+<captio></captio>
+<abstra></abstra>
+<histor></histor>
+<biblio></biblio>
+<biblia></biblia>
+<ispart></ispart>
+<oclc></oclc>
+<relate></relate>
+<subjec></subjec>
+<subjea></subjea>
+<subjeb></subjeb>
+<subjed></subjed>
+<subjef></subjef>
+<subjeh></subjeh>
+<subjee></subjee>
+<spatia></spatia>
+<placen></placen>
+<westbo></westbo>
+<eastbo></eastbo>
+<northb></northb>
+<southb></southb>
+<scale></scale>
+<projec></projec>
+<size></size>
+<mapsiz></mapsiz>
+<mapsia></mapsia>
+<physic></physic>
+<format>Maps</format>
+<langua></langua>
+<imagef></imagef>
+<images>3</images>
+<path>\\digitalarchive.lib.unc.edu\ncc\NCMaps\State Archives\</path>
+<rawsca>MC_170_A8814_1853_sh3_400dpi.tif</rawsca>
+<digita></digita>
+<hardwa></hardwa>
+<softwa></softwa>
+<pixela></pixela>
+<pixelb></pixelb>
+<bitdep></bitdep>
+<colors></colors>
+<filefo></filefo>
+<creatb></creatb>
+<collea></collea>
+<digitb></digitb>
+<host></host>
+<sponso>North Carolina Maps is made possible by the Institute of Museum and Library Services under the provisions of the Library Services and Technology Act as administered by the State Library of North Carolina.</sponso>
+<callnu></callnu>
+<additi></additi>
+<call></call>
+<citati></citati>
+<copyri></copyri>
+<usager></usager>
+<cdmid>Image</cdmid>
+<source></source>
+<tile></tile>
+<tiled></tiled>
+<addita></addita>
+<verify></verify>
+<fullrs></fullrs>
+<find>195.jp2</find>
+<dmaccess></dmaccess>
+<dmimage></dmimage>
+<dmad1></dmad1>
+<dmad2></dmad2>
+<dmoclcno></dmoclcno>
+<dmcreated>2007-12-13</dmcreated>
+<dmmodified>2008-12-16</dmmodified>
+<dmrecord>194</dmrecord>
+<mapid>MC_170_A8814_1853g</mapid>
+<collec>State Archives of North Carolina</collec>
+<title>Map of the Surveys for Atlantic and N. Carolina R-Road</title>
+<altern>Map of the Surveys for Atlantic and North Carolina Rail Road</altern>
+<date>1853</date>
+<displa>1853</displa>
+<conten>1853</conten>
+<contea>1853</contea>
+<creato>Gwynn, Walter, 1802-1882.</creato>
+<creata></creata>
+<placeo></placeo>
+<publis></publis>
+<captio></captio>
+<abstra>Map made under the direction of Walter Gwyn, Chief Engineer. Map shows a detailed depiction of the bed of the Atlantic and North Carolina Railroad from Goldsboro to Lenoxville.  Shows property lines, houses, ponds, lakes, pocosins, farms, vegetation, and cities and towns.</abstra>
+<histor></histor>
+<biblio></biblio>
+<biblia></biblia>
+<ispart></ispart>
+<oclc></oclc>
+<relate></relate>
+<subjec>Transportation and Communication</subjec>
+<subjea>Railroad</subjea>
+<subjeb>Canals;Colors;Creeks and Streams;Houses;Landowners;Property Lines;Roads;Swamps</subjeb>
+<subjed>North Carolina--Maps.</subjed>
+<subjef></subjef>
+<subjeh>Railroads--North Carolina--Maps.;Manuscript maps.</subjeh>
+<subjee></subjee>
+<spatia>United States, North Carolina, Eastern Region</spatia>
+<placen>Wayne County (N.C.);Carteret County (N.C.);Lenoir County (N.C.);Jones County (N.C.);Craven County (N.C.)</placen>
+<westbo>-77.7</westbo>
+<eastbo>-76.483333</eastbo>
+<northb>35.35</northb>
+<southb>34.683333</southb>
+<scale>1:59,400</scale>
+<projec></projec>
+<size>57 x 265 cm.</size>
+<mapsiz></mapsiz>
+<mapsia></mapsia>
+<physic>Paper</physic>
+<format>Maps</format>
+<langua>English</langua>
+<imagef></imagef>
+<images></images>
+<path></path>
+<rawsca></rawsca>
+<digita></digita>
+<hardwa></hardwa>
+<softwa></softwa>
+<pixela></pixela>
+<pixelb></pixelb>
+<bitdep></bitdep>
+<colors></colors>
+<filefo></filefo>
+<creatb></creatb>
+<collea></collea>
+<digitb>North Carolina Maps</digitb>
+<host>North Carolina Department of Cultural Resources</host>
+<sponso>North Carolina Maps is made possible by the Institute of Museum and Library Services under the provisions of the Library Services and Technology Act as administered by the State Library of North Carolina.</sponso>
+<callnu>MC.170.A8814.1853g;MARS Id: 3.12.1.1.1</callnu>
+<additi></additi>
+<call></call>
+<citati></citati>
+<copyri></copyri>
+<usager>This item is presented courtesy of the State Archives of North Carolina, for research and educational purposes. Prior permission from the State Archives is required for any commercial use.</usager>
+<cdmid>Image</cdmid>
+<source></source>
+<tile></tile>
+<tiled></tiled>
+<addita></addita>
+<verify></verify>
+<fullrs></fullrs>
+<find>196.cpd</find>
+<dmoclcno></dmoclcno>
+<dmaccess></dmaccess>
+<dmimage></dmimage>
+<dmcreated>2020-12-10</dmcreated>
+<dmmodified>2020-12-10</dmmodified>
+<dmrecord>195</dmrecord>
+<mapid>MC_041_1850g</mapid>
+<collec>State Archives of North Carolina</collec>
+<title>A map of Gates County, [North Carolina]</title>
+<altern></altern>
+<date>1850</date>
+<displa>circa 1850</displa>
+<conten>1850</conten>
+<contea>circa 1850</contea>
+<creato></creato>
+<creata></creata>
+<placeo></placeo>
+<publis></publis>
+<captio></captio>
+<abstra>Manuscript map shows townships, churches, ferries, mineral springs, rivers, and canals.  Townships shown include Renaldson, Hall, Piney Woods, Holly, and Mintonsville.</abstra>
+<histor></histor>
+<biblio></biblio>
+<biblia></biblia>
+<ispart></ispart>
+<oclc></oclc>
+<relate></relate>
+<subjec>County Maps</subjec>
+<subjea>Manuscript</subjea>
+<subjeb>Canals;Creeks and Streams;Places of Worship;Roads;Swamps;Townships</subjeb>
+<subjed>Gates County (N.C.)--Maps.</subjed>
+<subjef></subjef>
+<subjeh></subjeh>
+<subjee></subjee>
+<spatia>United States, North Carolina, Eastern Region, Gates County</spatia>
+<placen>Gates County (N.C.)</placen>
+<westbo>-76.95</westbo>
+<eastbo>-76.45</eastbo>
+<northb>36.55</northb>
+<southb>36.283333</southb>
+<scale>Scale not given.</scale>
+<projec></projec>
+<size>36 x 53 cm.</size>
+<mapsiz></mapsiz>
+<mapsia></mapsia>
+<physic>Paper</physic>
+<format>Maps</format>
+<langua>English</langua>
+<imagef></imagef>
+<images></images>
+<path>\\digitalarchive.lib.unc.edu\ncc\NCMaps\State Archives\</path>
+<rawsca>MC_041_1850g.tif</rawsca>
+<digita></digita>
+<hardwa></hardwa>
+<softwa></softwa>
+<pixela></pixela>
+<pixelb></pixelb>
+<bitdep></bitdep>
+<colors></colors>
+<filefo></filefo>
+<creatb></creatb>
+<collea></collea>
+<digitb>North Carolina Maps</digitb>
+<host>North Carolina Department of Cultural Resources</host>
+<sponso>North Carolina Maps is made possible by the Institute of Museum and Library Services under the provisions of the Library Services and Technology Act as administered by the State Library of North Carolina.</sponso>
+<callnu>MC.041.1850g;MARS Id: 3.1.1.38.1</callnu>
+<additi></additi>
+<call></call>
+<citati></citati>
+<copyri></copyri>
+<usager>This item is presented courtesy of the State Archives of North Carolina, for research and educational purposes. Prior permission from the State Archives is required for any commercial use.</usager>
+<cdmid>Image</cdmid>
+<source></source>
+<tile></tile>
+<tiled></tiled>
+<addita></addita>
+<verify></verify>
+<fullrs>Volume8\MC_041_1850g.TIF</fullrs>
+<dmoclcno></dmoclcno>
+<find>197.jp2</find>
+<dmaccess></dmaccess>
+<dmimage></dmimage>
+<dmcreated>2007-12-14</dmcreated>
+<dmmodified>2020-12-10</dmmodified>

--- a/src/test/resources/monograph_fields.csv
+++ b/src/test/resources/monograph_fields.csv
@@ -1,0 +1,77 @@
+cdm_nick,export_as,description,skip_export,cdm_required,cdm_searchable,cdm_hidden,cdm_vocab,cdm_dc_mapping
+mapid,mapid,map_id,false,n,y,y,n,audiena
+collec,collec,Repository,false,n,y,n,y,source
+title,title,Title,false,y,y,n,n,title
+altern,altern,Alternative Title,false,n,y,n,n,titlea
+date,date,date_published_numeric,false,n,y,y,n,date
+displa,displa,Date Published,false,n,y,n,y,date
+conten,conten,content_date_numeric,false,n,y,y,n,date
+contea,contea,Date Depicted,false,n,y,n,n,date
+creato,creato,Creator - Individual,false,n,y,n,y,creato
+creata,creata,Creator - Organization,false,n,y,n,y,creato
+placeo,placeo,Place of Publication,false,n,y,n,y,BLANK
+publis,publis,Publisher,false,n,y,n,y,publis
+captio,captio,Caption,false,n,y,n,n,BLANK
+abstra,abstra,Abstract,false,n,n,n,n,descri
+histor,histor,Historical Note,false,n,y,n,n,describ
+biblio,biblio,Bibliographic Note,false,n,y,n,n,describ
+biblia,biblia,Reference,false,n,y,n,n,relatii
+ispart,ispart,Related Item,false,n,n,n,n,relatig
+oclc,oclc,OCLC,false,n,n,n,n,BLANK
+relate,relate,Related Maps,false,n,n,n,n,relatib
+subjec,subjec,Theme,false,n,y,y,y,BLANK
+subjea,subjea,Map Type,false,n,y,n,y,BLANK
+subjeb,subjeb,Details,false,n,y,n,y,BLANK
+subjed,subjed,Subject - Geographic,false,n,y,n,y,subjec
+subjef,subjef,Subject - Name,false,n,y,n,y,subjec
+subjeh,subjeh,Subject - Topical,false,n,y,n,y,subjec
+subjee,subjee,Subject (tgm),false,n,y,n,y,subjec
+spatia,spatia,Scope,false,n,y,y,y,covera
+placen,placen,Places Depicted,false,n,y,n,y,covera
+westbo,westbo,West Longitude,false,n,n,n,n,coveraa
+eastbo,eastbo,East Longitude,false,n,n,n,n,coveraa
+northb,northb,North Latitude,false,n,n,n,n,coveraa
+southb,southb,South Latitude,false,n,n,n,n,coveraa
+scale,scale,Scale,false,n,y,n,n,BLANK
+projec,projec,Projection,false,n,n,n,y,BLANK
+size,size,Size,false,n,n,n,n,BLANK
+mapsiz,mapsiz,map_size_height,false,n,n,y,n,formata
+mapsia,mapsia,map_size_width,false,n,n,y,n,formata
+physic,physic,Medium,false,n,y,n,y,BLANK
+format,format,Format,false,y,y,n,y,format
+langua,langua,Language,false,n,y,n,y,langua
+imagef,imagef,image_file,false,n,n,y,n,BLANK
+images,images,image_sort_order,false,n,n,y,n,BLANK
+path,path,path,false,n,n,y,n,BLANK
+rawsca,rawsca,raw_scan_filename,false,n,n,y,n,BLANK
+digita,digita,digital_scan_date_raw_file,false,n,n,y,n,BLANK
+hardwa,hardwa,hardware_raw_scan,false,n,n,y,n,BLANK
+softwa,softwa,software_raw_scan,false,n,n,y,n,BLANK
+pixela,pixela,pixel_array_height_raw_scan,false,n,n,y,n,BLANK
+pixelb,pixelb,pixel_array_width_raw_scan,false,n,n,y,n,BLANK
+bitdep,bitdep,bit_depth_raw_scan,false,n,n,y,n,BLANK
+colors,colors,color_space_raw_scan,false,n,n,y,n,BLANK
+filefo,filefo,file_format_raw_scan,false,n,n,y,n,BLANK
+creatb,creatb,creator_raw_scan,false,n,n,y,n,BLANK
+collea,collea,Collection in Repository,false,n,y,n,n,source
+digitb,digitb,Digital Collection,false,n,y,n,y,BLANK
+host,host,Institution,false,n,y,n,y,publis
+sponso,sponso,Sponsor,false,n,n,n,n,BLANK
+callnu,callnu,Call Number,false,n,y,n,n,identi
+additi,additi,Additional Copies,false,n,y,n,y,BLANK
+call,call,"Call number, additional copies",false,n,y,n,n,BLANK
+citati,citati,citation,false,n,n,y,n,BLANK
+copyri,copyri,copyright-holder,false,n,n,y,n,rights
+usager,usager,Copyright,false,y,y,n,n,rights
+cdmid,cdmid,Type,false,y,y,n,y,type
+source,source,source_image,false,n,n,y,n,BLANK
+tile,tile,Tile map url,false,n,n,n,n,BLANK
+tiled,tiled,Tiled map available,false,n,y,n,y,BLANK
+addita,addita,Additional display,false,n,y,y,y,BLANK
+verify,verify,Verify,false,n,y,n,y,BLANK
+fullrs,fullrs,Full resolution,false,n,n,y,n,BLANK
+dmoclcno,dmoclcno,OCLC number,false,n,n,y,n,BLANK
+dmcreated,dmcreated,Date created,false,y,n,y,n,BLANK
+dmmodified,dmmodified,Date modified,false,y,n,y,n,BLANK
+dmrecord,dmrecord,CONTENTdm number,false,y,y,y,n,BLANK
+find,find,CONTENTdm file name,false,y,n,y,n,BLANK


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3959

- adjusts for monograph cpd structure differences in assigning children compound objects
- adds tests for exporting and indexing
- adds cpd and desc.all files for test monograph object