### PR TITLE
BXC-4306 Map SIPs to destinations by archival coll num

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsService.java
@@ -4,6 +4,7 @@ import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.exceptions.StateAlreadyExistsException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.options.DestinationMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 import edu.unc.lib.boxc.search.api.SearchFieldKey;
 import edu.unc.lib.boxc.search.api.exceptions.SolrRuntimeException;
 import org.apache.commons.csv.CSVFormat;
@@ -24,6 +25,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -148,6 +150,8 @@ public class ArchivalDestinationsService {
                     }
                 }
             }
+            project.getProjectProperties().setDestinationsGeneratedDate(Instant.now());
+            ProjectPropertiesSerialization.write(project);
         } else {
             throw new IllegalArgumentException("Field option is empty");
         }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsService.java
@@ -135,7 +135,7 @@ public class ArchivalDestinationsService {
                     BufferedWriter writer = Files.newBufferedWriter(destinationMappingsPath,
                             StandardOpenOption.APPEND,
                             StandardOpenOption.CREATE);
-                    CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.Builder.create().build());
+                    CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.Builder.create().setHeader(DestinationsInfo.CSV_HEADERS).build());
             ) {
                 Map<String, String> mapCollNumToPid = generateCollectionNumbersToPidMapping(options);
                 for (Map.Entry<String, String> entry : mapCollNumToPid.entrySet()) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsService.java
@@ -2,9 +2,11 @@ package edu.unc.lib.boxc.migration.cdm.services;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.exceptions.StateAlreadyExistsException;
+import edu.unc.lib.boxc.migration.cdm.model.DestinationsInfo;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.options.DestinationMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import edu.unc.lib.boxc.migration.cdm.validators.DestinationsValidator;
 import edu.unc.lib.boxc.search.api.SearchFieldKey;
 import edu.unc.lib.boxc.search.api.exceptions.SolrRuntimeException;
 import org.apache.commons.csv.CSVFormat;
@@ -122,6 +124,7 @@ public class ArchivalDestinationsService {
     public void addArchivalCollectionMappings(DestinationMappingOptions options) throws IOException {
         Path destinationMappingsPath = project.getDestinationMappingsPath();
         ensureMappingState(options.isForce());
+        DestinationsValidator.assertValidDestination(options.getDefaultDestination());
 
         if (options.getFieldName() != null) {
             try (
@@ -148,6 +151,11 @@ public class ArchivalDestinationsService {
                                 "",
                                 collNum);
                     }
+                }
+                if (options.getDefaultDestination() != null) {
+                    csvPrinter.printRecord(DestinationsInfo.DEFAULT_ID,
+                            options.getDefaultDestination(),
+                            options.getDefaultCollection());
                 }
             }
             project.getProjectProperties().setDestinationsGeneratedDate(Instant.now());

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
@@ -261,10 +261,49 @@ public class SipService {
                     return entry;
                 });
 
-                cdmToDestMapper.put(mapping, destEntry);
+                if (mapping.getId().contains(":")) {
+                    for (String cdmId : listCdmIdsByArchivalCollectionId(mapping.getId())) {
+                        cdmToDestMapper.put(cdmId, destEntry);
+                    }
+                } else {
+                    cdmToDestMapper.put(mapping.getId(), destEntry);
+                }
             }
         } catch (IOException e) {
             throw new MigrationException("Failed to load destination mappings", e);
+        }
+    }
+
+    /**
+     * @param id archival collection id
+     * @return list of CDM ids
+     */
+    private List<String> listCdmIdsByArchivalCollectionId(String id) {
+        String[] splitId = id.split(":");
+        String idField = splitId[0];
+        String idValue = splitId[1];
+
+        List<String> cdmIds = new ArrayList<>();
+
+        Connection conn = null;
+        try {
+            conn = indexService.openDbConnection();
+            Statement stmt = conn.createStatement();
+            // skip over values from children of compound objects, since they must go to the same destination as their parent work
+            ResultSet rs = stmt.executeQuery("select " + idValue
+                    + " from " + CdmIndexService.TB_NAME
+                    + " where " + " ("+ CdmIndexService.ENTRY_TYPE_FIELD + " != '"
+                    + CdmIndexService.ENTRY_TYPE_COMPOUND_CHILD + "'" +
+                    " OR " + CdmIndexService.ENTRY_TYPE_FIELD + " is null)" +
+                    " AND " + idField + " = '" + idValue + "'");
+            while (rs.next()) {
+                cdmIds.add(rs.getString(1));
+            }
+            return cdmIds;
+        } catch (SQLException e) {
+            throw new MigrationException("Error interacting with export index", e);
+        } finally {
+            CdmIndexService.closeDbConnection(conn);
         }
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
@@ -263,9 +263,11 @@ public class SipService {
 
                 if (mapping.getId().contains(":")) {
                     for (String cdmId : listCdmIdsByArchivalCollectionId(mapping.getId())) {
+                        System.out.println("archival mapping: " + cdmId);
                         cdmToDestMapper.put(cdmId, destEntry);
                     }
                 } else {
+                    System.out.println("other mapping:" + mapping.getId());
                     cdmToDestMapper.put(mapping.getId(), destEntry);
                 }
             }
@@ -284,6 +286,9 @@ public class SipService {
         String idValue = splitId[1];
 
         List<String> cdmIds = new ArrayList<>();
+        if (idValue.isEmpty()) {
+            return cdmIds;
+        }
 
         Connection conn = null;
         try {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
@@ -263,11 +263,9 @@ public class SipService {
 
                 if (mapping.getId().contains(":")) {
                     for (String cdmId : listCdmIdsByArchivalCollectionId(mapping.getId())) {
-                        System.out.println("archival mapping: " + cdmId);
                         cdmToDestMapper.put(cdmId, destEntry);
                     }
                 } else {
-                    System.out.println("other mapping:" + mapping.getId());
                     cdmToDestMapper.put(mapping.getId(), destEntry);
                 }
             }
@@ -295,7 +293,7 @@ public class SipService {
             conn = indexService.openDbConnection();
             Statement stmt = conn.createStatement();
             // skip over values from children of compound objects, since they must go to the same destination as their parent work
-            ResultSet rs = stmt.executeQuery("select " + idField
+            ResultSet rs = stmt.executeQuery("select " + CdmFieldInfo.CDM_ID
                     + " from " + CdmIndexService.TB_NAME
                     + " where " + " ("+ CdmIndexService.ENTRY_TYPE_FIELD + " != '"
                     + CdmIndexService.ENTRY_TYPE_COMPOUND_CHILD + "'" +

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
@@ -85,7 +85,6 @@ public class SipService {
         redirectMappingService.init();
         sipPremisLogger = new SipPremisLogger();
         sipPremisLogger.setPremisLoggerFactory(premisLoggerFactory);
-        initializeDestinations(options);
         postMigrationReportService = new PostMigrationReportService();
         postMigrationReportService.setDescriptionsService(descriptionsService);
         postMigrationReportService.setProject(project);
@@ -110,6 +109,7 @@ public class SipService {
             log.debug("No access mappings file, no access files will be added to the SIP");
         }
         workGeneratorFactory.setConn(conn);
+        initializeDestinations(options);
     }
 
     /**
@@ -290,7 +290,7 @@ public class SipService {
             conn = indexService.openDbConnection();
             Statement stmt = conn.createStatement();
             // skip over values from children of compound objects, since they must go to the same destination as their parent work
-            ResultSet rs = stmt.executeQuery("select " + idValue
+            ResultSet rs = stmt.executeQuery("select " + idField
                     + " from " + CdmIndexService.TB_NAME
                     + " where " + " ("+ CdmIndexService.ENTRY_TYPE_FIELD + " != '"
                     + CdmIndexService.ENTRY_TYPE_COMPOUND_CHILD + "'" +

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/CdmToDestMapper.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/CdmToDestMapper.java
@@ -15,7 +15,7 @@ public class CdmToDestMapper {
     private Map<String, DestinationSipEntry> cdmId2DestMap = new HashMap<>();
 
     public void put(String mappingId, DestinationSipEntry destEntry) {
-            cdmId2DestMap.put(mappingId, destEntry);
+        cdmId2DestMap.put(mappingId, destEntry);
     }
 
     public DestinationSipEntry getDestinationEntry(String cdmId) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/CdmToDestMapper.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/CdmToDestMapper.java
@@ -14,8 +14,8 @@ import java.util.Map;
 public class CdmToDestMapper {
     private Map<String, DestinationSipEntry> cdmId2DestMap = new HashMap<>();
 
-    public void put(DestinationsInfo.DestinationMapping destMapping, DestinationSipEntry destEntry) {
-        cdmId2DestMap.put(destMapping.getId(), destEntry);
+    public void put(String mappingId, DestinationSipEntry destEntry) {
+            cdmId2DestMap.put(mappingId, destEntry);
     }
 
     public DestinationSipEntry getDestinationEntry(String cdmId) {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsServiceTest.java
@@ -170,6 +170,8 @@ public class ArchivalDestinationsServiceTest {
 
         var options = new DestinationMappingOptions();
         options.setFieldName("dmrecord");
+        options.setDefaultCollection("001234");
+        options.setDefaultDestination("bfe93126-849a-43a5-b9d9-391e18ffacc6");
 
         service.addArchivalCollectionMappings(options);
 
@@ -183,6 +185,7 @@ public class ArchivalDestinationsServiceTest {
             List<CSVRecord> rows = csvParser.getRecords();
             assertIterableEquals(Arrays.asList("dmrecord:604", "", "604"), rows.get(0));
             assertIterableEquals(Arrays.asList("dmrecord:607", "", "607"), rows.get(1));
+            assertIterableEquals(Arrays.asList("default", "bfe93126-849a-43a5-b9d9-391e18ffacc6", "001234"), rows.get(2));
         }
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsServiceTest.java
@@ -41,11 +41,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.MockitoAnnotations.openMocks;
 import static org.mockito.Mockito.when;
 
 public class ArchivalDestinationsServiceTest {
     private static final String PROJECT_NAME = "proj";
+    private static final String DEST_UUID = "bfe93126-849a-43a5-b9d9-391e18ffacc6";
+    private static final String DEST_UUID2 = "8ae56bbc-400e-496d-af4b-3c585e20dba1";
+    private static final String DEST_UUID3 = "bdbd99af-36a5-4bab-9785-e3a802d3737e";
     private static final String SOLR_URL = "http://example.com:88/solr";
 
     @Captor
@@ -83,7 +87,7 @@ public class ArchivalDestinationsServiceTest {
     }
 
     @Test
-    public void generateCollectionNumbersListTest() throws Exception {
+    public void generateCollectionNumbersListKeepsakesTest() throws Exception {
         testHelper.indexExportData("mini_keepsakes");
 
         var options = new DestinationMappingOptions();
@@ -94,8 +98,19 @@ public class ArchivalDestinationsServiceTest {
     }
 
     @Test
-    public void generateCollectionNumbersToPidMappingNullPidTest() throws Exception {
-        solrResponseWithoutPid();
+    public void generateCollectionNumbersListGilmerTest() throws Exception {
+        testHelper.indexExportData("grouped_gilmer");
+
+        var options = new DestinationMappingOptions();
+        options.setFieldName("groupa");
+
+        var result = service.generateCollectionNumbersList(options);
+        assertIterableEquals(Arrays.asList("group1", "group2"), result);
+    }
+
+    @Test
+    public void generateCollectionNumbersToPidMappingNullPidKeepsakesTest() throws Exception {
+        solrResponseWithoutPidKeepsakes();
 
         Map<String, String> expected = new HashMap<>();
         expected.put("216", null);
@@ -117,13 +132,13 @@ public class ArchivalDestinationsServiceTest {
     }
 
     @Test
-    public void generateCollectionNumbersToPidMappingWithPidTest() throws Exception {
-        solrResponseWithPid();
+    public void generateCollectionNumbersToPidMappingWithPidKeepsakesTest() throws Exception {
+        solrResponseWithPidKeepsakes();
 
         Map<String, String> expected = new HashMap<>();
-        expected.put("216", "bdbd99af-36a5-4bab-9785-e3a802d3737e");
+        expected.put("216", DEST_UUID);
         expected.put("604", null);
-        expected.put("607", "bdbd99af-36a5-4bab-9785-e3a802d3737e");
+        expected.put("607", DEST_UUID2);
 
         var options = new DestinationMappingOptions();
         options.setFieldName("dmrecord");
@@ -140,8 +155,8 @@ public class ArchivalDestinationsServiceTest {
     }
 
     @Test
-    public void addArchivalCollectionMappingsWithPidTest() throws Exception {
-        solrResponseWithPid();
+    public void addArchivalCollectionMappingsWithPidKeepsakesTest() throws Exception {
+        solrResponseWithPidKeepsakes();
         Path destinationMappingsPath = project.getDestinationMappingsPath();
 
         var options = new DestinationMappingOptions();
@@ -153,45 +168,43 @@ public class ArchivalDestinationsServiceTest {
         try (
                 Reader reader = Files.newBufferedReader(destinationMappingsPath);
                 CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
-                        .withFirstRecordAsHeader()
-                        .withHeader(FieldUrlAssessmentService.URL_CSV_HEADERS)
                         .withTrim());
         ) {
             List<CSVRecord> rows = csvParser.getRecords();
-            assertIterableEquals(Arrays.asList("dmrecord:604", "", "604"), rows.get(0));
-            assertIterableEquals(Arrays.asList("dmrecord:607", "bdbd99af-36a5-4bab-9785-e3a802d3737e", ""), rows.get(1));
+            assertIterableEquals(Arrays.asList("dmrecord:216", DEST_UUID, ""), rows.get(0));
+            assertIterableEquals(Arrays.asList("dmrecord:604", "", "604"), rows.get(1));
+            assertIterableEquals(Arrays.asList("dmrecord:607", DEST_UUID2, ""), rows.get(2));
         }
     }
 
     @Test
     public void addArchivalCollectionMappingsWithoutPidTest() throws Exception {
-        solrResponseWithoutPid();
+        solrResponseWithoutPidKeepsakes();
         Path destinationMappingsPath = project.getDestinationMappingsPath();
 
         var options = new DestinationMappingOptions();
         options.setFieldName("dmrecord");
         options.setDefaultCollection("001234");
-        options.setDefaultDestination("bfe93126-849a-43a5-b9d9-391e18ffacc6");
+        options.setDefaultDestination(DEST_UUID3);
 
         service.addArchivalCollectionMappings(options);
 
         try (
                 Reader reader = Files.newBufferedReader(destinationMappingsPath);
                 CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
-                        .withFirstRecordAsHeader()
-                        .withHeader(FieldUrlAssessmentService.URL_CSV_HEADERS)
                         .withTrim());
         ) {
             List<CSVRecord> rows = csvParser.getRecords();
-            assertIterableEquals(Arrays.asList("dmrecord:604", "", "604"), rows.get(0));
-            assertIterableEquals(Arrays.asList("dmrecord:607", "", "607"), rows.get(1));
-            assertIterableEquals(Arrays.asList("default", "bfe93126-849a-43a5-b9d9-391e18ffacc6", "001234"), rows.get(2));
+            assertIterableEquals(Arrays.asList("dmrecord:216", "", "216"), rows.get(0));
+            assertIterableEquals(Arrays.asList("dmrecord:604", "", "604"), rows.get(1));
+            assertIterableEquals(Arrays.asList("dmrecord:607", "", "607"), rows.get(2));
+            assertIterableEquals(Arrays.asList("default", DEST_UUID3, "001234"), rows.get(3));
         }
     }
 
     @Test
     public void addArchivalCollectionMappingsWithoutForceFlagTest() throws Exception {
-        solrResponseWithPid();
+        solrResponseWithPidKeepsakes();
         writeCsv(mappingBody("aid:40126,bdbd99af-36a5-4bab-9785-e3a802d3737e,"));
 
         var options = new DestinationMappingOptions();
@@ -208,7 +221,7 @@ public class ArchivalDestinationsServiceTest {
 
     @Test
     public void addArchivalCollectionMappingsWithForceFlagTest() throws Exception {
-        solrResponseWithPid();
+        solrResponseWithPidKeepsakes();
         Path destinationMappingsPath = project.getDestinationMappingsPath();
         writeCsv(mappingBody("aid:40126,2720138a-a1ab-4b73-b7bc-6aabe75620c0,"));
 
@@ -221,13 +234,12 @@ public class ArchivalDestinationsServiceTest {
         try (
                 Reader reader = Files.newBufferedReader(destinationMappingsPath);
                 CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
-                        .withFirstRecordAsHeader()
-                        .withHeader(FieldUrlAssessmentService.URL_CSV_HEADERS)
                         .withTrim());
         ) {
             List<CSVRecord> rows = csvParser.getRecords();
-            assertIterableEquals(Arrays.asList("dmrecord:604", "", "604"), rows.get(0));
-            assertIterableEquals(Arrays.asList("dmrecord:607", "bdbd99af-36a5-4bab-9785-e3a802d3737e", ""), rows.get(1));
+            assertIterableEquals(Arrays.asList("dmrecord:216", DEST_UUID, ""), rows.get(0));
+            assertIterableEquals(Arrays.asList("dmrecord:604", "", "604"), rows.get(1));
+            assertIterableEquals(Arrays.asList("dmrecord:607", DEST_UUID2, ""), rows.get(2));
         }
     }
 
@@ -244,28 +256,61 @@ public class ArchivalDestinationsServiceTest {
         assertTrue(actualMessage.contains(expectedMessage));
     }
 
-    private void solrResponseWithoutPid() throws Exception {
+    private void solrResponseWithoutPidKeepsakes() throws Exception {
         testHelper.indexExportData("mini_keepsakes");
         QueryResponse testResponse = new QueryResponse();
         testResponse.setResponse(new NamedList<>(Map.of("response", new SolrDocumentList())));
         when(solrClient.query(solrQueryCaptor.capture())).thenReturn(testResponse);
     }
 
-    private void solrResponseWithPid() throws Exception {
+    private void solrResponseWithPidKeepsakes() throws Exception {
         testHelper.indexExportData("mini_keepsakes");
 
-        QueryResponse testResponseA = new QueryResponse();
-        SolrDocument testDocumentA = new SolrDocument();
-        testDocumentA.addField(ArchivalDestinationsService.PID_KEY, "bdbd99af-36a5-4bab-9785-e3a802d3737e");
-        SolrDocumentList testListA = new SolrDocumentList();
-        testListA.add(testDocumentA);
-        testResponseA.setResponse(new NamedList<>(Map.of("response", testListA)));
+        QueryResponse testResponse1 = new QueryResponse();
+        SolrDocument testDocument1 = new SolrDocument();
+        testDocument1.addField(ArchivalDestinationsService.PID_KEY, DEST_UUID);
+        SolrDocumentList testList1 = new SolrDocumentList();
+        testList1.add(testDocument1);
+        testResponse1.setResponse(new NamedList<>(Map.of("response", testList1)));
 
-        QueryResponse testResponseB = new QueryResponse();
-        testResponseB.setResponse(new NamedList<>(Map.of("response", new SolrDocumentList())));
+        QueryResponse testResponse2 = new QueryResponse();
+        testResponse2.setResponse(new NamedList<>(Map.of("response", new SolrDocumentList())));
 
-        when(solrClient.query(solrQueryCaptor.capture())).thenReturn(testResponseA).thenReturn(testResponseB)
-                .thenReturn(testResponseA);
+        QueryResponse testResponse3 = new QueryResponse();
+        SolrDocument testDocument3 = new SolrDocument();
+        testDocument3.addField(ArchivalDestinationsService.PID_KEY, DEST_UUID2);
+        SolrDocumentList testList3 = new SolrDocumentList();
+        testList3.add(testDocument3);
+        testResponse3.setResponse(new NamedList<>(Map.of("response", testList3)));
+
+        when(solrClient.query(solrQueryCaptor.capture())).thenReturn(testResponse1).thenReturn(testResponse2)
+                .thenReturn(testResponse3);
+    }
+
+    private void solrResponseWithPidGilmer() throws Exception {
+        QueryResponse testResponse1 = new QueryResponse();
+        SolrDocument testDocument1 = new SolrDocument();
+        testDocument1.addField(ArchivalDestinationsService.PID_KEY, DEST_UUID);
+        SolrDocumentList testList1 = new SolrDocumentList();
+        testList1.add(testDocument1);
+        testResponse1.setResponse(new NamedList<>(Map.of("response", testList1)));
+
+        QueryResponse testResponse2 = new QueryResponse();
+        SolrDocument testDocument2 = new SolrDocument();
+        testDocument2.addField(ArchivalDestinationsService.PID_KEY, DEST_UUID2);
+        SolrDocumentList testList2 = new SolrDocumentList();
+        testList2.add(testDocument2);
+        testResponse2.setResponse(new NamedList<>(Map.of("response", testList2)));
+
+        when(solrClient.query(any())).thenAnswer(invocation -> {
+            var query = invocation.getArgument(0, SolrQuery.class);
+            var solrQ = query.get("q");
+            if (solrQ.equals(ArchivalDestinationsService.COLLECTION_ID + ":group1")) {
+                return testResponse1;
+            } else {
+                return testResponse2;
+            }
+        });
     }
 
     private String mappingBody(String... rows) {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -955,34 +955,34 @@ public class SipServiceTest {
         List<MigrationSip> sips = service.generateSips(makeOptions());
         assertEquals(3, sips.size());
 
-        //groupa:group1
+        // groupa:group2
         MigrationSip sip1 = sips.get(0);
         assertTrue(Files.exists(sip1.getSipPath()));
-        assertEquals(DEST_UUID, sip1.getDestinationPid().getUUID());
+        assertEquals(DEST_UUID2, sip1.getDestinationPid().getUUID());
         Model model = testHelper.getSipModel(sip1);
         Bag depBag = model.getBag(sip1.getDepositPid().getRepositoryPath());
         List<RDFNode> depBagChildren = depBag.iterator().toList();
-        assertEquals(0, depBagChildren.size());
+        assertEquals(1, depBagChildren.size());
         assertPersistedSipInfoMatches(sip1);
 
-        //default, should be groupa:group2
+        // groupa:group1
         MigrationSip sip2 = sips.get(1);
         assertTrue(Files.exists(sip2.getSipPath()));
-        assertEquals(DEST_UUID2, sip2.getDestinationPid().getUUID());
+        assertEquals(DEST_UUID, sip2.getDestinationPid().getUUID());
         Model model2 = testHelper.getSipModel(sip2);
         Bag depBag2 = model2.getBag(sip2.getDepositPid().getRepositoryPath());
         List<RDFNode> depBagChildren2 = depBag2.iterator().toList();
-        assertEquals(0, depBagChildren2.size());
+        assertEquals(2, depBagChildren2.size());
         assertPersistedSipInfoMatches(sip2);
 
-        //default
+        // default
         MigrationSip sip3 = sips.get(2);
         assertTrue(Files.exists(sip3.getSipPath()));
         assertEquals(DEST_UUID3, sip3.getDestinationPid().getUUID());
         Model model3 = testHelper.getSipModel(sip3);
         Bag depBag3 = model3.getBag(sip3.getDepositPid().getRepositoryPath());
         List<RDFNode> depBagChildren3 = depBag3.iterator().toList();
-        assertEquals(4, depBagChildren3.size());
+        assertEquals(2, depBagChildren3.size());
         assertPersistedSipInfoMatches(sip3);
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
@@ -305,8 +305,10 @@ public class SipServiceHelper {
         destinationsService.generateMapping(options);
     }
 
-    public void generateArchivalCollectionDestinationMapping(String fieldName) throws Exception {
+    public void generateArchivalCollectionDestinationMapping(String defDest, String defColl, String fieldName) throws Exception {
         DestinationMappingOptions options = new DestinationMappingOptions();
+        options.setDefaultDestination(defDest);
+        options.setDefaultCollection(defColl);
         options.setFieldName(fieldName);
         archivalDestinationsService.addArchivalCollectionMappings(options);
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,11 +17,13 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import edu.unc.lib.boxc.migration.cdm.services.AggregateFileMappingService;
+import edu.unc.lib.boxc.migration.cdm.services.ArchivalDestinationsService;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
 import edu.unc.lib.boxc.migration.cdm.services.ChompbConfigService;
 import edu.unc.lib.boxc.migration.cdm.services.GroupMappingService;
@@ -31,6 +34,10 @@ import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.vocabulary.RDF;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.util.NamedList;
 import org.jdom2.Document;
 import org.jdom2.Element;
 
@@ -83,6 +90,7 @@ public class SipServiceHelper {
     private AggregateFileMappingService aggregateBottomMappingService;
     private DescriptionsService descriptionsService;
     private DestinationsService destinationsService;
+    private ArchivalDestinationsService archivalDestinationsService;
     private CdmIndexService indexService;
     private GroupMappingService groupMappingService;
     private PIDMinter pidMinter;
@@ -113,6 +121,10 @@ public class SipServiceHelper {
         descriptionsService.setProject(project);
         destinationsService = new DestinationsService();
         destinationsService.setProject(project);
+        archivalDestinationsService = new ArchivalDestinationsService();
+        archivalDestinationsService.setProject(project);
+        archivalDestinationsService.setIndexService(indexService);
+        archivalDestinationsService.setDestinationsService(destinationsService);
 
         Files.createDirectories(project.getExportPath());
     }
@@ -291,6 +303,12 @@ public class SipServiceHelper {
         options.setDefaultDestination(defDest);
         options.setDefaultCollection(defColl);
         destinationsService.generateMapping(options);
+    }
+
+    public void generateArchivalCollectionDestinationMapping(String fieldName) throws Exception {
+        DestinationMappingOptions options = new DestinationMappingOptions();
+        options.setFieldName(fieldName);
+        archivalDestinationsService.addArchivalCollectionMappings(options);
     }
 
     public List<Path> populateSourceFiles(String... filenames) throws Exception {
@@ -475,6 +493,10 @@ public class SipServiceHelper {
 
     public DestinationsService getDestinationsService() {
         return destinationsService;
+    }
+
+    public ArchivalDestinationsService getArchivalDestinationsService() {
+        return archivalDestinationsService;
     }
 
     public CdmIndexService getIndexService() {


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4306](https://unclibrary.atlassian.net/browse/BXC-4306)

- `SipService`: move `initializeDestinations` to end of `initDependencies`, add mapping by archival collection number, add `listCdmIdsByArchivalCollectionId` method, add test
- `ArchivalDestinationsService`: write csv file, add default destination and test
- `CdmToDestMapper`: switch mapping id from DestinationMapping to String
- `SipServiceHelper`: add `generateArchivalDestinationMapping`