### PR TITLE
BXC-4377 default work permissions

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
@@ -24,6 +24,7 @@ public class MigrationProject {
     public static final String SIPS_DIRNAME = "sips";
     public static final String REDIRECT_MAPPING_FILENAME = "redirect_mappings.csv";
     public static final String POST_MIGR_REPORT_FILENAME = "post_migration_report.csv";
+    public static final String PERMISSIONS_FILENAME = "patron_permissions.csv";
 
     private Path projectPath;
     private MigrationProjectProperties properties;
@@ -161,5 +162,12 @@ public class MigrationProject {
      */
     public Path getPostMigrationReportPath() {
         return projectPath.resolve(POST_MIGR_REPORT_FILENAME);
+    }
+
+    /**
+     * @return Path of the patron permission mappings file
+     */
+    public Path getPermissionsPath() {
+        return projectPath.resolve(PERMISSIONS_FILENAME);
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/PermissionsInfo.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/PermissionsInfo.java
@@ -1,0 +1,75 @@
+package edu.unc.lib.boxc.migration.cdm.model;
+
+import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.PUBLIC_PRINC;
+import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.AUTHENTICATED_PRINC;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Permission mapping information for a project
+ * @author krwong
+ */
+public class PermissionsInfo {
+    public static final String DEFAULT_ID = "default";
+    public static final String ID_FIELD = "id";
+    public static final String[] CSV_HEADERS = new String[] {
+            ID_FIELD, PUBLIC_PRINC, AUTHENTICATED_PRINC };
+
+    private List<PermissionMapping> mappings;
+
+    public PermissionsInfo() {
+        mappings = new ArrayList<>();
+    }
+
+    public List<PermissionMapping> getMappings() {
+        return mappings;
+    }
+
+    public void setMappings(List<PermissionMapping> mappings) {
+        this.mappings = mappings;
+    }
+
+    /**
+     * An individual permission mapping
+     * @author krwong
+     */
+    public static class PermissionMapping {
+        private String id;
+        private String everyone;
+        private String authenticated;
+
+        public PermissionMapping() {
+        }
+
+        public PermissionMapping(String id, String everyone, String authenticated) {
+            this.id = id;
+            this.everyone = everyone;
+            this.authenticated = authenticated;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getEveryone() {
+            return everyone;
+        }
+
+        public void setEveryone(String everyone) {
+            this.everyone = everyone;
+        }
+
+        public String getAuthenticated() {
+            return authenticated;
+        }
+
+        public void setAuthenticated(String authenticated) {
+            this.authenticated = authenticated;
+        }
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
@@ -1,0 +1,71 @@
+package edu.unc.lib.boxc.migration.cdm.options;
+
+import picocli.CommandLine.Option;
+
+public class PermissionMappingOptions {
+    @Option(names = {"-id", "--cdm-id"},
+            description = {
+                    "CDM ID(s) going to a specific box-c deposit destination in this migration project.",
+                    "Must be a CDM ID or a comma-delimited list of CDM IDs"})
+    private String cdmId;
+
+    @Option(names = {"-e", "--everyone"},
+            description = {
+                    "CDM ID(s) going to a specific box-c deposit destination in this migration project.",
+                    "Must be a CDM ID or a comma-delimited list of CDM IDs"})
+    private String everyone;
+
+    @Option(names = {"-a", "--authenticated"},
+            description = {
+                    "CDM ID(s) going to a specific box-c deposit destination in this migration project.",
+                    "Must be a CDM ID or a comma-delimited list of CDM IDs"})
+    private String authenticated;
+
+    @Option(names = {"-f", "--force"},
+            description = "Overwrite permission mapping if one already exists")
+    private boolean force;
+
+    @Option(names = {"-so", "--staff-only"},
+            description = "Staff only permissions, 'everyone' field and 'authenticated' field set to 'none'.")
+    private boolean staffOnly;
+
+    public String getCdmId() {
+        return cdmId;
+    }
+
+    public void setCdmId(String cdmId) {
+        this.cdmId = cdmId;
+    }
+
+    public String getEveryone() {
+        return everyone;
+    }
+
+    public void setEveryone(String everyone) {
+        this.everyone = everyone;
+    }
+
+    public String getAuthenticated() {
+        return authenticated;
+    }
+
+    public void setAuthenticated(String authenticated) {
+        this.authenticated = authenticated;
+    }
+
+    public boolean isForce() {
+        return force;
+    }
+
+    public void setForce(boolean force) {
+        this.force = force;
+    }
+
+    public boolean isStaffOnly() {
+        return staffOnly;
+    }
+
+    public void setStaffOnly(boolean staffOnly) {
+        this.staffOnly = staffOnly;
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
@@ -5,7 +5,7 @@ import picocli.CommandLine.Option;
 
 public class PermissionMappingOptions {
     @Option(names = {"-id", "--cdm-id"},
-            description = "CDM ID(s) of the item(s) being mapping")
+            description = "CDM ID(s) of the item(s) being mapped")
     private String cdmId;
 
     @Option(names = {"-e", "--everyone"},

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
@@ -5,20 +5,17 @@ import picocli.CommandLine.Option;
 public class PermissionMappingOptions {
     @Option(names = {"-id", "--cdm-id"},
             description = {
-                    "CDM ID(s) going to a specific box-c deposit destination in this migration project.",
-                    "Must be a CDM ID or a comma-delimited list of CDM IDs"})
+                    "CDM ID(s) of the item(s) being mapping"})
     private String cdmId;
 
     @Option(names = {"-e", "--everyone"},
             description = {
-                    "CDM ID(s) going to a specific box-c deposit destination in this migration project.",
-                    "Must be a CDM ID or a comma-delimited list of CDM IDs"})
+                    "The patron access role assigned to the “everyone” group."})
     private String everyone;
 
     @Option(names = {"-a", "--authenticated"},
             description = {
-                    "CDM ID(s) going to a specific box-c deposit destination in this migration project.",
-                    "Must be a CDM ID or a comma-delimited list of CDM IDs"})
+                    "The patron access role assigned to the “authenticated” group (anyone that is logged in)."})
     private String authenticated;
 
     @Option(names = {"-f", "--force"},
@@ -26,7 +23,7 @@ public class PermissionMappingOptions {
     private boolean force;
 
     @Option(names = {"-so", "--staff-only"},
-            description = "Staff only permissions, 'everyone' field and 'authenticated' field set to 'none'.")
+            description = "Staff only permissions, 'everyone' field and 'authenticated' field set to 'none'")
     private boolean staffOnly;
 
     public String getCdmId() {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
@@ -1,22 +1,20 @@
 package edu.unc.lib.boxc.migration.cdm.options;
 
+import edu.unc.lib.boxc.auth.api.UserRole;
 import picocli.CommandLine.Option;
 
 public class PermissionMappingOptions {
     @Option(names = {"-id", "--cdm-id"},
-            description = {
-                    "CDM ID(s) of the item(s) being mapping"})
+            description = "CDM ID(s) of the item(s) being mapping")
     private String cdmId;
 
     @Option(names = {"-e", "--everyone"},
-            description = {
-                    "The patron access role assigned to the “everyone” group."})
-    private String everyone;
+            description = {"The patron access role assigned to the “everyone” group."})
+    private UserRole everyone;
 
     @Option(names = {"-a", "--authenticated"},
-            description = {
-                    "The patron access role assigned to the “authenticated” group (anyone that is logged in)."})
-    private String authenticated;
+            description = {"The patron access role assigned to the “authenticated” group (anyone that is logged in)."})
+    private UserRole authenticated;
 
     @Option(names = {"-f", "--force"},
             description = "Overwrite permission mapping if one already exists")
@@ -34,19 +32,19 @@ public class PermissionMappingOptions {
         this.cdmId = cdmId;
     }
 
-    public String getEveryone() {
+    public UserRole getEveryone() {
         return everyone;
     }
 
-    public void setEveryone(String everyone) {
+    public void setEveryone(UserRole everyone) {
         this.everyone = everyone;
     }
 
-    public String getAuthenticated() {
+    public UserRole getAuthenticated() {
         return authenticated;
     }
 
-    public void setAuthenticated(String authenticated) {
+    public void setAuthenticated(UserRole authenticated) {
         this.authenticated = authenticated;
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
@@ -9,11 +9,11 @@ public class PermissionMappingOptions {
     private String cdmId;
 
     @Option(names = {"-e", "--everyone"},
-            description = {"The patron access role assigned to the “everyone” group."})
+            description = "The patron access role assigned to the “everyone” group.")
     private UserRole everyone;
 
     @Option(names = {"-a", "--authenticated"},
-            description = {"The patron access role assigned to the “authenticated” group (anyone that is logged in)."})
+            description = "The patron access role assigned to the “authenticated” group (anyone that is logged in).")
     private UserRole authenticated;
 
     @Option(names = {"-f", "--force"},

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
@@ -1,0 +1,159 @@
+package edu.unc.lib.boxc.migration.cdm.services;
+
+import edu.unc.lib.boxc.auth.api.UserRole;
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.exceptions.StateAlreadyExistsException;
+import edu.unc.lib.boxc.migration.cdm.model.DestinationsInfo;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.model.PermissionsInfo;
+import edu.unc.lib.boxc.migration.cdm.options.PermissionMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.CSVRecord;
+import org.slf4j.Logger;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Service for permission mapping
+ * @author krwong
+ */
+public class PermissionsService {
+    private static final Logger log = getLogger(PermissionsService.class);
+
+    private MigrationProject project;
+    private String everyoneField;
+    private String authenticatedField;
+    private List<String> patronRoles;
+
+    /**
+     * Generates default mapping csv
+     * @param options default mapping options
+     */
+    public void generateDefaultPermissions(PermissionMappingOptions options) throws Exception {
+        Path fieldsPath = project.getPermissionsPath();
+        ensureMappingState(options.isForce());
+
+        List<String> patronRoles = getPatronRoles();
+
+        // Everyone permission
+        if (options.isStaffOnly()) {
+            everyoneField = "none";
+        } else if (options.getEveryone() != null) {
+            if (patronRoles.contains(options.getEveryone())) {
+                everyoneField = options.getEveryone();
+            } else {
+                throw new IllegalArgumentException("Everyone value is invalid. " +
+                        "Must be one of the following patron roles: " + patronRoles);
+            }
+        } else {
+            // if no permissions/roles are specified, default to canViewOriginals
+            everyoneField = "canViewOriginals";
+        }
+
+        // Authenticated permission
+        if (options.isStaffOnly()) {
+            authenticatedField = "none";
+        } else if (options.getAuthenticated() != null) {
+            if (patronRoles.contains(options.getAuthenticated())) {
+                authenticatedField = options.getAuthenticated();
+            } else {
+                throw new IllegalArgumentException("Authenticated value is invalid. " +
+                        "Must be one of the following patron roles: " + patronRoles);
+            }
+        } else {
+            // if no permissions/roles are specified, default to canViewOriginals
+            authenticatedField = "canViewOriginals";
+        }
+
+        try (
+                BufferedWriter writer = Files.newBufferedWriter(fieldsPath);
+                CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.withHeader(PermissionsInfo.CSV_HEADERS));
+        ) {
+            if (options.getCdmId() != null && options.getCdmId().matches("default")) {
+                csvPrinter.printRecord(DestinationsInfo.DEFAULT_ID,
+                        everyoneField,
+                        authenticatedField);
+            }
+        }
+
+        ProjectPropertiesSerialization.write(project);
+    }
+
+    /**
+     * @param project
+     * @return the permissions mapping info for the provided project
+     * @throws IOException
+     */
+    public static PermissionsInfo loadMappings(MigrationProject project) throws IOException {
+        Path path = project.getPermissionsPath();
+        try (
+                Reader reader = Files.newBufferedReader(path);
+                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
+                        .withFirstRecordAsHeader()
+                        .withHeader(PermissionsInfo.CSV_HEADERS)
+                        .withTrim());
+        ) {
+            PermissionsInfo info = new PermissionsInfo();
+            List<PermissionsInfo.PermissionMapping> mappings = info.getMappings();
+            for (CSVRecord csvRecord : csvParser) {
+                PermissionsInfo.PermissionMapping mapping = new PermissionsInfo.PermissionMapping();
+                mapping.setId(csvRecord.get(0));
+                mapping.setEveryone(csvRecord.get(1));
+                mapping.setAuthenticated(csvRecord.get(2));
+                mappings.add(mapping);
+            }
+            return info;
+        }
+    }
+
+    public void removeMappings() throws IOException {
+        try {
+            Files.delete(project.getPermissionsPath());
+        } catch (NoSuchFileException e) {
+            log.debug("File does not exist, skipping deletion");
+        }
+        ProjectPropertiesSerialization.write(project);
+    }
+
+    private void ensureMappingState(boolean force) {
+        if (Files.exists(project.getPermissionsPath())) {
+            if (force) {
+                try {
+                    removeMappings();
+                } catch (IOException e) {
+                    throw new MigrationException("Failed to overwrite permissions file", e);
+                }
+            } else {
+                throw new StateAlreadyExistsException("Cannot create permissions, a file already exists."
+                        + " Use the force flag to overwrite.");
+            }
+        }
+    }
+
+    private List<String> getPatronRoles() {
+        if (patronRoles == null) {
+            patronRoles = new ArrayList<>();
+            List<UserRole> userRoleList = UserRole.getPatronRoles();
+            for (UserRole userRole : userRoleList) {
+                patronRoles.add(userRole.getPredicate());
+            }
+        }
+        return patronRoles;
+    }
+
+    public void setProject(MigrationProject project) {
+        this.project = project;
+    }
+}

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -1,0 +1,197 @@
+package edu.unc.lib.boxc.migration.cdm.services;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.StateAlreadyExistsException;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.model.PermissionsInfo;
+import edu.unc.lib.boxc.migration.cdm.options.PermissionMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
+import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class PermissionsServiceTest {
+    private static final String PROJECT_NAME = "proj";
+
+    @TempDir
+    public Path tmpFolder;
+
+    private SipServiceHelper testHelper;
+    private MigrationProject project;
+    private PermissionsService service;
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        closeable = openMocks(this);
+        project = MigrationProjectFactory.createMigrationProject(
+                tmpFolder, PROJECT_NAME, null, "user",
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
+        testHelper = new SipServiceHelper(project, tmpFolder);
+        service = new PermissionsService();
+        service.setProject(project);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    public void generateDefaultPermissionsTest() throws Exception {
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setCdmId("default");
+        options.setEveryone("canViewMetadata");
+        options.setAuthenticated("canViewMetadata");
+
+        service.generateDefaultPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        try (
+                Reader reader = Files.newBufferedReader(permissionsMappingPath);
+                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
+                        .withFirstRecordAsHeader()
+                        .withHeader(PermissionsInfo.CSV_HEADERS)
+                        .withTrim());
+        ) {
+            List<CSVRecord> rows = csvParser.getRecords();
+            assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        }
+    }
+
+    @Test
+    public void generateDefaultPermissionsNoneTest() throws Exception {
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setCdmId("default");
+
+        service.generateDefaultPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        try (
+                Reader reader = Files.newBufferedReader(permissionsMappingPath);
+                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
+                        .withFirstRecordAsHeader()
+                        .withHeader(PermissionsInfo.CSV_HEADERS)
+                        .withTrim());
+        ) {
+            List<CSVRecord> rows = csvParser.getRecords();
+            assertIterableEquals(Arrays.asList("default", "canViewOriginals", "canViewOriginals"), rows.get(0));
+        }
+    }
+
+    @Test
+    public void generateDefaultPermissionsStaffOnlyTest() throws Exception {
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setCdmId("default");
+        options.setStaffOnly(true);
+
+        service.generateDefaultPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        try (
+                Reader reader = Files.newBufferedReader(permissionsMappingPath);
+                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
+                        .withFirstRecordAsHeader()
+                        .withHeader(PermissionsInfo.CSV_HEADERS)
+                        .withTrim());
+        ) {
+            List<CSVRecord> rows = csvParser.getRecords();
+            assertIterableEquals(Arrays.asList("default", "none", "none"), rows.get(0));
+        }
+    }
+
+    @Test
+    public void generateDefaultPermissionsInvalidTest() throws Exception {
+        var options = new PermissionMappingOptions();
+        options.setCdmId("default");
+        options.setEveryone("canViewMetadata");
+        options.setAuthenticated("test");
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            service.generateDefaultPermissions(options);
+        });
+
+        String expectedMessage = "Authenticated value is invalid. Must be one of the following patron roles: " +
+                "[none, canDiscover, canViewMetadata, canViewAccessCopies, canViewOriginals]";
+        String actualMessage = exception.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void generateDefaultPermissionsWithoutForceFlagTest() throws Exception {
+        writeCsv(mappingBody("default,none,none"));
+
+        var options = new PermissionMappingOptions();
+        options.setCdmId("default");
+        options.setEveryone("canViewMetadata");
+        options.setAuthenticated("canViewMetadata");
+
+        Exception exception = assertThrows(StateAlreadyExistsException.class, () -> {
+            service.generateDefaultPermissions(options);
+        });
+
+        String expectedMessage = "Cannot create permissions, a file already exists. Use the force flag to overwrite.";
+        String actualMessage = exception.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void generateDefaultPermissionsWithForceFlagTest() throws Exception {
+        Path permissionsMappingPath = project.getPermissionsPath();
+        writeCsv(mappingBody("default,none,none"));
+
+        var options = new PermissionMappingOptions();
+        options.setCdmId("default");
+        options.setEveryone("canViewMetadata");
+        options.setAuthenticated("canViewMetadata");
+        options.setForce(true);
+
+        service.generateDefaultPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        try (
+                Reader reader = Files.newBufferedReader(permissionsMappingPath);
+                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
+                        .withFirstRecordAsHeader()
+                        .withHeader(PermissionsInfo.CSV_HEADERS)
+                        .withTrim());
+        ) {
+            List<CSVRecord> rows = csvParser.getRecords();
+            assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        }
+    }
+
+    private String mappingBody(String... rows) {
+        return String.join(",", PermissionsInfo.CSV_HEADERS) + "\n"
+                + String.join("\n", rows);
+    }
+
+    private void writeCsv(String mappingBody) throws IOException {
+        FileUtils.write(project.getPermissionsPath().toFile(),
+                mappingBody, StandardCharsets.UTF_8);
+        ProjectPropertiesSerialization.write(project);
+    }
+}

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -1,5 +1,6 @@
 package edu.unc.lib.boxc.migration.cdm.services;
 
+import edu.unc.lib.boxc.auth.api.UserRole;
 import edu.unc.lib.boxc.migration.cdm.exceptions.StateAlreadyExistsException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.PermissionsInfo;
@@ -62,8 +63,8 @@ public class PermissionsServiceTest {
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
         options.setCdmId("default");
-        options.setEveryone("canViewMetadata");
-        options.setAuthenticated("canViewMetadata");
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
 
         service.generateDefaultPermissions(options);
         assertTrue(Files.exists(permissionsMappingPath));
@@ -127,14 +128,14 @@ public class PermissionsServiceTest {
     public void generateDefaultPermissionsInvalidTest() throws Exception {
         var options = new PermissionMappingOptions();
         options.setCdmId("default");
-        options.setEveryone("canViewMetadata");
-        options.setAuthenticated("test");
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canManage);
 
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
             service.generateDefaultPermissions(options);
         });
 
-        String expectedMessage = "Authenticated value is invalid. Must be one of the following patron roles: " +
+        String expectedMessage = "Assigned role value is invalid. Must be one of the following patron roles: " +
                 "[none, canDiscover, canViewMetadata, canViewAccessCopies, canViewOriginals]";
         String actualMessage = exception.getMessage();
         assertTrue(actualMessage.contains(expectedMessage));
@@ -146,8 +147,8 @@ public class PermissionsServiceTest {
 
         var options = new PermissionMappingOptions();
         options.setCdmId("default");
-        options.setEveryone("canViewMetadata");
-        options.setAuthenticated("canViewMetadata");
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
 
         Exception exception = assertThrows(StateAlreadyExistsException.class, () -> {
             service.generateDefaultPermissions(options);
@@ -165,8 +166,8 @@ public class PermissionsServiceTest {
 
         var options = new PermissionMappingOptions();
         options.setCdmId("default");
-        options.setEveryone("canViewMetadata");
-        options.setAuthenticated("canViewMetadata");
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
         options.setForce(true);
 
         service.generateDefaultPermissions(options);


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4377](https://unclibrary.atlassian.net/browse/BXC-4377)

- `MigrationProject`: add `PERMISSIONS_FILENAME` constant and `getPermissionsPath`
- `PermissionsInfo`: permission mapping info for a project
- `PermissionMappingOptions`: current options include `--cdm-id`, `--everyone`, -`-authenticated`,  and `--force` and `--staff-only` flags
- `PermissionsService`: add methods `generateDefaultPermissions` and `loadMappings`; helper methods `removeMappings`, `ensureMappingState`, `getPatronRoles`; and tests