### PR TITLE
BXC-4305 update destinations.csv with archival coll mappings

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsService.java
@@ -3,7 +3,10 @@ package edu.unc.lib.boxc.migration.cdm.services;
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.options.DestinationMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.validators.DestinationsValidator;
 import edu.unc.lib.boxc.search.api.exceptions.SolrRuntimeException;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
@@ -11,6 +14,10 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocumentList;
 import org.slf4j.Logger;
 
+import java.io.BufferedWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -96,6 +103,46 @@ public class ArchivalDestinationsService {
             }
         }
         return mapCollNumToPid;
+    }
+
+    /**
+     * Add archival collection mapping(s) to destination mappings file
+     * @param options
+     * @throws Exception
+     */
+    public void addArchivalCollectionMappings(DestinationMappingOptions options) throws Exception {
+        DestinationsValidator.assertValidDestination(options.getDefaultDestination());
+
+        Path destinationMappingsPath = project.getDestinationMappingsPath();
+
+        try (
+                BufferedWriter writer = Files.newBufferedWriter(destinationMappingsPath,
+                        StandardOpenOption.APPEND,
+                        StandardOpenOption.CREATE);
+                CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.Builder.create().build());
+        ) {
+            if (options.getDefaultDestination() != null) {
+                Map<String, String> mapCollNumToPid = generateCollectionNumbersToPidMapping(options);
+                for (Map.Entry<String, String> entry : mapCollNumToPid.entrySet()) {
+                    String collNum = entry.getKey();
+                    String pid = entry.getValue();
+
+                    // destinations.csv columns: id, destination, collection
+                    // if the boxc pid is not null, destination field = the boxc pid and "collection" field is empty
+                    // if the boxc pid is null, destination field is empty and "collection" field = <coll_num>
+                    // the user will need to fill in the "destination" value, which would be a boxc AdminUnit pid
+                    if (pid != null) {
+                        csvPrinter.printRecord(options.getFieldName() + ":" + collNum,
+                                pid,
+                                "");
+                    } else {
+                        csvPrinter.printRecord(options.getFieldName() + ":" + collNum,
+                                "",
+                                collNum);
+                    }
+                }
+            }
+        }
     }
 
     public void setProject(MigrationProject project) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsService.java
@@ -44,8 +44,9 @@ public class ArchivalDestinationsService {
     private String solrServerUrl;
     private HttpSolrClient solr;
 
-    public static final String PID = SearchFieldKey.ID.getSolrField();
+    public static final String PID_KEY = SearchFieldKey.ID.getSolrField();
     public static final String COLLECTION_ID = SearchFieldKey.COLLECTION_ID.getSolrField();
+    public static final String RESOURCE_TYPE = SearchFieldKey.RESOURCE_TYPE.getSolrField();
 
     public void initialize() {
         solr = new HttpSolrClient.Builder(solrServerUrl).build();
@@ -85,7 +86,7 @@ public class ArchivalDestinationsService {
      * @param options destination mapping options
      * @return A map
      */
-    public Map<String, String> generateCollectionNumbersToPidMapping(DestinationMappingOptions options) throws Exception {
+    public Map<String, String> generateCollectionNumbersToPidMapping(DestinationMappingOptions options) {
         Map<String, String> mapCollNumToPid = new HashMap<>();
 
         List<String> listCollectionNumbers = generateCollectionNumbersList(options);
@@ -94,7 +95,7 @@ public class ArchivalDestinationsService {
             String collNumQuery =  COLLECTION_ID + ":" + collNum;
             SolrQuery query = new SolrQuery();
             query.set("q", collNumQuery);
-            query.setFilterQueries("resourceType:Collection");
+            query.setFilterQueries(RESOURCE_TYPE + ":Collection");
 
             try {
                 QueryResponse response = solr.query(query);
@@ -102,9 +103,9 @@ public class ArchivalDestinationsService {
                 if (results.isEmpty()) {
                     mapCollNumToPid.put(collNum, null);
                 } else {
-                    mapCollNumToPid.put(collNum, results.get(0).getFieldValue(PID).toString());
+                    mapCollNumToPid.put(collNum, results.get(0).getFieldValue(PID_KEY).toString());
                 }
-            } catch (SolrServerException e) {
+            } catch (SolrServerException | IOException e) {
                 throw new SolrRuntimeException(e);
             }
         }
@@ -116,7 +117,7 @@ public class ArchivalDestinationsService {
      * @param options
      * @throws Exception
      */
-    public void addArchivalCollectionMappings(DestinationMappingOptions options) throws Exception {
+    public void addArchivalCollectionMappings(DestinationMappingOptions options) throws IOException {
         Path destinationMappingsPath = project.getDestinationMappingsPath();
         ensureMappingState(options.isForce());
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsService.java
@@ -111,8 +111,6 @@ public class ArchivalDestinationsService {
      * @throws Exception
      */
     public void addArchivalCollectionMappings(DestinationMappingOptions options) throws Exception {
-        DestinationsValidator.assertValidDestination(options.getDefaultDestination());
-
         Path destinationMappingsPath = project.getDestinationMappingsPath();
 
         try (
@@ -121,7 +119,7 @@ public class ArchivalDestinationsService {
                         StandardOpenOption.CREATE);
                 CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.Builder.create().build());
         ) {
-            if (options.getDefaultDestination() != null) {
+            if (options.getFieldName() != null) {
                 Map<String, String> mapCollNumToPid = generateCollectionNumbersToPidMapping(options);
                 for (Map.Entry<String, String> entry : mapCollNumToPid.entrySet()) {
                     String collNum = entry.getKey();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsServiceTest.java
@@ -112,7 +112,7 @@ public class ArchivalDestinationsServiceTest {
         assertEquals(ArchivalDestinationsService.COLLECTION_ID + ":216", solrValues.get(0).getQuery());
         assertEquals(ArchivalDestinationsService.COLLECTION_ID + ":604", solrValues.get(1).getQuery());
         assertEquals(ArchivalDestinationsService.COLLECTION_ID + ":607", solrValues.get(2).getQuery());
-        assertEquals("resourceType:Collection",
+        assertEquals(ArchivalDestinationsService.RESOURCE_TYPE + ":Collection",
                 Arrays.stream(solrValues.get(0).getFilterQueries()).findFirst().get());
     }
 
@@ -135,7 +135,7 @@ public class ArchivalDestinationsServiceTest {
         assertEquals(ArchivalDestinationsService.COLLECTION_ID + ":216", solrValues.get(0).getQuery());
         assertEquals(ArchivalDestinationsService.COLLECTION_ID + ":604", solrValues.get(1).getQuery());
         assertEquals(ArchivalDestinationsService.COLLECTION_ID + ":607", solrValues.get(2).getQuery());
-        assertEquals("resourceType:Collection",
+        assertEquals(ArchivalDestinationsService.RESOURCE_TYPE + ":Collection",
                 Arrays.stream(solrValues.get(0).getFilterQueries()).findFirst().get());
     }
 
@@ -253,7 +253,7 @@ public class ArchivalDestinationsServiceTest {
 
         QueryResponse testResponseA = new QueryResponse();
         SolrDocument testDocumentA = new SolrDocument();
-        testDocumentA.addField(ArchivalDestinationsService.PID, "bdbd99af-36a5-4bab-9785-e3a802d3737e");
+        testDocumentA.addField(ArchivalDestinationsService.PID_KEY, "bdbd99af-36a5-4bab-9785-e3a802d3737e");
         SolrDocumentList testListA = new SolrDocumentList();
         testListA.add(testDocumentA);
         testResponseA.setResponse(new NamedList<>(Map.of("response", testListA)));

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusServiceTest.java
@@ -253,6 +253,43 @@ public class DestinationsStatusServiceTest extends AbstractOutputTest {
         assertOutputMatches(".*New Collections: +0\n.*");
     }
 
+    @Test
+    public void archivalCollNumsWithPidTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        writeCsv(mappingBody("aid:40126,bdbd99af-36a5-4bab-9785-e3a802d3737e,"));
+
+        statusService.report(Verbosity.VERBOSE);
+
+        assertOutputMatches(".*Last Generated: +[0-9\\-T:]+.*");
+        assertOutputMatches(".*Objects Mapped: +0 \\(0.0%\\).*");
+        assertOutputMatches(".*Unmapped Objects: +3 \\(100.0%\\).*");
+        assertOutputMatches(".*Unmapped Objects:.*\n +\\* 25\n.*");
+        assertOutputMatches(".*Unknown Objects: +1 .*");
+        assertOutputMatches(".*Destinations Valid: +Yes.*");
+        assertOutputMatches(".*To Default: +0 \\(0.0%\\).*");
+        assertOutputMatches(".*Destinations: +1\n.*");
+        assertOutputMatches(".*Destinations:.*\n +\\* bdbd99af-36a5-4bab-9785-e3a802d3737e.*");
+        assertOutputMatches(".*New Collections: +0\n.*");
+    }
+
+    @Test
+    public void archivalCollNumsNullPidTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        writeCsv(mappingBody("aid:40147,,40147"));
+
+        statusService.report(Verbosity.VERBOSE);
+
+        assertOutputMatches(".*Last Generated: +[0-9\\-T:]+.*");
+        assertOutputMatches(".*Objects Mapped: +0 \\(0.0%\\).*");
+        assertOutputMatches(".*Unmapped Objects: +3 \\(100.0%\\).*");
+        assertOutputMatches(".*Unmapped Objects:.*\n +\\* 25\n.*");
+        assertOutputMatches(".*Unknown Objects: +0 .*");
+        assertOutputMatches(".*Destinations Valid: +No.*");
+        assertOutputMatches(".*To Default: +0 \\(0.0%\\).*");
+        assertOutputMatches(".*Destinations: +0\n.*");
+        assertOutputMatches(".*New Collections: +0\n.*");
+    }
+
     private String mappingBody(String... rows) {
         return String.join(",", DestinationsInfo.CSV_HEADERS) + "\n"
                 + String.join("\n", rows);


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4305](https://unclibrary.atlassian.net/browse/BXC-4305)

- `addArchivalCollectionMappings`: method to add archival collection mappings to destination.csv