### PR TITLE
BXC-4336 - Retain newlines in multiline fields

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
@@ -84,7 +84,7 @@ public class CdmIndexService {
             var recordBuilder = new StringBuilder();
             var incompleteRecord = false;
             for (var line: (Iterable<String>) lineStream::iterator) {
-                recordBuilder.append(line);
+                recordBuilder.append(line).append('\n');
                 incompleteRecord = true;
                 // reached the end of a record
                 if (line.contains(CLOSE_CDM_ID_TAG)) {

--- a/src/test/resources/descriptions/plantations/cdm_fields.csv
+++ b/src/test/resources/descriptions/plantations/cdm_fields.csv
@@ -1,0 +1,53 @@
+cdm_nick,export_as,description,skip_export,cdm_required,cdm_searchable,cdm_hidden,cdm_vocab,cdm_dc_mapping
+title,title,Title,false,y,y,n,n,title
+altern,altern,Alternative Title,false,n,y,n,n,title
+creato,creato,Creator,false,n,y,n,y,creato
+contri,contri,Contributor,false,n,y,n,y,contri
+date,date,Creation Date,false,n,y,y,n,date
+data,data,Date,false,n,n,n,n,date
+search,search,Search by Decade,false,n,y,y,n,coverab
+descri,descri,Description,false,n,y,n,n,descri
+transc,transc,Transcription,false,n,y,n,n,BLANK
+subjec,subjec,Subject (tgm),false,n,y,n,y,subjec
+subjea,subjea,Subject  Name,false,n,y,n,y,subjec
+subjeb,subjeb,Subject  Topical,false,n,y,n,y,subjec
+subjed,subjed,Subject  Geographic,false,n,y,n,y,subjec
+covera,covera,Geographic Location,false,n,y,n,y,coveraa
+titla,titla,Title Note,false,n,n,n,n,descri
+captio,captio,Caption,false,n,y,n,n,descri
+contra,contra,Contributor Note,false,n,n,n,n,descri
+notes,notes,Notes,false,n,n,n,n,descri
+type,type,Original Form,false,n,y,n,y,format
+resour,resour,Resource Type,false,n,y,n,y,type
+langua,langua,Language Code,false,n,n,y,y,langua
+langub,langub,Language,false,n,n,n,y,langua
+format,format,Physical Description of Original,false,n,n,y,n,formata
+medium,medium,Medium of Original,false,n,y,n,y,formatb
+collec,collec,Collection in Repository,false,n,n,n,n,source
+is,is,Is Part Of,false,n,n,n,n,relatig
+digita,digita,Digital Collection,false,n,y,n,n,BLANK
+reposi,reposi,Repository,false,n,n,n,y,publis
+host,host,Host,false,n,n,n,n,publis
+url,url,URL,false,n,n,n,n,identi
+local,local,Local Identifier,false,n,y,n,n,identi
+citati,citati,Citation,false,n,n,n,n,identi
+filena,filena,filename,false,n,n,n,n,BLANK
+path,path,path,false,n,n,n,n,BLANK
+copyri,copyri,Copyright Holder,false,n,n,n,n,rights
+usage,usage,Usage Rights,false,n,n,n,n,rights
+digitc,digitc,Digital Scan Date filename,false,n,n,y,n,BLANK
+creata,creata,Creator Raw Scan,false,n,n,y,n,BLANK
+creatb,creatb,Creator filename,false,n,n,y,n,BLANK
+proces,proces,Processor,false,n,n,y,n,BLANK
+hardwb,hardwb,Hardware filename,false,n,n,y,n,BLANK
+softwb,softwb,Software filename,false,n,n,y,n,BLANK
+pixea,pixea,Pixel Array filename,false,n,n,y,n,BLANK
+bia,bia,Bit Depth filename,false,n,n,y,n,BLANK
+coloa,coloa,Color Space filename,false,n,n,y,n,BLANK
+fila,fila,File Format filename,false,n,n,y,n,BLANK
+fullrs,fullrs,Full resolution,false,n,n,y,n,
+dmoclcno,dmoclcno,OCLC number,false,n,n,y,n,
+dmcreated,dmcreated,Date created,false,y,n,y,n,
+dmmodified,dmmodified,Date modified,false,y,n,y,n,
+dmrecord,dmrecord,CONTENTdm number,false,y,n,y,n,
+find,find,CONTENTdm file name,false,y,n,y,n,

--- a/src/test/resources/descriptions/plantations/index/description/desc.all
+++ b/src/test/resources/descriptions/plantations/index/description/desc.all
@@ -1,0 +1,62 @@
+<title>Page 009</title>
+<altern>1st barrel of Carolina rice, made 1735.</altern>
+<creato></creato>
+<contri></contri>
+<date></date>
+<data></data>
+<search></search>
+<descri>An excerpt from the "South Carolina Gazette," 24 January 1735, describing the history of the first barrel of rice produced in Carolina.</descri>
+<transc>1st Barrel of Carolina Rice, made 1735.
+The following I copied from the "South Carolina Gazette" of "January 24th 1735." (at the Charleston Library, August 1873). 
+"One Barrel of Ancony Rice from 16th Cattel’s plantation, 
+"the first that ever was made in this country, was 
+"ship’d off yesterday by the Mr Richard Hill, for London."
+(Shipped from Charles Town).  (Cattel’s farm near the City).
+(The above has been copied in "Family Record," Vol. III-318. L. M.).</transc>
+<subjec>Rice; Rice industry;</subjec>
+<subjea></subjea>
+<subjeb>Rice--Planting--South Carolina--History--18th century.; Plantations--South Carolina.;</subjeb>
+<subjed>South Carolina--History--18th century.;</subjed>
+<covera>United States, South Carolina;</covera>
+<titla></titla>
+<captio></captio>
+<contra></contra>
+<notes></notes>
+<type></type>
+<resour>Image</resour>
+<langua></langua>
+<langub></langub>
+<format></format>
+<medium></medium>
+<collec></collec>
+<is></is>
+<digita></digita>
+<reposi></reposi>
+<host></host>
+<url></url>
+<local></local>
+<citati></citati>
+<filena>484_009.tif</filena>
+<path></path>
+<copyri>Public domain</copyri>
+<usage></usage>
+<digitc>02/21/2007</digitc>
+<creata>Fred Stipe</creata>
+<creatb>Fred Stipe</creatb>
+<proces></proces>
+<hardwb></hardwb>
+<softwb></softwb>
+<pixea>2633 x 4204</pixea>
+<bia>16</bia>
+<coloa>RGB</coloa>
+<fila>tiff</fila>
+<fullrs></fullrs>
+<find>608.jpg</find>
+<dmaccess></dmaccess>
+<dmimage></dmimage>
+<dmad1></dmad1>
+<dmad2></dmad2>
+<dmoclcno></dmoclcno>
+<dmcreated>2007-04-17</dmcreated>
+<dmmodified>2007-05-14</dmmodified>
+<dmrecord>607</dmrecord>


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4336

* Retain newlines in the middle of fields value, so that we can keep line breaks in transcript/full text fields. Whitespace/newlines at the beginning and end of a fields value will still be trimmed off.