### PR TITLE
BXC-4410 adjust permissions cmd for default

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
@@ -4,9 +4,9 @@ import edu.unc.lib.boxc.auth.api.UserRole;
 import picocli.CommandLine.Option;
 
 public class PermissionMappingOptions {
-    @Option(names = {"-id", "--cdm-id"},
-            description = "CDM ID(s) of the item(s) being mapped")
-    private String cdmId;
+    @Option(names = {"-wd", "--with-default"},
+            description = "Add 'default' entry to CSV mapping, 'id' field set to 'default")
+    private boolean withDefault;
 
     @Option(names = {"-e", "--everyone"},
             description = "The patron access role assigned to the “everyone” group.")
@@ -24,12 +24,12 @@ public class PermissionMappingOptions {
             description = "Staff only permissions, 'everyone' field and 'authenticated' field set to 'none'")
     private boolean staffOnly;
 
-    public String getCdmId() {
-        return cdmId;
+    public boolean isWithDefault() {
+        return withDefault;
     }
 
-    public void setCdmId(String cdmId) {
-        this.cdmId = cdmId;
+    public void setWithDefault(boolean withDefault) {
+        this.withDefault = withDefault;
     }
 
     public UserRole getEveryone() {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
@@ -59,7 +59,7 @@ public class PermissionsService {
                 BufferedWriter writer = Files.newBufferedWriter(fieldsPath);
                 CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.withHeader(PermissionsInfo.CSV_HEADERS));
         ) {
-            if (options.getCdmId() != null && options.getCdmId().matches(PermissionsInfo.DEFAULT_ID)) {
+            if (options.isWithDefault()) {
                 csvPrinter.printRecord(PermissionsInfo.DEFAULT_ID,
                         everyoneField,
                         authenticatedField);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
@@ -20,11 +20,19 @@ public class PermissionsCommandIT extends AbstractCommandIT {
     }
 
     @Test
+    public void generateNoDefaultPermissions() throws Exception {
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "generate"};
+        executeExpectSuccess(args);
+    }
+
+    @Test
     public void generateDefaultPermissions() throws Exception {
         String[] args = new String[] {
                 "-w", project.getProjectPath().toString(),
                 "permissions", "generate",
-                "-id", "default",
+                "-wd",
                 "--everyone", "canViewMetadata",
                 "--authenticated", "canViewMetadata"};
         executeExpectSuccess(args);
@@ -37,7 +45,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
         String[] args = new String[] {
                 "-w", project.getProjectPath().toString(),
                 "permissions", "generate",
-                "-id", "default"};
+                "-wd"};
         executeExpectSuccess(args);
         assertDefaultMapping("default", "canViewOriginals",
                 "canViewOriginals");
@@ -48,7 +56,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
         String[] args = new String[] {
                 "-w", project.getProjectPath().toString(),
                 "permissions", "generate",
-                "-id", "default",
+                "-wd",
                 "-so"};
         executeExpectSuccess(args);
         assertDefaultMapping("default", "none", "none");
@@ -59,7 +67,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
         String[] args = new String[] {
                 "-w", project.getProjectPath().toString(),
                 "permissions", "generate",
-                "-id", "default",
+                "-wd",
                 "--everyone", "canViewMetadata",
                 "--authenticated", "canManage"};
         executeExpectFailure(args);
@@ -75,7 +83,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
         String[] args = new String[] {
                 "-w", project.getProjectPath().toString(),
                 "permissions", "generate",
-                "-id", "default",
+                "-wd",
                 "--everyone", "canViewMetadata",
                 "--authenticated", "canViewMetadata"};
         executeExpectFailure(args);
@@ -91,7 +99,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
         String[] args = new String[] {
                 "-w", project.getProjectPath().toString(),
                 "permissions", "generate",
-                "-id", "default",
+                "-wd",
                 "--everyone", "canViewOriginals",
                 "--authenticated", "canViewOriginals",
                 "--force"};
@@ -105,7 +113,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
         String[] args = new String[] {
                 "-w", project.getProjectPath().toString(),
                 "permissions", "generate",
-                "-id", "default",
+                "-wd",
                 "--everyone", "canViewMetadata",
                 "--authenticated", "canViewMetadata"};
         executeExpectSuccess(args);
@@ -123,7 +131,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
         String[] args = new String[] {
                 "-w", project.getProjectPath().toString(),
                 "permissions", "generate",
-                "-id", "default",
+                "-wd",
                 "--everyone", "canViewMetadata",
                 "--authenticated", "canViewMetadata"};
         executeExpectSuccess(args);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -26,6 +26,8 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
+import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.AUTHENTICATED_PRINC;
+import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.PUBLIC_PRINC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -60,10 +62,27 @@ public class PermissionsServiceTest {
     }
 
     @Test
+    public void generateNoDefaultPermissionsTest() throws Exception {
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+
+        service.generateDefaultPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        try (
+                Reader reader = Files.newBufferedReader(permissionsMappingPath);
+                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT);
+        ) {
+            List<CSVRecord> rows = csvParser.getRecords();
+            assertIterableEquals(Arrays.asList(PermissionsInfo.ID_FIELD, PUBLIC_PRINC, AUTHENTICATED_PRINC), rows.get(0));
+        }
+    }
+
+    @Test
     public void generateDefaultPermissionsTest() throws Exception {
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
-        options.setCdmId("default");
+        options.setWithDefault(true);
         options.setEveryone(UserRole.canViewMetadata);
         options.setAuthenticated(UserRole.canViewMetadata);
 
@@ -86,7 +105,7 @@ public class PermissionsServiceTest {
     public void generateDefaultPermissionsUnspecifiedTest() throws Exception {
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
-        options.setCdmId("default");
+        options.setWithDefault(true);
 
         service.generateDefaultPermissions(options);
         assertTrue(Files.exists(permissionsMappingPath));
@@ -107,7 +126,7 @@ public class PermissionsServiceTest {
     public void generateDefaultPermissionsStaffOnlyTest() throws Exception {
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
-        options.setCdmId("default");
+        options.setWithDefault(true);
         options.setStaffOnly(true);
 
         service.generateDefaultPermissions(options);
@@ -128,7 +147,7 @@ public class PermissionsServiceTest {
     @Test
     public void generateDefaultPermissionsInvalidTest() throws Exception {
         var options = new PermissionMappingOptions();
-        options.setCdmId("default");
+        options.setWithDefault(true);
         options.setEveryone(UserRole.canViewMetadata);
         options.setAuthenticated(UserRole.canManage);
 
@@ -147,7 +166,7 @@ public class PermissionsServiceTest {
         writeCsv(mappingBody("default,none,none"));
 
         var options = new PermissionMappingOptions();
-        options.setCdmId("default");
+        options.setWithDefault(true);
         options.setEveryone(UserRole.canViewMetadata);
         options.setAuthenticated(UserRole.canViewMetadata);
 
@@ -166,7 +185,7 @@ public class PermissionsServiceTest {
         writeCsv(mappingBody("default,none,none"));
 
         var options = new PermissionMappingOptions();
-        options.setCdmId("default");
+        options.setWithDefault(true);
         options.setEveryone(UserRole.canViewMetadata);
         options.setAuthenticated(UserRole.canViewMetadata);
         options.setForce(true);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -15,7 +15,6 @@ import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.PostMigrationReportTestHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
-import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.rdf.Cdr;
 import edu.unc.lib.boxc.model.api.rdf.CdrAcl;
 import edu.unc.lib.boxc.model.api.rdf.CdrDeposit;
@@ -993,8 +992,7 @@ public class SipServiceTest {
         testHelper.indexExportData("mini_gilmer");
         testHelper.generateDefaultDestinationsMapping(DEST_UUID, null);
         testHelper.populateDescriptions("gilmer_mods1.xml");
-        testHelper.generatePermissionsMapping(PermissionsInfo.DEFAULT_ID, UserRole.canViewMetadata,
-                UserRole.canViewMetadata);
+        testHelper.generateDefaultPermissionsMapping(UserRole.canViewMetadata, UserRole.canViewMetadata);
         List<Path> stagingLocs = testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
 
         List<MigrationSip> sips = service.generateSips(makeOptions());

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
@@ -314,9 +314,9 @@ public class SipServiceHelper {
         archivalDestinationsService.addArchivalCollectionMappings(options);
     }
 
-    public void generatePermissionsMapping(String cdmId, UserRole everyone, UserRole authenticated) throws Exception {
+    public void generateDefaultPermissionsMapping(UserRole everyone, UserRole authenticated) throws Exception {
         PermissionMappingOptions options = new PermissionMappingOptions();
-        options.setCdmId(cdmId);
+        options.setWithDefault(true);
         options.setEveryone(everyone);
         options.setAuthenticated(authenticated);
         permissionsService.generateDefaultPermissions(options);


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4410](https://unclibrary.atlassian.net/browse/BXC-4410)

- `PermissionMappingOptions`: remove `--id` option, add `--with-default` flag
- `PermissionsService`: use `--with-default` flag
- add/modify tests