### PR TITLE
BXC-4380 validate permissions

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommand.java
@@ -3,15 +3,19 @@ package edu.unc.lib.boxc.migration.cdm;
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.options.PermissionMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.services.PermissionsService;
+import edu.unc.lib.boxc.migration.cdm.validators.PermissionsValidator;
 import org.slf4j.Logger;
+import picocli.CommandLine;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.ParentCommand;
 import picocli.CommandLine.Command;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 
 import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -46,6 +50,38 @@ public class PermissionsCommand {
         } catch (Exception e) {
             log.error("Failed to generate mappings", e);
             outputLogger.info("Failed to generate mappings: {}", e.getMessage(), e);
+            return 1;
+        }
+    }
+
+    @Command(name = "validate",
+            description = "Validate the permissions mapping file for this project")
+    public int validate(@CommandLine.Option(names = { "-f", "--force"},
+            description = "Ignore incomplete, overlapping and duplicate mappings") boolean force) throws Exception {
+        try {
+            initialize();
+            PermissionsValidator validator = new PermissionsValidator();
+            validator.setProject(project);
+            List<String> errors = validator.validateMappings(force);
+            if (errors.isEmpty()) {
+                outputLogger.info("PASS: Permissions mapping at path {} is valid",
+                        project.getPermissionsPath());
+                return 0;
+            } else {
+                if (parentCommand.getVerbosity().equals(Verbosity.QUIET)) {
+                    outputLogger.info("FAIL: Permissions mapping is invalid with {} errors", errors.size());
+                } else {
+                    outputLogger.info("FAIL: Permissions mapping at path {} is invalid due to the following issues:",
+                            project.getPermissionsPath());
+                    for (String error : errors) {
+                        outputLogger.info("    - " + error);
+                    }
+                }
+                return 1;
+            }
+        } catch (MigrationException e) {
+            log.error("Failed to validate permissions mappings", e);
+            outputLogger.info("FAIL: Failed to validate permissions mappings: {}", e.getMessage());
             return 1;
         }
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommand.java
@@ -8,7 +8,6 @@ import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.services.PermissionsService;
 import edu.unc.lib.boxc.migration.cdm.validators.PermissionsValidator;
 import org.slf4j.Logger;
-import picocli.CommandLine;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.ParentCommand;
 import picocli.CommandLine.Command;
@@ -56,13 +55,12 @@ public class PermissionsCommand {
 
     @Command(name = "validate",
             description = "Validate the permissions mapping file for this project")
-    public int validate(@CommandLine.Option(names = { "-f", "--force"},
-            description = "Ignore incomplete, overlapping and duplicate mappings") boolean force) throws Exception {
+    public int validate() throws Exception {
         try {
             initialize();
             PermissionsValidator validator = new PermissionsValidator();
             validator.setProject(project);
-            List<String> errors = validator.validateMappings(force);
+            List<String> errors = validator.validateMappings();
             if (errors.isEmpty()) {
                 outputLogger.info("PASS: Permissions mapping at path {} is valid",
                         project.getPermissionsPath());

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidator.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidator.java
@@ -1,0 +1,118 @@
+package edu.unc.lib.boxc.migration.cdm.validators;
+
+import edu.unc.lib.boxc.auth.api.UserRole;
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.model.PermissionsInfo;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PermissionsValidator {
+    private MigrationProject project;
+    private List<String> patronRoles;
+
+    /**
+     * Validate the permissions mappings for this project.
+     * @param force if true, incomplete, overlapping and duplicate mappings will be ignored
+     * @return A list of errors. An empty list will be returned for a valid mapping
+     */
+    public List<String> validateMappings(boolean force) {
+        List<String> errors = new ArrayList<>();
+        Path path = project.getPermissionsPath();
+        String defaultEveryone = null;
+        String defaultAuthenticated = null;
+
+        try (
+            Reader reader = Files.newBufferedReader(path);
+            CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
+                    .withFirstRecordAsHeader()
+                    .withHeader(PermissionsInfo.CSV_HEADERS)
+                    .withTrim());
+        ) {
+            int i = 2;
+            for (CSVRecord csvRecord : csvParser) {
+                if (csvRecord.size() != 3) {
+                    errors.add("Invalid entry at line " + i + ", must be 3 columns but were " + csvRecord.size());
+                    i++;
+                    continue;
+                }
+                String id = csvRecord.get(0);
+                String everyone = csvRecord.get(1);
+                String authenticated = csvRecord.get(2);
+
+                // default values
+                if (PermissionsInfo.DEFAULT_ID.equals(id)) {
+                    if (defaultEveryone != null && defaultAuthenticated != null) {
+                        errors.add("Can only map default permissions once, encountered reassignment at line " + i);
+                    } else {
+                        defaultEveryone = everyone;
+                        defaultAuthenticated = authenticated;
+                    }
+                }
+
+                // id
+                if (StringUtils.isBlank(id)) {
+                    if (!force) {
+                        errors.add("Invalid blank id at line " + i);
+                    }
+                } else if (!PermissionsInfo.DEFAULT_ID.equals(id)) {
+                    errors.add("ID field must be 'default' (for now).");
+                }
+
+                // everyone
+                if (!StringUtils.isBlank(everyone)) {
+                    List<String> patronRoles = getPatronRoles();
+                    if(!patronRoles.contains(everyone)) {
+                        errors.add("Invalid 'everyone' permission at line " + i + ", " + everyone +
+                                " is not a valid patron permission");
+                    }
+                } else {
+                    errors.add("No 'everyone' permission mapped at line " + i);
+                }
+
+                // authenticated
+                if (!StringUtils.isBlank(authenticated)) {
+                    List<String> patronRoles = getPatronRoles();
+                    if(!patronRoles.contains(authenticated)) {
+                        errors.add("Invalid 'authenticated' permission at line " + i + ", " + authenticated +
+                                " is not a valid patron permission");
+                    }
+                } else {
+                    errors.add("No 'authenticated' permission mapped at line " + i);
+                }
+
+                i++;
+            }
+            if (i == 2) {
+                errors.add("Permission mappings file contained no mappings");
+            }
+            return errors;
+        } catch (IOException | IllegalArgumentException e) {
+            throw new MigrationException("Failed to read mappings file", e);
+        }
+    }
+
+    private List<String> getPatronRoles() {
+        if (patronRoles == null) {
+            patronRoles = new ArrayList<>();
+            List<UserRole> userRoleList = UserRole.getPatronRoles();
+            for (UserRole userRole : userRoleList) {
+                patronRoles.add(userRole.name());
+            }
+        }
+        return patronRoles;
+    }
+
+    public void setProject(MigrationProject project) {
+        this.project = project;
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidator.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidator.java
@@ -63,8 +63,6 @@ public class PermissionsValidator {
                 // id
                 if (StringUtils.isBlank(id)) {
                     errors.add("Invalid blank id at line " + i);
-                } else if (!PermissionsInfo.DEFAULT_ID.equals(id)) {
-                    errors.add("ID field must be 'default' (for now).");
                 }
 
                 // everyone

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidator.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidator.java
@@ -18,7 +18,6 @@ import java.util.List;
 
 /**
  * Validator for permission file mappings.
- *
  * @author krwong
  */
 public class PermissionsValidator {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
@@ -100,6 +100,49 @@ public class PermissionsCommandIT extends AbstractCommandIT {
                 "canViewOriginals");
     }
 
+    @Test
+    public void validateValidDefaultPermissions() throws Exception {
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "generate",
+                "-id", "default",
+                "--everyone", "canViewMetadata",
+                "--authenticated", "canViewMetadata"};
+        executeExpectSuccess(args);
+
+        String[] args2 = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "validate" };
+        executeExpectSuccess(args2);
+
+        assertOutputContains("PASS: Permissions mapping at path " + project.getPermissionsPath() + " is valid");
+    }
+
+    @Test
+    public void validateInvalidDefaultPermissions() throws Exception {
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "generate",
+                "-id", "default",
+                "--everyone", "canViewMetadata",
+                "--authenticated", "canViewMetadata"};
+        executeExpectSuccess(args);
+
+        // Add a duplicate default permissions mapping
+        FileUtils.write(project.getPermissionsPath().toFile(),
+                "default,none,none", StandardCharsets.UTF_8, true);
+
+        String[] args2 = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "validate" };
+        executeExpectFailure(args2);
+
+        assertOutputContains("FAIL: Permissions mapping at path " + project.getPermissionsPath()
+                + " is invalid");
+        assertOutputContains("Can only map default permissions once, encountered reassignment at line 3");
+        assertEquals(2, output.split("    - ").length, "Must only be two errors: " + output);
+    }
+
     private void assertDefaultMapping(String defaultValue, String expectedEveryone, String expectedAuthenticated)
             throws IOException {
         var mappings = getMappings();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
@@ -64,7 +64,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
                 "--authenticated", "canManage"};
         executeExpectFailure(args);
         assertOutputContains("Assigned role value is invalid. Must be one of the following patron roles: " +
-                "[none, canDiscover, canViewMetadata, canViewAccessCopies, canViewOriginals]");
+                "[none, canDiscover, canViewMetadata, canViewAccessCopies, canViewReducedQuality, canViewOriginals]");
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -136,10 +137,9 @@ public class PermissionsServiceTest {
         });
 
         String expectedMessage = "Assigned role value is invalid. Must be one of the following patron roles: " +
-                "[none, canDiscover, canViewMetadata, canViewAccessCopies, canViewOriginals]";
+                "[none, canDiscover, canViewMetadata, canViewAccessCopies, canViewReducedQuality, canViewOriginals]";
         String actualMessage = exception.getMessage();
-        assertTrue(actualMessage.contains(expectedMessage),
-                "Actual message did not contain expected text. Was: " + actualMessage);
+        assertEquals(expectedMessage, actualMessage);
     }
 
     @Test
@@ -157,7 +157,7 @@ public class PermissionsServiceTest {
 
         String expectedMessage = "Cannot create permissions, a file already exists. Use the force flag to overwrite.";
         String actualMessage = exception.getMessage();
-        assertTrue(actualMessage.contains(expectedMessage));
+        assertEquals(expectedMessage, actualMessage);
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -138,7 +138,8 @@ public class PermissionsServiceTest {
         String expectedMessage = "Assigned role value is invalid. Must be one of the following patron roles: " +
                 "[none, canDiscover, canViewMetadata, canViewAccessCopies, canViewOriginals]";
         String actualMessage = exception.getMessage();
-        assertTrue(actualMessage.contains(expectedMessage));
+        assertTrue(actualMessage.contains(expectedMessage),
+                "Actual message did not contain expected text. Was: " + actualMessage);
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidatorTest.java
@@ -44,21 +44,21 @@ public class PermissionsValidatorTest {
     @Test
     public void validMappingsTest() throws Exception {
         writeCsv(mappingBody("default,none,none"));
-        List<String> errors = validator.validateMappings(false);
+        List<String> errors = validator.validateMappings();
         assertNumberErrors(errors, 0);
     }
 
     @Test
     public void noMappingFileTest() throws Exception {
         Assertions.assertThrows(MigrationException.class, () -> {
-            validator.validateMappings(false);
+            validator.validateMappings();
         });
     }
 
     @Test
     public void noEntriesTest() throws Exception {
         writeCsv(mappingBody());
-        List<String> errors = validator.validateMappings(false);
+        List<String> errors = validator.validateMappings();
         assertHasError(errors, "Permission mappings file contained no mappings");
         assertNumberErrors(errors, 1);
     }
@@ -66,7 +66,7 @@ public class PermissionsValidatorTest {
     @Test
     public void blankIdTest() throws Exception {
         writeCsv(mappingBody(",none,none"));
-        List<String> errors = validator.validateMappings(false);
+        List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid blank id at line 2");
         assertNumberErrors(errors, 1);
     }
@@ -74,7 +74,7 @@ public class PermissionsValidatorTest {
     @Test
     public void blankEveryoneTest() throws Exception {
         writeCsv(mappingBody("default,,none"));
-        List<String> errors = validator.validateMappings(false);
+        List<String> errors = validator.validateMappings();
         assertHasError(errors, "No 'everyone' permission mapped at line 2");
         assertNumberErrors(errors, 1);
     }
@@ -82,7 +82,7 @@ public class PermissionsValidatorTest {
     @Test
     public void invalidEveryoneTest() throws Exception {
         writeCsv(mappingBody("default,okaynope,none"));
-        List<String> errors = validator.validateMappings(false);
+        List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid 'everyone' permission at line 2, okaynope is not a valid patron permission");
         assertNumberErrors(errors, 1);
     }
@@ -90,7 +90,7 @@ public class PermissionsValidatorTest {
     @Test
     public void blankAuthenticatedTest() throws Exception {
         writeCsv(mappingBody("default,none,"));
-        List<String> errors = validator.validateMappings(false);
+        List<String> errors = validator.validateMappings();
         assertHasError(errors, "No 'authenticated' permission mapped at line 2");
         assertNumberErrors(errors, 1);
     }
@@ -98,7 +98,7 @@ public class PermissionsValidatorTest {
     @Test
     public void invalidAuthenticatedTest() throws Exception {
         writeCsv(mappingBody("default,none,okaynope"));
-        List<String> errors = validator.validateMappings(false);
+        List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid 'authenticated' permission at line 2, " +
                 "okaynope is not a valid patron permission");
         assertNumberErrors(errors, 1);
@@ -108,7 +108,7 @@ public class PermissionsValidatorTest {
     public void multipleDefaultsTest() throws Exception {
         writeCsv(mappingBody("default,none,none",
                 "default,canViewOriginals,canViewOriginals"));
-        List<String> errors = validator.validateMappings(false);
+        List<String> errors = validator.validateMappings();
         assertHasErrorMatching(errors, "Can only map default permissions once.*at line 3");
         assertNumberErrors(errors, 1);
     }
@@ -116,7 +116,7 @@ public class PermissionsValidatorTest {
     @Test
     public void tooFewColumnsTest() throws Exception {
         writeCsv(mappingBody("default,none"));
-        List<String> errors = validator.validateMappings(false);
+        List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid entry at line 2, must be 3 columns but were 2");
         assertNumberErrors(errors, 1);
     }
@@ -124,7 +124,7 @@ public class PermissionsValidatorTest {
     @Test
     public void tooManyColumnsTest() throws Exception {
         writeCsv(mappingBody("default,none,none,none"));
-        List<String> errors = validator.validateMappings(false);
+        List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid entry at line 2, must be 3 columns but were 4");
         assertNumberErrors(errors, 1);
     }
@@ -132,7 +132,7 @@ public class PermissionsValidatorTest {
     @Test
     public void errorsOnSameLineTest() throws Exception {
         writeCsv(mappingBody("default,okaynope,"));
-        List<String> errors = validator.validateMappings(false);
+        List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid 'everyone' permission at line 2, " +
                 "okaynope is not a valid patron permission");
         assertHasErrorMatching(errors, "No 'authenticated' permission mapped at line 2");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidatorTest.java
@@ -1,7 +1,6 @@
 package edu.unc.lib.boxc.migration.cdm.validators;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
-import edu.unc.lib.boxc.migration.cdm.model.DestinationsInfo;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.PermissionsInfo;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidatorTest.java
@@ -1,0 +1,169 @@
+package edu.unc.lib.boxc.migration.cdm.validators;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.DestinationsInfo;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.model.PermissionsInfo;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.services.PermissionsService;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PermissionsValidatorTest {
+    private static final String PROJECT_NAME = "proj";
+    private static final String USERNAME = "migr_user";
+    @TempDir
+    public Path tmpFolder;
+
+    private MigrationProject project;
+    private PermissionsValidator validator;
+    private PermissionsService permissionsService;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        project = MigrationProjectFactory.createMigrationProject(
+                tmpFolder, PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
+
+        validator = new PermissionsValidator();
+        validator.setProject(project);
+        permissionsService = new PermissionsService();
+        permissionsService.setProject(project);
+    }
+
+    @Test
+    public void validMappingsTest() throws Exception {
+        writeCsv(mappingBody("default,none,none"));
+        List<String> errors = validator.validateMappings(false);
+        assertNumberErrors(errors, 0);
+    }
+
+    @Test
+    public void noMappingFileTest() throws Exception {
+        Assertions.assertThrows(MigrationException.class, () -> {
+            validator.validateMappings(false);
+        });
+    }
+
+    @Test
+    public void noEntriesTest() throws Exception {
+        writeCsv(mappingBody());
+        List<String> errors = validator.validateMappings(false);
+        assertHasError(errors, "Permission mappings file contained no mappings");
+        assertNumberErrors(errors, 1);
+    }
+
+    @Test
+    public void blankIdTest() throws Exception {
+        writeCsv(mappingBody(",none,none"));
+        List<String> errors = validator.validateMappings(false);
+        assertHasError(errors, "Invalid blank id at line 2");
+        assertNumberErrors(errors, 1);
+    }
+
+    @Test
+    public void blankEveryoneTest() throws Exception {
+        writeCsv(mappingBody("default,,none"));
+        List<String> errors = validator.validateMappings(false);
+        assertHasError(errors, "No 'everyone' permission mapped at line 2");
+        assertNumberErrors(errors, 1);
+    }
+
+    @Test
+    public void invalidEveryoneTest() throws Exception {
+        writeCsv(mappingBody("default,okaynope,none"));
+        List<String> errors = validator.validateMappings(false);
+        assertHasError(errors, "Invalid 'everyone' permission at line 2, okaynope is not a valid patron permission");
+        assertNumberErrors(errors, 1);
+    }
+
+    @Test
+    public void blankAuthenticatedTest() throws Exception {
+        writeCsv(mappingBody("default,none,"));
+        List<String> errors = validator.validateMappings(false);
+        assertHasError(errors, "No 'authenticated' permission mapped at line 2");
+        assertNumberErrors(errors, 1);
+    }
+
+    @Test
+    public void invalidAuthenticatedTest() throws Exception {
+        writeCsv(mappingBody("default,none,okaynope"));
+        List<String> errors = validator.validateMappings(false);
+        assertHasError(errors, "Invalid 'authenticated' permission at line 2, " +
+                "okaynope is not a valid patron permission");
+        assertNumberErrors(errors, 1);
+    }
+
+    @Test
+    public void multipleDefaultsTest() throws Exception {
+        writeCsv(mappingBody("default,none,none",
+                "default,canViewOriginals,canViewOriginals"));
+        List<String> errors = validator.validateMappings(false);
+        assertHasErrorMatching(errors, "Can only map default permissions once.*at line 3");
+        assertNumberErrors(errors, 1);
+    }
+
+    @Test
+    public void tooFewColumnsTest() throws Exception {
+        writeCsv(mappingBody("default,none"));
+        List<String> errors = validator.validateMappings(false);
+        assertHasError(errors, "Invalid entry at line 2, must be 3 columns but were 2");
+        assertNumberErrors(errors, 1);
+    }
+
+    @Test
+    public void tooManyColumnsTest() throws Exception {
+        writeCsv(mappingBody("default,none,none,none"));
+        List<String> errors = validator.validateMappings(false);
+        assertHasError(errors, "Invalid entry at line 2, must be 3 columns but were 4");
+        assertNumberErrors(errors, 1);
+    }
+
+    @Test
+    public void errorsOnSameLineTest() throws Exception {
+        writeCsv(mappingBody("default,okaynope,"));
+        List<String> errors = validator.validateMappings(false);
+        assertHasError(errors, "Invalid 'everyone' permission at line 2, " +
+                "okaynope is not a valid patron permission");
+        assertHasErrorMatching(errors, "No 'authenticated' permission mapped at line 2");
+        assertNumberErrors(errors, 2);
+    }
+
+    private void assertHasError(List<String> errors, String expected) {
+        assertTrue(errors.contains(expected),
+                "Expected error:\n" + expected + "\nBut the returned errors were:\n" +
+                        String.join("\n", errors));
+    }
+
+    private void assertHasErrorMatching(List<String> errors, String expectedP) {
+        assertTrue(errors.stream().anyMatch(e -> e.matches(expectedP)),
+                "Expected error:\n" + expectedP + "\nBut the returned errors were:\n" +
+                        String.join("\n", errors));
+    }
+
+    private String mappingBody(String... rows) {
+        return String.join(",", PermissionsInfo.CSV_HEADERS) + "\n"
+                + String.join("\n", rows);
+    }
+
+    private void writeCsv(String mappingBody) throws IOException {
+        FileUtils.write(project.getPermissionsPath().toFile(),
+                mappingBody, StandardCharsets.UTF_8);
+    }
+
+    private void assertNumberErrors(List<String> errors, int expected) {
+        assertEquals(expected, errors.size(),
+                "Incorrect number of errors:\n" + String.join("\n", errors));
+    }
+}

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidatorTest.java
@@ -43,7 +43,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void validMappingsTest() throws Exception {
-        writeCsv(mappingBody("default,none,none"));
+        writeCsv(mappingBody("25,none,none"));
         List<String> errors = validator.validateMappings();
         assertNumberErrors(errors, 0);
     }
@@ -73,7 +73,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void blankEveryoneTest() throws Exception {
-        writeCsv(mappingBody("default,,none"));
+        writeCsv(mappingBody("25,,none"));
         List<String> errors = validator.validateMappings();
         assertHasError(errors, "No 'everyone' permission mapped at line 2");
         assertNumberErrors(errors, 1);
@@ -97,7 +97,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void invalidAuthenticatedTest() throws Exception {
-        writeCsv(mappingBody("default,none,okaynope"));
+        writeCsv(mappingBody("26,none,okaynope"));
         List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid 'authenticated' permission at line 2, " +
                 "okaynope is not a valid patron permission");
@@ -123,7 +123,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void tooManyColumnsTest() throws Exception {
-        writeCsv(mappingBody("default,none,none,none"));
+        writeCsv(mappingBody("25,none,none,none"));
         List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid entry at line 2, must be 3 columns but were 4");
         assertNumberErrors(errors, 1);
@@ -131,7 +131,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void errorsOnSameLineTest() throws Exception {
-        writeCsv(mappingBody("default,okaynope,"));
+        writeCsv(mappingBody("26,okaynope,"));
         List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid 'everyone' permission at line 2, " +
                 "okaynope is not a valid patron permission");


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4380](https://unclibrary.atlassian.net/browse/BXC-4380)

- `PermissionsCommand`: add `validate` subcommand and tests
- `PermissionsValidator`: add `validateMappings` method, `getPatronRoles` helper method, and tests