### PR TITLE
Bxc 4286 extend filter index

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/FilterIndexCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/FilterIndexCommand.java
@@ -82,8 +82,26 @@ public class FilterIndexCommand implements Callable<Integer> {
         if (isNotEmpty(options.getExcludeValues()) && isNotEmpty(options.getIncludeValues())) {
             throw new IllegalArgumentException("Cannot provide both --include and --exclude at the same time");
         }
-        if (isEmpty(options.getExcludeValues()) && isEmpty(options.getIncludeValues())) {
-            throw new IllegalArgumentException("Must provide either an --include or --exclude value (but not both)");
+        if (isEmpty(options.getExcludeValues()) && isEmpty(options.getIncludeValues()) &&
+                StringUtils.isBlank(options.getIncludeRangeStart()) && StringUtils.isBlank(options.getIncludeRangeEnd())
+                && StringUtils.isBlank(options.getExcludeRangeStart()) && StringUtils.isBlank(options.getExcludeRangeEnd())) {
+            throw new IllegalArgumentException("Must provide an --include, --exclude, --include-range-start and " +
+                    "--include-range-end, or --exclude-range-start and --exclude range-end value(s) (but not all)");
+        }
+        if ((!StringUtils.isBlank(options.getIncludeRangeStart()) && !StringUtils.isBlank(options.getExcludeRangeStart())) ||
+                (!StringUtils.isBlank(options.getIncludeRangeEnd()) && !StringUtils.isBlank(options.getExcludeRangeEnd())) ||
+                (!StringUtils.isBlank(options.getIncludeRangeStart()) && !StringUtils.isBlank(options.getExcludeRangeEnd())) ||
+                (!StringUtils.isBlank(options.getExcludeRangeStart()) && !StringUtils.isBlank(options.getIncludeRangeEnd()))) {
+            throw new IllegalArgumentException("Cannot provide both --include-range and" +
+                    " --exclude-range values at the same time");
+        }
+        if ((!StringUtils.isBlank(options.getIncludeRangeStart()) && StringUtils.isBlank(options.getIncludeRangeEnd())) ||
+                (StringUtils.isBlank(options.getIncludeRangeStart()) && !StringUtils.isBlank(options.getIncludeRangeEnd()))) {
+            throw new IllegalArgumentException("Must provide both --include-range-start and --include-range-end");
+        }
+        if ((!StringUtils.isBlank(options.getExcludeRangeStart()) && StringUtils.isBlank(options.getExcludeRangeEnd())) ||
+                (StringUtils.isBlank(options.getExcludeRangeStart()) && !StringUtils.isBlank(options.getExcludeRangeEnd()))) {
+            throw new IllegalArgumentException("Must provide both --exclude-range-start and --exclude-range-end");
         }
         if (StringUtils.isBlank(options.getFieldName())) {
             throw new IllegalArgumentException("Must provide a --field-name value");

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/FilterIndexCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/FilterIndexCommand.java
@@ -88,10 +88,8 @@ public class FilterIndexCommand implements Callable<Integer> {
             throw new IllegalArgumentException("Must provide an --include, --exclude, --include-range-start and " +
                     "--include-range-end, or --exclude-range-start and --exclude range-end value(s) (but not all)");
         }
-        if ((!StringUtils.isBlank(options.getIncludeRangeStart()) && !StringUtils.isBlank(options.getExcludeRangeStart())) ||
-                (!StringUtils.isBlank(options.getIncludeRangeEnd()) && !StringUtils.isBlank(options.getExcludeRangeEnd())) ||
-                (!StringUtils.isBlank(options.getIncludeRangeStart()) && !StringUtils.isBlank(options.getExcludeRangeEnd())) ||
-                (!StringUtils.isBlank(options.getExcludeRangeStart()) && !StringUtils.isBlank(options.getIncludeRangeEnd()))) {
+        if ((StringUtils.isNotBlank(options.getIncludeRangeStart()) || StringUtils.isNotBlank(options.getIncludeRangeEnd())) &&
+                (StringUtils.isNotBlank(options.getExcludeRangeStart()) || StringUtils.isNotBlank(options.getExcludeRangeEnd()))) {
             throw new IllegalArgumentException("Cannot provide both --include-range and" +
                     " --exclude-range values at the same time");
         }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/IndexFilteringOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/IndexFilteringOptions.java
@@ -27,22 +27,22 @@ public class IndexFilteringOptions {
 
     @CommandLine.Option(names = {"-is", "--include-range-start"},
             description = {
-                    "Filter the index to records AFTER the provided START value."})
+                    "Filter the index to records AFTER the provided START value. Inclusive of start/end values."})
     private String includeRangeStart;
 
     @CommandLine.Option(names = {"-ie", "--include-range-end"},
             description = {
-                    "Filter the index to records BEFORE the provided END value."})
+                    "Filter the index to records BEFORE the provided END value. Inclusive of start/end values."})
     private String includeRangeEnd;
 
     @CommandLine.Option(names = {"-es", "--exclude-range-start"},
             description = {
-                    "Filter the index to records which are BEFORE the provided START value."})
+                    "Filter the index to records BEFORE the provided START value. Exclusive of start/end values."})
     private String excludeRangeStart;
 
     @CommandLine.Option(names = {"-ee", "--exclude-range-end"},
             description = {
-                    "Filter the index to records which are AFTER the provided END value."})
+                    "Filter the index to records which are AFTER the provided END value. Exclusive of start/end values."})
     private String excludeRangeEnd;
 
     @CommandLine.Option(names = {"-d", "--dry-run"},

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/IndexFilteringOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/IndexFilteringOptions.java
@@ -25,6 +25,26 @@ public class IndexFilteringOptions {
                     "Filter the index to only records which DO NOT match the provided value(s)."})
     private List<String> excludeValues;
 
+    @CommandLine.Option(names = {"-is", "--include-range-start"},
+            description = {
+                    "Filter the index to records AFTER the provided START value."})
+    private String includeRangeStart;
+
+    @CommandLine.Option(names = {"-ie", "--include-range-end"},
+            description = {
+                    "Filter the index to records BEFORE the provided END value."})
+    private String includeRangeEnd;
+
+    @CommandLine.Option(names = {"-es", "--exclude-range-start"},
+            description = {
+                    "Filter the index to records which are BEFORE the provided START value."})
+    private String excludeRangeStart;
+
+    @CommandLine.Option(names = {"-ee", "--exclude-range-end"},
+            description = {
+                    "Filter the index to records which are AFTER the provided END value."})
+    private String excludeRangeEnd;
+
     @CommandLine.Option(names = {"-d", "--dry-run"},
             description = {
                     "If provided, only output how many items would be left if the filter were applied."})
@@ -52,6 +72,38 @@ public class IndexFilteringOptions {
 
     public void setExcludeValues(List<String> excludeValues) {
         this.excludeValues = excludeValues;
+    }
+
+    public String getIncludeRangeStart() {
+        return includeRangeStart;
+    }
+
+    public void setIncludeRangeStart(String includeRangeStart) {
+        this.includeRangeStart = includeRangeStart;
+    }
+
+    public String getIncludeRangeEnd() {
+        return includeRangeEnd;
+    }
+
+    public void setIncludeRangeEnd(String includeRangeEnd) {
+        this.includeRangeEnd = includeRangeEnd;
+    }
+
+    public String getExcludeRangeStart() {
+        return excludeRangeStart;
+    }
+
+    public void setExcludeRangeStart(String excludeRangeStart) {
+        this.excludeRangeStart = excludeRangeStart;
+    }
+
+    public String getExcludeRangeEnd() {
+        return excludeRangeEnd;
+    }
+
+    public void setExcludeRangeEnd(String excludeRangeEnd) {
+        this.excludeRangeEnd = excludeRangeEnd;
     }
 
     public boolean isDryRun() {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/IndexFilteringService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/IndexFilteringService.java
@@ -95,13 +95,13 @@ public class IndexFilteringService {
             finalQuery = negation + '(' + query + ')';
         } else if ((!StringUtils.isBlank(options.getIncludeRangeStart()) && !StringUtils.isBlank(options.getIncludeRangeEnd())) ||
                 (!StringUtils.isBlank(options.getExcludeRangeStart()) && !StringUtils.isBlank(options.getExcludeRangeEnd()))) {
-            var includeFilter = !StringUtils.isBlank(options.getIncludeRangeStart()) && !StringUtils.isBlank(options.getIncludeRangeEnd());
+            var includeFilter = !StringUtils.isBlank(options.getIncludeRangeStart());
             var startRange = includeFilter ? options.getIncludeRangeStart() : options.getExcludeRangeStart();
             var endRange = includeFilter ? options.getIncludeRangeEnd() : options.getExcludeRangeEnd();
             var query = fieldName + " BETWEEN '" + startRange + "' AND '" + endRange + "'";
             // Negate the filter if we are doing an exclude filter, or if we are inverting the query and it is an include
             var negation = (invertQuery ^ includeFilter ? "" : " NOT ");
-            finalQuery = negation + '(' + query + ')';
+            finalQuery = negation + query;
         }
         return finalQuery;
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/FilterIndexCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/FilterIndexCommandIT.java
@@ -1,17 +1,12 @@
 package edu.unc.lib.boxc.migration.cdm;
 
-import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
 import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -50,7 +45,7 @@ public class FilterIndexCommandIT extends AbstractCommandIT {
     }
 
     @Test
-    public void filterIncludeOrExcpludeTest() throws Exception {
+    public void filterIncludeOrExcludeTest() throws Exception {
         testHelper.indexExportData("grouped_gilmer");
         String[] args = new String[] {
                 "-w", project.getProjectPath().toString(),
@@ -58,11 +53,12 @@ public class FilterIndexCommandIT extends AbstractCommandIT {
                 "-n", "groupa"};
         executeExpectFailure(args);
 
-        assertOutputContains("Must provide either an --include or --exclude value");
+        assertOutputContains("Must provide an --include, --exclude, --include-range-start " +
+                "and --include-range-end, or --exclude-range-start and --exclude range-end value(s) (but not all)");
     }
 
     @Test
-    public void filterBothIncludeAndExcpludeTest() throws Exception {
+    public void filterBothIncludeAndExcludeTest() throws Exception {
         testHelper.indexExportData("grouped_gilmer");
         String[] args = new String[] {
                 "-w", project.getProjectPath().toString(),
@@ -148,6 +144,78 @@ public class FilterIndexCommandIT extends AbstractCommandIT {
         assertOutputContains("Filtering index from 5 to 1 remaining entries");
         assertOutputContains("Filtering of index for my_proj completed");
         assertRemaining(1);
+    }
+
+    @Test
+    public void filterIncludeRangeTest() throws Exception {
+        testHelper.indexExportData("grouped_gilmer");
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "filter_index",
+                "-n", "dmcreated",
+                "-is", "2005-12-01",
+                "-ie", "2005-12-31"};
+        executeExpectSuccess(args);
+
+        assertOutputContains("Filtering index from 5 to 3 remaining entries");
+        assertOutputContains("Filtering of index for my_proj completed");
+        assertRemaining(3);
+    }
+
+    @Test
+    public void filterExcludeRangeTest() throws Exception {
+        testHelper.indexExportData("grouped_gilmer");
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "filter_index",
+                "-n", "dmcreated",
+                "-es", "2005-12-01",
+                "-ee", "2005-12-31"};
+        executeExpectSuccess(args);
+
+        assertOutputContains("Filtering index from 5 to 2 remaining entries");
+        assertOutputContains("Filtering of index for my_proj completed");
+        assertRemaining(2);
+    }
+
+    @Test
+    public void filterBothIncludeExcludeRangeTest() throws Exception {
+        testHelper.indexExportData("grouped_gilmer");
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "filter_index",
+                "-n", "dmcreated",
+                "-is", "2005-12-01",
+                "-ie", "2005-12-31",
+                "-es", "2005-12-01",
+                "-ee", "2005-12-31"};
+        executeExpectFailure(args);
+
+        assertOutputContains("Cannot provide both --include-range and --exclude-range values at the same time");
+    }
+
+    @Test
+    public void filterNoIncludeStartRangeTest() throws Exception {
+        testHelper.indexExportData("grouped_gilmer");
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "filter_index",
+                "-ie", "2005-12-01",};
+        executeExpectFailure(args);
+
+        assertOutputContains("Must provide both --include-range-start and --include-range-end");
+    }
+
+    @Test
+    public void filterNoExcludeEndRangeTest() throws Exception {
+        testHelper.indexExportData("grouped_gilmer");
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "filter_index",
+                "-es", "2005-12-01"};
+        executeExpectFailure(args);
+
+        assertOutputContains("Must provide both --exclude-range-start and --exclude-range-end");
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/IndexFilteringServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/IndexFilteringServiceTest.java
@@ -220,6 +220,36 @@ public class IndexFilteringServiceTest {
         assertIterableEquals(Arrays.asList("602", "603", "604"), remaining);
     }
 
+    @Test
+    public void filterIndexIncludeRangeTest() throws Exception {
+        testHelper.indexExportData("grouped_gilmer");
+
+        var options = new IndexFilteringOptions();
+        options.setFieldName("dmcreated");
+        options.setIncludeRangeStart("2005-12-01");
+        options.setIncludeRangeEnd("2005-12-31");
+        service.filterIndex(options);
+
+        var remaining = getRemainingIds();
+        assertIterableEquals(Arrays.asList("27", "28", "29"), remaining);
+        assertEquals(3, remaining.size());
+    }
+
+    @Test
+    public void filterIndexExcludeRangeTest() throws Exception {
+        testHelper.indexExportData("grouped_gilmer");
+
+        var options = new IndexFilteringOptions();
+        options.setFieldName("dmcreated");
+        options.setExcludeRangeStart("2005-12-01");
+        options.setExcludeRangeEnd("2005-12-31");
+        service.filterIndex(options);
+
+        var remaining = getRemainingIds();
+        assertIterableEquals(Arrays.asList("25", "26"), remaining);
+        assertEquals(2, remaining.size());
+    }
+
     private List<String> getRemainingIds() throws Exception {
         Connection conn = testHelper.getIndexService().openDbConnection();
         var result = new ArrayList<String>();


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4286](https://unclibrary.atlassian.net/browse/BXC-4286)

- add `--include-range-start`, `--include-range-end`, `--exclude-range-start`, `--exclude-range-end` options
- `IndexFilteringService`: modify `buildQueryFilters` to allow include/exclude range
- `FilterIndexCommand`: add exceptions to `ValidateOptions`
- add tests, remove unused imports