### PR TITLE
BXC-4379 apply patron permissions in sips

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/PermissionsInfo.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/PermissionsInfo.java
@@ -31,6 +31,21 @@ public class PermissionsInfo {
     }
 
     /**
+     * @return default mapping, or none if no match
+     */
+    public PermissionsInfo.PermissionMapping getDefaultMapping() {
+        return this.mappings.stream().filter(m -> m.getId().equals(DEFAULT_ID)).findFirst().orElse(null);
+    }
+
+    /**
+     * @param cdmId
+     * @return mapping with matching cdm id, or default mapping if no match
+     */
+    public PermissionsInfo.PermissionMapping getMappingByCdmId(String cdmId) {
+        return this.mappings.stream().filter(m -> m.getId().equals(cdmId)).findFirst().orElse(getDefaultMapping());
+    }
+
+    /**
      * An individual permission mapping
      * @author krwong
      */

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
@@ -71,6 +71,7 @@ public class SipService {
     private SipPremisLogger sipPremisLogger;
     private MigrationProject project;
     private ChompbConfigService.ChompbConfig chompbConfig;
+    private PermissionsService permissionsService;
     private PIDMinter pidMinter;
     private CdmToDestMapper cdmToDestMapper = new CdmToDestMapper();
     private WorkGeneratorFactory workGeneratorFactory;
@@ -103,6 +104,11 @@ public class SipService {
         workGeneratorFactory.setPostMigrationReportService(postMigrationReportService);
         workGeneratorFactory.setAggregateTopMappingService(aggregateTopMappingService);
         workGeneratorFactory.setAggregateBottomMappingService(aggregateBottomMappingService);
+        try {
+            workGeneratorFactory.setPermissionsInfo(permissionsService.loadMappings(project));
+        } catch (NoSuchFileException e) {
+            log.debug("No permissions mappings file, no permissions will be added to the SIP");
+        }
         try {
             workGeneratorFactory.setAccessFilesInfo(accessFileService.loadMappings());
         } catch (NoSuchFileException e) {
@@ -366,6 +372,10 @@ public class SipService {
 
     public void setPremisLoggerFactory(PremisLoggerFactory premisLoggerFactory) {
         this.premisLoggerFactory = premisLoggerFactory;
+    }
+
+    public void setPermissionsService(PermissionsService permissionsService) {
+        this.permissionsService = permissionsService;
     }
 
     public void setPidMinter(PIDMinter pidMinter) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGeneratorFactory.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGeneratorFactory.java
@@ -1,5 +1,6 @@
 package edu.unc.lib.boxc.migration.cdm.services.sips;
 
+import edu.unc.lib.boxc.migration.cdm.model.PermissionsInfo;
 import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo;
 import edu.unc.lib.boxc.migration.cdm.options.SipGenerationOptions;
 import edu.unc.lib.boxc.migration.cdm.services.AccessFileService;
@@ -32,6 +33,7 @@ public class WorkGeneratorFactory {
     private AggregateFileMappingService aggregateTopMappingService;
     private AggregateFileMappingService aggregateBottomMappingService;
     private PIDMinter pidMinter;
+    private PermissionsInfo permissionsInfo;
 
     public WorkGenerator create(String cdmId, String cdmCreated, String entryType) throws IOException {
         WorkGenerator gen;
@@ -55,6 +57,7 @@ public class WorkGeneratorFactory {
         gen.pidMinter = pidMinter;
         gen.redirectMappingService = redirectMappingService;
         gen.postMigrationReportService = postMigrationReportService;
+        gen.permissionsInfo = permissionsInfo;
         return gen;
     }
 
@@ -108,5 +111,9 @@ public class WorkGeneratorFactory {
 
     public void setAggregateBottomMappingService(AggregateFileMappingService aggregateBottomMappingService) {
         this.aggregateBottomMappingService = aggregateBottomMappingService;
+    }
+
+    public void setPermissionsInfo(PermissionsInfo permissionsInfo) {
+        this.permissionsInfo = permissionsInfo;
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
@@ -22,11 +22,14 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import edu.unc.lib.boxc.auth.api.UserRole;
+import edu.unc.lib.boxc.migration.cdm.options.PermissionMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.services.AggregateFileMappingService;
 import edu.unc.lib.boxc.migration.cdm.services.ArchivalDestinationsService;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
 import edu.unc.lib.boxc.migration.cdm.services.ChompbConfigService;
 import edu.unc.lib.boxc.migration.cdm.services.GroupMappingService;
+import edu.unc.lib.boxc.migration.cdm.services.PermissionsService;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
@@ -93,6 +96,7 @@ public class SipServiceHelper {
     private ArchivalDestinationsService archivalDestinationsService;
     private CdmIndexService indexService;
     private GroupMappingService groupMappingService;
+    private PermissionsService permissionsService;
     private PIDMinter pidMinter;
     private PremisLoggerFactoryImpl premisLoggerFactory;
     private ChompbConfigService.ChompbConfig chompbConfig;
@@ -125,6 +129,8 @@ public class SipServiceHelper {
         archivalDestinationsService.setProject(project);
         archivalDestinationsService.setIndexService(indexService);
         archivalDestinationsService.setDestinationsService(destinationsService);
+        permissionsService = new PermissionsService();
+        permissionsService.setProject(project);
 
         Files.createDirectories(project.getExportPath());
     }
@@ -141,6 +147,7 @@ public class SipServiceHelper {
         service.setChompbConfig(chompbConfig);
         service.setAggregateTopMappingService(getAggregateFileMappingService());
         service.setAggregateBottomMappingService(getAggregateBottomMappingService());
+        service.setPermissionsService(permissionsService);
         return service;
     }
 
@@ -311,6 +318,14 @@ public class SipServiceHelper {
         options.setDefaultCollection(defColl);
         options.setFieldName(fieldName);
         archivalDestinationsService.addArchivalCollectionMappings(options);
+    }
+
+    public void generatePermissionsMapping(String cdmId, UserRole everyone, UserRole authenticated) throws Exception {
+        PermissionMappingOptions options = new PermissionMappingOptions();
+        options.setCdmId(cdmId);
+        options.setEveryone(everyone);
+        options.setAuthenticated(authenticated);
+        permissionsService.generateDefaultPermissions(options);
     }
 
     public List<Path> populateSourceFiles(String... filenames) throws Exception {


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4379](https://unclibrary.atlassian.net/browse/BXC-4379)

- `PermissionsInfo`: add `getDefaultMapping` and `getMappingByCdmId` methods
- `PermissionsServiceTest`: add test for `getDefaultMapping` and `getMappingByCdmId`
- `SipService`: add `PermissionsInfo` to `initDependencies`
- `SipServiceTest`: add test for generating sips with permissions
- `WorkGenerator`: `addPermission` helper method which takes a CDM ID and a Resource and adds the appropriate literal properties
