### PR TITLE
BXC-4299 replace deprecated MockitoAnnotations.initMocks

### DIFF
--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
@@ -9,6 +9,7 @@ import edu.unc.lib.boxc.migration.cdm.services.export.ExportStateService;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -28,13 +29,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author bbpennel
  */
 public class CdmExportServiceTest {
     private static final String PROJECT_NAME = "proj";
+    private AutoCloseable closeable;
     @TempDir
     public Path tmpFolder;
 
@@ -50,7 +52,7 @@ public class CdmExportServiceTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
                 tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         fieldService = new CdmFieldService();
@@ -75,6 +77,11 @@ public class CdmExportServiceTest {
                 return null;
             }
         }).when(cdmFileRetrievalService).downloadDescAllFile();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     private CdmExportOptions makeExportOptions() {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
@@ -5,13 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -22,6 +21,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +40,7 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 public class CdmFieldServiceTest {
     private static final String CDM_BASE_URL = "http://example.com:88/";
     private static final String PROJECT_NAME = "proj";
+    private AutoCloseable closeable;
     @TempDir
     public Path tmpFolder;
 
@@ -54,7 +55,7 @@ public class CdmFieldServiceTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
                 tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
         service = new CdmFieldService();
@@ -63,6 +64,11 @@ public class CdmFieldServiceTest {
 
         when(httpClient.execute(any(HttpGet.class))).thenReturn(httpResp);
         when(httpResp.getEntity()).thenReturn(respEntity);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportServiceTest.java
@@ -4,6 +4,7 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -13,7 +14,7 @@ import java.nio.file.Paths;
 
 import static edu.unc.lib.boxc.migration.cdm.test.PostMigrationReportTestHelper.assertContainsRow;
 import static edu.unc.lib.boxc.migration.cdm.test.PostMigrationReportTestHelper.parseReport;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author bbpennel
@@ -26,6 +27,7 @@ public class PostMigrationReportServiceTest {
     private static final String BOXC_URL_1 = BOXC_BASE_URL + BOXC_ID_1;
     private static final String BOXC_URL_2 = BOXC_BASE_URL + BOXC_ID_2;
     private static final String BOXC_URL_3 = BOXC_BASE_URL + BOXC_ID_3;
+    private AutoCloseable closeable;
     @TempDir
     public Path tmpFolder;
 
@@ -36,7 +38,7 @@ public class PostMigrationReportServiceTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
                 tmpFolder, "proj", null, "user",
                 CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
@@ -48,6 +50,11 @@ public class PostMigrationReportServiceTest {
         service.setChompbConfig(testHelper.getChompbConfig());
         service.setDescriptionsService(testHelper.getDescriptionsService());
         service.init();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportVerifierTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportVerifierTest.java
@@ -1,17 +1,16 @@
 package edu.unc.lib.boxc.migration.cdm.services;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
-import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
-import edu.unc.lib.boxc.migration.cdm.util.PostMigrationReportConstants;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author bbpennel
@@ -39,6 +38,7 @@ public class PostMigrationReportVerifierTest {
     private static final String BOXC_URL_2 = "http://example.com/bxc/91c08272-260f-40f1-bb7c-78854d504368";
     private static final String CDM_URL_1 = "http://localhost/cdm/singleitem/collection/proj/id/25";
     private static final String CDM_URL_2 = "http://localhost/cdm/singleitem/collection/proj/id/26";
+    private AutoCloseable closeable;
     @TempDir
     public Path tmpFolder;
     @Mock
@@ -50,7 +50,7 @@ public class PostMigrationReportVerifierTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
                 tmpFolder, "proj", null, "user",
                 CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
@@ -61,6 +61,11 @@ public class PostMigrationReportVerifierTest {
         verifier = new PostMigrationReportVerifier();
         verifier.setProject(project);
         verifier.setHttpClient(httpClient);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4299](https://unclibrary.atlassian.net/browse/BXC-4299)

- replace initMocks() with openMocks()
- add AutoCloseable instance variable and close the mocks