### PR TITLE
BXC-4128 - Grouped work ordering

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommand.java
@@ -6,6 +6,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import edu.unc.lib.boxc.migration.cdm.options.GroupMappingSyncOptions;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
@@ -64,13 +65,13 @@ public class GroupMappingCommand {
 
     @Command(name = "sync",
             description = { "Sync the group mapping file for this project into the index database." } )
-    public int sync() throws Exception {
+    public int sync(@Mixin GroupMappingSyncOptions options) throws Exception {
         long start = System.nanoTime();
 
         try {
             initialize();
 
-            groupService.syncMappings();
+            groupService.syncMappings(options);
             outputLogger.info("Group mapping synched to index for {} in {}s", project.getProjectName(),
                     (System.nanoTime() - start) / 1e9);
             return 0;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommand.java
@@ -72,7 +72,7 @@ public class GroupMappingCommand {
             initialize();
 
             groupService.syncMappings(options);
-            outputLogger.info("Group mapping synched to index for {} in {}s", project.getProjectName(),
+            outputLogger.info("Group mapping synced to index for {} in {}s", project.getProjectName(),
                     (System.nanoTime() - start) / 1e9);
             return 0;
         } catch (MigrationException | IllegalArgumentException e) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
@@ -20,7 +20,7 @@ public class MigrationProjectProperties {
     private Instant sourceFilesUpdatedDate;
     private Instant accessFilesUpdatedDate;
     private Instant groupMappingsUpdatedDate;
-    private Instant groupMappingsSynchedDate;
+    private Instant groupMappingsSyncedDate;
     private Instant descriptionsExpandedDate;
     private Instant sipsGeneratedDate;
     private Set<String> sipsSubmitted;
@@ -144,14 +144,14 @@ public class MigrationProjectProperties {
     }
 
     /**
-     * @return timestamp the group mappings were last synched to the database
+     * @return timestamp the group mappings were last synced to the database
      */
-    public Instant getGroupMappingsSynchedDate() {
-        return groupMappingsSynchedDate;
+    public Instant getGroupMappingsSyncedDate() {
+        return groupMappingsSyncedDate;
     }
 
-    public void setGroupMappingsSynchedDate(Instant groupMappingsSynchedDate) {
-        this.groupMappingsSynchedDate = groupMappingsSynchedDate;
+    public void setGroupMappingsSyncedDate(Instant groupMappingsSyncedDate) {
+        this.groupMappingsSyncedDate = groupMappingsSyncedDate;
     }
 
     /**

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/GroupMappingSyncOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/GroupMappingSyncOptions.java
@@ -1,0 +1,23 @@
+package edu.unc.lib.boxc.migration.cdm.options;
+
+import picocli.CommandLine;
+
+/**
+ * Options for operation to sync group mappings back into the database
+ * @author bbpennel
+ */
+public class GroupMappingSyncOptions {
+    @CommandLine.Option(names = {"-n", "--sort-field"},
+            description = {
+                    "Name of the CDM export field to sort grouped files by within each grouped work."},
+            defaultValue = "file")
+    private String sortField;
+
+    public String getSortField() {
+        return sortField;
+    }
+
+    public void setSortField(String sortField) {
+        this.sortField = sortField;
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldService.java
@@ -155,7 +155,7 @@ public class CdmFieldService {
      * @return
      * @throws IOException
      */
-    public CdmFieldInfo loadFieldsFromProject(MigrationProject project) throws IOException {
+    public CdmFieldInfo loadFieldsFromProject(MigrationProject project) {
         Path fieldsPath = project.getFieldsPath();
         try (
             Reader reader = Files.newBufferedReader(fieldsPath);
@@ -180,6 +180,8 @@ public class CdmFieldService {
                 fields.add(entry);
             }
             return fieldInfo;
+        } catch (IOException e) {
+            throw new InvalidProjectStateException("Cannot read fields file", e);
         }
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingService.java
@@ -280,7 +280,7 @@ public class GroupMappingService {
     }
 
     /**
-     * Syncs group mappings from the mapping file into the database. Clears out any previously synched
+     * Syncs group mappings from the mapping file into the database. Clears out any previously synced
      * group mapping details before updating.
      * @throws IOException
      */
@@ -298,7 +298,7 @@ public class GroupMappingService {
             Statement stmt = conn.createStatement();
             // Cleanup any previously synced grouping data
             cleanupStaleSyncedGroups(stmt);
-            if (project.getProjectProperties().getGroupMappingsSynchedDate() != null) {
+            if (project.getProjectProperties().getGroupMappingsSyncedDate() != null) {
                 setSyncedDate(null);
             }
 
@@ -373,7 +373,7 @@ public class GroupMappingService {
     private void updateGroupedChildrenOrder(Statement stmt, GroupMappingSyncOptions options,
                                             String groupId, List<String> childrenIds) throws SQLException {
         // Retrieve list of children cdm_ids ordered by the sort field with the current group
-        ResultSet rs = stmt.executeQuery("select " + CdmFieldInfo.CDM_ID + "," + options.getSortField()
+        ResultSet rs = stmt.executeQuery("select " + CdmFieldInfo.CDM_ID
                 + " from " + CdmIndexService.TB_NAME
                 + " where " + CdmIndexService.PARENT_ID_FIELD + " = '" + groupId + "'"
                 + " order by " + options.getSortField() + " ASC");
@@ -391,7 +391,7 @@ public class GroupMappingService {
     }
 
     private void setSyncedDate(Instant timestamp) throws IOException {
-        project.getProjectProperties().setGroupMappingsSynchedDate(timestamp);
+        project.getProjectProperties().setGroupMappingsSyncedDate(timestamp);
         ProjectPropertiesSerialization.write(project);
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGeneratorFactory.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGeneratorFactory.java
@@ -31,10 +31,8 @@ public class WorkGeneratorFactory {
 
     public WorkGenerator create(String cdmId, String cdmCreated, String entryType) {
         WorkGenerator gen;
-        if (CdmIndexService.ENTRY_TYPE_COMPOUND_OBJECT.equals(entryType)) {
+        if (CdmIndexService.ENTRY_TYPE_COMPOUND_OBJECT.equals(entryType) || CdmIndexService.ENTRY_TYPE_GROUPED_WORK.equals(entryType)) {
             gen = new OrderedWorkGenerator();
-        } else if (CdmIndexService.ENTRY_TYPE_GROUPED_WORK.equals(entryType)) {
-            gen = new MultiFileWorkGenerator();
         } else {
             gen = new WorkGenerator();
         }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/GroupMappingStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/GroupMappingStatusService.java
@@ -55,8 +55,8 @@ public class GroupMappingStatusService extends AbstractStatusService {
             }
         }
         showField("Mappings Modified", modified == null ? "Not present" : modified);
-        Instant synched = project.getProjectProperties().getGroupMappingsSynchedDate();
-        showField("Last Synched", synched == null ? "Not completed" : synched);
+        Instant synced = project.getProjectProperties().getGroupMappingsSyncedDate();
+        showField("Last Synced", synced == null ? "Not completed" : synced);
 
         if (!verbosity.isNormal()) {
             return;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/ProjectStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/ProjectStatusService.java
@@ -45,8 +45,6 @@ public class ProjectStatusService extends AbstractStatusService {
             showField("Skipped", fieldInfo.getFields().stream().filter(f -> f.getSkipExport()).count());
         } catch (InvalidProjectStateException e) {
             showField("Mapping File Valid", "No (" + e.getMessage() + ")");
-        } catch (IOException e) {
-            throw new MigrationException("Failed to load fields", e);
         }
         sectionDivider();
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommandIT.java
@@ -100,7 +100,7 @@ public class GroupMappingCommandIT extends AbstractCommandIT {
 
         assertOutputMatches(".*Last Generated: +[0-9\\-T:]+.*");
         assertOutputMatches(".*Mappings Modified: +[0-9\\-T:]+.*");
-        assertOutputMatches(".*Last Synched: +Not completed.*");
+        assertOutputMatches(".*Last Synced: +Not completed.*");
 
         String[] args3 = new String[] {
                 "-w", project.getProjectPath().toString(),
@@ -117,7 +117,7 @@ public class GroupMappingCommandIT extends AbstractCommandIT {
 
         assertOutputMatches(".*Last Generated: +[0-9\\-T:]+.*");
         assertOutputMatches(".*Mappings Modified: +[0-9\\-T:]+.*");
-        assertOutputMatches(".*Last Synched: +[0-9\\-T:]+.*");
+        assertOutputMatches(".*Last Synced: +[0-9\\-T:]+.*");
 
         assertOutputMatches(".*Total Groups: +1.*");
         assertOutputMatches(".*Objects In Groups: +2.*");
@@ -134,7 +134,7 @@ public class GroupMappingCommandIT extends AbstractCommandIT {
 
         assertOutputMatches(".*Last Generated: +[0-9\\-T:]+.*");
         assertOutputMatches(".*Mappings Modified: +[0-9\\-T:]+.*");
-        assertOutputMatches(".*Last Synched: +[0-9\\-T:]+.*");
+        assertOutputMatches(".*Last Synced: +[0-9\\-T:]+.*");
 
         assertOutputNotMatches(".*Total Groups.*");
 
@@ -149,7 +149,7 @@ public class GroupMappingCommandIT extends AbstractCommandIT {
 
         assertOutputMatches(".*Last Generated: +[0-9\\-T:]+.*");
         assertOutputMatches(".*Mappings Modified: +[0-9\\-T:]+.*");
-        assertOutputMatches(".*Last Synched: +[0-9\\-T:]+.*");
+        assertOutputMatches(".*Last Synced: +[0-9\\-T:]+.*");
 
         assertOutputMatches(".*Total Groups: +1.*");
         assertOutputMatches(".*Objects In Groups: +2.*");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
@@ -239,7 +239,7 @@ public class SourceFilesCommandIT extends AbstractCommandIT {
     @Test
     public void statusUnmappedDoesNotContainGroupObjectsTest() throws Exception {
         indexGroupExportSamples();
-        addSourceFile("276_182_E.tif");
+        addSourceFile("276_185_E.tif");
         addSourceFile("276_203_E.tif");
 
         String[] args = new String[] {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
@@ -300,7 +300,7 @@ public class CdmFieldServiceTest {
 
     @Test
     public void loadMissingFieldsFileTest() throws Exception {
-        Assertions.assertThrows(NoSuchFileException.class, () -> {
+        Assertions.assertThrows(InvalidProjectStateException.class, () -> {
             service.loadFieldsFromProject(project);
         });
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
@@ -25,7 +25,6 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -33,6 +32,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -73,13 +73,12 @@ public class GroupMappingServiceTest {
     public void generateNoIndexTest() throws Exception {
         GroupMappingOptions options = makeDefaultOptions();
 
-        try {
+        var e = assertThrows(InvalidProjectStateException.class, () -> {
             service.generateMapping(options);
             fail();
-        } catch (InvalidProjectStateException e) {
-            assertExceptionContains("Project must be indexed", e);
-            assertMappedDateNotPresent();
-        }
+        });
+        assertExceptionContains("Project must be indexed", e);
+        assertMappedDateNotPresent();
     }
 
     @Test
@@ -96,7 +95,7 @@ public class GroupMappingServiceTest {
     @Test
     public void generateDryRunTest() throws Exception {
         OutputHelper.captureOutput(() -> {
-            try {
+            assertThrows(NoSuchFileException.class, () -> {
                 indexExportSamples();
                 GroupMappingOptions options = makeDefaultOptions();
                 options.setDryRun(true);
@@ -104,9 +103,7 @@ public class GroupMappingServiceTest {
 
                 service.loadMappings();
                 fail();
-            } catch (NoSuchFileException e) {
-                // expected
-            }
+            });
         });
 
         assertMappedDateNotPresent();
@@ -118,12 +115,9 @@ public class GroupMappingServiceTest {
         GroupMappingOptions options = makeDefaultOptions();
         service.generateMapping(options);
 
-        try {
+        assertThrows(StateAlreadyExistsException.class, () -> {
             service.generateMapping(options);
-            fail();
-        } catch (StateAlreadyExistsException e) {
-            // expected
-        }
+        });
 
         // mapping state should be unchanged
         GroupMappingInfo info = service.loadMappings();
@@ -236,57 +230,50 @@ public class GroupMappingServiceTest {
 
     @Test
     public void syncNotIndexedTest() throws Exception {
-        try {
+        var e = assertThrows(InvalidProjectStateException.class, () -> {
             service.syncMappings(makeDefaultSyncOptions());
-            fail();
-        } catch (InvalidProjectStateException e) {
-            assertExceptionContains("Project must be indexed", e);
-            assertMappedDateNotPresent();
-            assertSynchedDateNotPresent();
-        }
+        });
+        assertExceptionContains("Project must be indexed", e);
+        assertMappedDateNotPresent();
+        assertSyncedDateNotPresent();
     }
 
     @Test
     public void syncNotGeneratedTest() throws Exception {
         indexExportSamples();
-        try {
+        var e = assertThrows(InvalidProjectStateException.class, () -> {
             service.syncMappings(makeDefaultSyncOptions());
-            fail();
-        } catch (InvalidProjectStateException e) {
-            assertExceptionContains("Project has not previously generated group mappings", e);
-            assertMappedDateNotPresent();
-            assertSynchedDateNotPresent();
-        }
+        });
+        assertExceptionContains("Project has not previously generated group mappings", e);
+        assertMappedDateNotPresent();
+        assertSyncedDateNotPresent();
     }
 
     @Test
     public void syncNoSortFieldTest() throws Exception {
         indexExportSamples();
         service.generateMapping(makeDefaultOptions());
-        try {
+
+        var e = assertThrows(IllegalArgumentException.class, () -> {
             var options = makeDefaultSyncOptions();
             options.setSortField("");
             service.syncMappings(options);
-            fail();
-        } catch (IllegalArgumentException e) {
-            assertExceptionContains("Sort field must be provided", e);
-            assertSynchedDateNotPresent();
-        }
+        });
+        assertExceptionContains("Sort field must be provided", e);
+        assertSyncedDateNotPresent();
     }
 
     @Test
     public void syncInvalidSortFieldTest() throws Exception {
         indexExportSamples();
         service.generateMapping(makeDefaultOptions());
-        try {
+        var e = assertThrows(IllegalArgumentException.class, () -> {
             var options = makeDefaultSyncOptions();
             options.setSortField("boxy");
             service.syncMappings(options);
-            fail();
-        } catch (IllegalArgumentException e) {
-            assertExceptionContains("Sort field must be a valid field for this project", e);
-            assertSynchedDateNotPresent();
-        }
+        });
+        assertExceptionContains("Sort field must be a valid field for this project", e);
+        assertSyncedDateNotPresent();
     }
 
     @Test
@@ -301,14 +288,14 @@ public class GroupMappingServiceTest {
         try {
             GroupMappingInfo info = service.loadMappings();
             conn = indexService.openDbConnection();
-            assertWorkSynched(conn, "groupa:group1", "Redoubt C", "2005-11-23");
+            assertWorkSynced(conn, "groupa:group1", "Redoubt C", "2005-11-23");
             assertFilesGrouped(conn, "groupa:group1", "25", "26");
             assertFileHasOrder(conn, "25", 1);
             assertFileHasOrder(conn, "26", 0);
             // Group key with a single child should not be grouped
             assertNumberOfGroups(conn, 1);
             assertParentIdsPresent(conn, "groupa:group1", null);
-            assertSynchedDatePresent();
+            assertSyncedDatePresent();
         } finally {
             CdmIndexService.closeDbConnection(conn);
         }
@@ -327,14 +314,14 @@ public class GroupMappingServiceTest {
         try {
             GroupMappingInfo info = service.loadMappings();
             conn = indexService.openDbConnection();
-            assertWorkSynched(conn, "digitc:2005-11-10", "Redoubt C", "2005-11-23");
+            assertWorkSynced(conn, "digitc:2005-11-10", "Redoubt C", "2005-11-23");
             assertFilesGrouped(conn, "digitc:2005-11-10", "25", "28", "29");
             assertFileHasOrder(conn, "25", 0);
             assertFileHasOrder(conn, "28", 1);
             assertFileHasOrder(conn, "29", 2);
             assertNumberOfGroups(conn, 1);
             assertParentIdsPresent(conn, "digitc:2005-11-10", null);
-            assertSynchedDatePresent();
+            assertSyncedDatePresent();
         } finally {
             CdmIndexService.closeDbConnection(conn);
         }
@@ -348,7 +335,7 @@ public class GroupMappingServiceTest {
         try {
             GroupMappingInfo info = service.loadMappings();
             conn = indexService.openDbConnection();
-            assertWorkSynched(conn, "groupa:group1", "Redoubt C", "2005-11-23");
+            assertWorkSynced(conn, "groupa:group1", "Redoubt C", "2005-11-23");
             assertFilesGrouped(conn, "groupa:group1", "25", "26");
             assertFileHasOrder(conn, "25", 1);
             assertFileHasOrder(conn, "26", 0);
@@ -359,13 +346,13 @@ public class GroupMappingServiceTest {
             assertGroupingPresent(info, "groupa:group1", "25", "26");
             assertEquals(1, info.getGroupedMappings().size());
 
-            assertSynchedDatePresent();
+            assertSyncedDatePresent();
         } finally {
             CdmIndexService.closeDbConnection(conn);
         }
     }
 
-    private void assertWorkSynched(Connection conn, String workId, String expectedTitle, String expectedCreated)
+    private void assertWorkSynced(Connection conn, String workId, String expectedTitle, String expectedCreated)
             throws Exception {
         String groupKey = asGroupKey(workId);
         Statement stmt = conn.createStatement();
@@ -492,14 +479,14 @@ public class GroupMappingServiceTest {
         assertNull(props.getGroupMappingsUpdatedDate());
     }
 
-    private void assertSynchedDatePresent() throws Exception {
+    private void assertSyncedDatePresent() throws Exception {
         MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
-        assertNotNull(props.getGroupMappingsSynchedDate());
+        assertNotNull(props.getGroupMappingsSyncedDate());
     }
 
-    private void assertSynchedDateNotPresent() throws Exception {
+    private void assertSyncedDateNotPresent() throws Exception {
         MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
-        assertNull(props.getGroupMappingsSynchedDate());
+        assertNull(props.getGroupMappingsSyncedDate());
     }
 
     private void assertGroupAMappingsPresent(GroupMappingInfo info) {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -6,6 +6,7 @@ import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationSip;
 import edu.unc.lib.boxc.migration.cdm.options.GroupMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.options.GroupMappingSyncOptions;
 import edu.unc.lib.boxc.migration.cdm.options.SipGenerationOptions;
 import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
@@ -450,7 +451,7 @@ public class SipServiceTest {
         groupService.setIndexService(testHelper.getIndexService());
         groupService.setFieldService(testHelper.getFieldService());
         groupService.generateMapping(groupOptions);
-        groupService.syncMappings();
+        groupService.syncMappings(new GroupMappingSyncOptions());
 
         List<MigrationSip> sips = service.generateSips(makeOptions());
         assertEquals(1, sips.size());
@@ -496,7 +497,7 @@ public class SipServiceTest {
         groupService.setIndexService(testHelper.getIndexService());
         groupService.setFieldService(testHelper.getFieldService());
         groupService.generateMapping(groupOptions);
-        groupService.syncMappings();
+        groupService.syncMappings(new GroupMappingSyncOptions());
 
         List<MigrationSip> sips = service.generateSips(makeOptions());
         assertEquals(1, sips.size());
@@ -654,7 +655,7 @@ public class SipServiceTest {
         groupService.setIndexService(testHelper.getIndexService());
         groupService.setFieldService(testHelper.getFieldService());
         groupService.generateMapping(groupOptions);
-        groupService.syncMappings();
+        groupService.syncMappings(new GroupMappingSyncOptions());
 
         service.generateSips(makeOptions());
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -439,10 +439,11 @@ public class SipServiceTest {
 
     @Test
     public void generateSipsWithGroupedWork() throws Exception {
-        testHelper.indexExportData("mini_gilmer");
+        testHelper.indexExportData("grouped_gilmer");
         testHelper.generateDefaultDestinationsMapping(DEST_UUID, null);
         testHelper.populateDescriptions("grouped_mods.xml");
-        List<Path> stagingLocs = testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
+        List<Path> stagingLocs = testHelper.populateSourceFiles("276_185_E.tif", "276_183_E.tif", "276_203_E.tif",
+                "276_241_E.tif", "276_245a_E.tif");
 
         GroupMappingOptions groupOptions = new GroupMappingOptions();
         groupOptions.setGroupField("groupa");
@@ -451,7 +452,7 @@ public class SipServiceTest {
         groupService.setIndexService(testHelper.getIndexService());
         groupService.setFieldService(testHelper.getFieldService());
         groupService.generateMapping(groupOptions);
-        groupService.syncMappings(new GroupMappingSyncOptions());
+        groupService.syncMappings(makeDefaultSyncOptions());
 
         List<MigrationSip> sips = service.generateSips(makeOptions());
         assertEquals(1, sips.size());
@@ -465,19 +466,26 @@ public class SipServiceTest {
 
         Bag depBag = model.getBag(sip.getDepositPid().getRepositoryPath());
         List<RDFNode> depBagChildren = depBag.iterator().toList();
-        assertEquals(2, depBagChildren.size());
+        assertEquals(4, depBagChildren.size());
 
         Resource workResc1 = testHelper.getResourceByCreateTime(depBagChildren, "2005-11-23");
         Bag work1Bag = model.getBag(workResc1);
         testHelper.assertGroupedWorkPopulatedInSip(workResc1, dirManager, model, "grp:groupa:group1", false,
                 stagingLocs.get(0), stagingLocs.get(1));
-        assertFalse(workResc1.hasProperty(Cdr.memberOrder), "Grouped work should not have order");
         // Assert that children of grouped work have descriptions added (only second file as a description)
+        Resource work1File1Resc = testHelper.findChildByStagingLocation(work1Bag, stagingLocs.get(0));
         Resource work1File2Resc = testHelper.findChildByStagingLocation(work1Bag, stagingLocs.get(1));
         testHelper.assertModsPresentWithCdmId(dirManager, PIDs.get(work1File2Resc.getURI()), "26");
-        Resource workResc3 = testHelper.getResourceByCreateTime(depBagChildren, "2005-12-08");
-        testHelper.assertObjectPopulatedInSip(workResc3, dirManager, model, stagingLocs.get(2), null, "27");
-        assertFalse(workResc3.hasProperty(Cdr.memberOrder), "Grouped work should not have order");
+        // Second file should be ordered before the first file for the grouped work
+        String work1Members = PIDs.get(work1File2Resc.getURI()).getId() + "|" + PIDs.get(work1File1Resc.getURI()).getId();
+        assertTrue(workResc1.hasProperty(Cdr.memberOrder, work1Members));
+        Resource workResc2 = testHelper.getResourceByCreateTime(depBagChildren, "2005-12-08");
+        testHelper.assertObjectPopulatedInSip(workResc2, dirManager, model, stagingLocs.get(2), null, "27");
+        assertFalse(workResc2.hasProperty(Cdr.memberOrder), "Work with group field but only one file should not have order");
+        Resource workResc3 = testHelper.getResourceByCreateTime(depBagChildren, "2005-12-09");
+        assertFalse(workResc3.hasProperty(Cdr.memberOrder), "Regular work should not have order");
+        Resource workResc4 = testHelper.getResourceByCreateTime(depBagChildren, "2005-12-10");
+        assertFalse(workResc4.hasProperty(Cdr.memberOrder), "Regular work should not have order");
 
         assertPersistedSipInfoMatches(sip);
     }
@@ -497,7 +505,7 @@ public class SipServiceTest {
         groupService.setIndexService(testHelper.getIndexService());
         groupService.setFieldService(testHelper.getFieldService());
         groupService.generateMapping(groupOptions);
-        groupService.syncMappings(new GroupMappingSyncOptions());
+        groupService.syncMappings(makeDefaultSyncOptions());
 
         List<MigrationSip> sips = service.generateSips(makeOptions());
         assertEquals(1, sips.size());
@@ -655,7 +663,7 @@ public class SipServiceTest {
         groupService.setIndexService(testHelper.getIndexService());
         groupService.setFieldService(testHelper.getFieldService());
         groupService.generateMapping(groupOptions);
-        groupService.syncMappings(new GroupMappingSyncOptions());
+        groupService.syncMappings(makeDefaultSyncOptions());
 
         service.generateSips(makeOptions());
 
@@ -836,6 +844,12 @@ public class SipServiceTest {
         SipGenerationOptions options = new SipGenerationOptions();
         options.setUsername(USERNAME);
         options.setForce(force);
+        return options;
+    }
+
+    private GroupMappingSyncOptions makeDefaultSyncOptions() {
+        var options = new GroupMappingSyncOptions();
+        options.setSortField("file");
         return options;
     }
 

--- a/src/test/resources/descriptions/grouped_gilmer/index/description/desc.all
+++ b/src/test/resources/descriptions/grouped_gilmer/index/description/desc.all
@@ -255,7 +255,7 @@
 <dmad1></dmad1>
 <dmad2></dmad2>
 <dmoclcno></dmoclcno>
-<dmcreated>2005-12-08</dmcreated>
+<dmcreated>2005-12-09</dmcreated>
 <dmmodified>2015-09-14</dmmodified>
 <dmrecord>28</dmrecord>
 <title>Fort Fisher and adjoining fortifications</title>
@@ -320,6 +320,6 @@
 <dmad1></dmad1>
 <dmad2></dmad2>
 <dmoclcno></dmoclcno>
-<dmcreated>2005-12-08</dmcreated>
+<dmcreated>2005-12-10</dmcreated>
 <dmmodified>2015-09-14</dmmodified>
 <dmrecord>29</dmrecord>

--- a/src/test/resources/descriptions/grouped_gilmer/index/description/desc.all
+++ b/src/test/resources/descriptions/grouped_gilmer/index/description/desc.all
@@ -31,7 +31,7 @@
 <local>276/182</local>
 <creata>Gilmer Map Number 7</creata>
 <sponso>[Identification of item], in the Jeremy Francis Gilmer Papers #276, Southern Historical Collection, Wilson Library, University of North Carolina at Chapel Hill.</sponso>
-<file>276_182_E.tif</file>
+<file>276_185_E.tif</file>
 <rights>Public Domain</rights>
 <orderi></orderi>
 <initia>276_182.tif</initia>

--- a/src/test/resources/mods_collections/grouped_mods.xml
+++ b/src/test/resources/mods_collections/grouped_mods.xml
@@ -14,4 +14,12 @@
         <mods:identifier type="local">276/203</mods:identifier>
         <mods:identifier type="local" displayLabel="CONTENTdm number">27</mods:identifier>
     </mods:mods>
+    <mods:mods>
+        <mods:titleInfo><mods:title>Title on map.</mods:title></mods:titleInfo>
+        <mods:identifier type="local" displayLabel="CONTENTdm number">28</mods:identifier>
+    </mods:mods>
+    <mods:mods>
+        <mods:titleInfo><mods:title>Fort Fisher and adjoining fortifications</mods:title></mods:titleInfo>
+        <mods:identifier type="local" displayLabel="CONTENTdm number">29</mods:identifier>
+    </mods:mods>
 </mods:modsCollection>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-4128

* When syncing group works back into the database, chompb will capture order of files within works, where the children are ordered by a user specified CDM field (defaults to "file")
* Some refactoring to break up large method
* Update grouped work sip generation test to use a more appropriate dataset, update some related test resources to work better with sip generation.