### PR TITLE
BXC-4411 add work and file entries to permissions cmd

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommand.java
@@ -39,7 +39,7 @@ public class PermissionsCommand {
         try {
             initialize();
 
-            permissionsService.generateDefaultPermissions(options);
+            permissionsService.generatePermissions(options);
             outputLogger.info("Permissions mapping generated for {} in {}s", project.getProjectName(),
                     (System.nanoTime() - start) / 1e9);
             return 0;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
@@ -8,6 +8,15 @@ public class PermissionMappingOptions {
             description = "Add 'default' entry to CSV mapping, 'id' field set to 'default")
     private boolean withDefault;
 
+    @Option(names = {"-ww", "--with-works"},
+            description = "Add entry for every work (grouped works, compound objects, and single file works) " +
+                    "to CSV mapping")
+    private boolean withWorks;
+
+    @Option(names = {"-wf", "--with-files"},
+            description = "Add entry for every file (compound children and grouped children) to CSV mapping")
+    private boolean withFiles;
+
     @Option(names = {"-e", "--everyone"},
             description = "The patron access role assigned to the “everyone” group.")
     private UserRole everyone;
@@ -30,6 +39,22 @@ public class PermissionMappingOptions {
 
     public void setWithDefault(boolean withDefault) {
         this.withDefault = withDefault;
+    }
+
+    public boolean isWithWorks() {
+        return withWorks;
+    }
+
+    public void setWithWorks(boolean withWorks) {
+        this.withWorks = withWorks;
+    }
+
+    public boolean isWithFiles() {
+        return withFiles;
+    }
+
+    public void setWithFiles(boolean withFiles) {
+        this.withFiles = withFiles;
     }
 
     public UserRole getEveryone() {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
@@ -185,11 +185,7 @@ public class PermissionsService {
         // works and files
         if (options.isWithWorks() && options.isWithFiles()) {
             String workAndFileQuery = "select distinct " + CdmFieldInfo.CDM_ID +
-                    " from " + CdmIndexService.TB_NAME
-                    + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_GROUPED_WORK + "'"
-                    + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_COMPOUND_OBJECT + "'"
-                    + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_COMPOUND_CHILD + "'"
-                    + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " is null";
+                    " from " + CdmIndexService.TB_NAME;
             mappedIds = getIds(workAndFileQuery);
         }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
@@ -3,6 +3,7 @@ package edu.unc.lib.boxc.migration.cdm.services;
 import edu.unc.lib.boxc.auth.api.UserRole;
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.exceptions.StateAlreadyExistsException;
+import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.PermissionsInfo;
 import edu.unc.lib.boxc.migration.cdm.options.PermissionMappingOptions;
@@ -19,9 +20,15 @@ import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
+import static edu.unc.lib.boxc.migration.cdm.services.CdmIndexService.ENTRY_TYPE_COMPOUND_CHILD;
+import static edu.unc.lib.boxc.migration.cdm.services.CdmIndexService.ENTRY_TYPE_FIELD;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -32,13 +39,14 @@ public class PermissionsService {
     private static final Logger log = getLogger(PermissionsService.class);
 
     private MigrationProject project;
+    private CdmIndexService indexService;
     private List<String> patronRoles;
 
     /**
-     * Generates default mapping csv
-     * @param options default mapping options
+     * Generates permission mapping csv
+     * @param options permission mapping options
      */
-    public void generateDefaultPermissions(PermissionMappingOptions options) throws Exception {
+    public void generatePermissions(PermissionMappingOptions options) throws Exception {
         Path fieldsPath = project.getPermissionsPath();
         ensureMappingState(options.isForce());
 
@@ -63,6 +71,54 @@ public class PermissionsService {
                 csvPrinter.printRecord(PermissionsInfo.DEFAULT_ID,
                         everyoneField,
                         authenticatedField);
+            }
+
+            // works and files
+            if (options.isWithWorks() && options.isWithFiles()) {
+                String workAndFileQuery = "select distinct " + CdmFieldInfo.CDM_ID +
+                        " from " + CdmIndexService.TB_NAME
+                        + " where " + ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_GROUPED_WORK + "'"
+                        + " or " + ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_COMPOUND_OBJECT + "'"
+                        + " or " + ENTRY_TYPE_FIELD + " = '" + ENTRY_TYPE_COMPOUND_CHILD + "'"
+                        + " or " + ENTRY_TYPE_FIELD + " is null";
+                List<String> workAndFileIds = getIds(workAndFileQuery);
+                for (String id : workAndFileIds) {
+                    csvPrinter.printRecord(id,
+                            everyoneField,
+                            authenticatedField);
+                }
+            }
+
+            // works
+            if (options.isWithWorks() && !options.isWithFiles()) {
+                // for every work in the project (grouped works, compound objects, and single file works)
+                String workQuery = "select distinct " + CdmFieldInfo.CDM_ID
+                        + " from " + CdmIndexService.TB_NAME
+                        + " where " + ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_GROUPED_WORK + "'"
+                        + " or " + ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_COMPOUND_OBJECT + "'"
+                        + " or " + ENTRY_TYPE_FIELD + " is null";
+                List<String> workIds = getIds(workQuery);
+                for (String id : workIds) {
+                    csvPrinter.printRecord(id,
+                            everyoneField,
+                            authenticatedField);
+                }
+            }
+
+            // files
+            if (options.isWithFiles() && !options.isWithWorks()) {
+                // for every file in the project (compound children and grouped children)
+                // If the entry type is null, the object is a individual cdm object
+                String fileQuery = "select distinct " + CdmFieldInfo.CDM_ID +
+                        " from " + CdmIndexService.TB_NAME
+                        + " where " + ENTRY_TYPE_FIELD + " = '" + ENTRY_TYPE_COMPOUND_CHILD + "'"
+                        + " or " + ENTRY_TYPE_FIELD + " is null";
+                List<String> fileIds = getIds(fileQuery);
+                for (String id : fileIds) {
+                    csvPrinter.printRecord(id,
+                            everyoneField,
+                            authenticatedField);
+                }
             }
         }
 
@@ -146,7 +202,37 @@ public class PermissionsService {
         return roleValue;
     }
 
+    private List<String> getIds(String query) {
+        List<String> ids = new ArrayList<>();
+
+        getIndexService();
+        try (Connection conn = indexService.openDbConnection()) {
+            Statement stmt = conn.createStatement();
+            ResultSet rs = stmt.executeQuery(query);
+            while (rs.next()) {
+                if (!rs.getString(1).isEmpty()) {
+                    ids.add(rs.getString(1));
+                }
+            }
+            return ids;
+        } catch (SQLException e) {
+            throw new MigrationException("Error interacting with export index", e);
+        }
+    }
+
+    private CdmIndexService getIndexService() {
+        if (indexService == null) {
+            indexService = new CdmIndexService();
+            indexService.setProject(project);
+        }
+        return indexService;
+    }
+
     public void setProject(MigrationProject project) {
         this.project = project;
+    }
+
+    public void setIndexService(CdmIndexService indexService) {
+        this.indexService = indexService;
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
@@ -200,7 +200,8 @@ public class PermissionsService {
                     + " from " + CdmIndexService.TB_NAME
                     + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_GROUPED_WORK + "'"
                     + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_COMPOUND_OBJECT + "'"
-                    + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " is null";
+                    + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " is null"
+                    + " and " + CdmIndexService.PARENT_ID_FIELD + " is null";
             mappedIds = getIds(workQuery);
         }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
@@ -73,13 +73,11 @@ public class PermissionsService {
                         authenticatedField);
             }
 
-            if (options.isWithWorks() && options.isWithFiles() || options.isWithWorks() || options.isWithFiles()) {
-                List<String> mappedIds = queryForMappedIds(options);
-                for (String id : mappedIds) {
-                    csvPrinter.printRecord(id,
-                            everyoneField,
-                            authenticatedField);
-                }
+            List<String> mappedIds = queryForMappedIds(options);
+            for (String id : mappedIds) {
+                csvPrinter.printRecord(id,
+                        everyoneField,
+                        authenticatedField);
             }
         }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
@@ -211,8 +211,9 @@ public class PermissionsService {
             // If the entry type is null, the object is a individual cdm object
             String fileQuery = "select distinct " + CdmFieldInfo.CDM_ID +
                     " from " + CdmIndexService.TB_NAME
-                    + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_COMPOUND_CHILD
-                    + "'" + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " is null";
+                    + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_COMPOUND_CHILD + "'"
+                    + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " is null"
+                    + " and " + CdmIndexService.PARENT_ID_FIELD + " is not null";
             mappedIds = getIds(fileQuery);
         }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
@@ -138,22 +138,21 @@ public class PermissionsCommandIT extends AbstractCommandIT {
     }
 
     @Test
-    public void generateFilePermissions() throws Exception {
+    public void generateFilePermissionsWithDefault() throws Exception {
         testHelper.indexExportData("mini_gilmer");
         String[] args = new String[] {
                 "-w", project.getProjectPath().toString(),
                 "permissions", "generate",
+                "-wd",
                 "-wf",
                 "-e", "canViewMetadata",
                 "-a", "canViewMetadata"};
         executeExpectSuccess(args);
-        assertMapping(0, "25", "canViewMetadata", "canViewMetadata");
-        assertMapping(1, "26", "canViewMetadata", "canViewMetadata");
-        assertMapping(2, "27", "canViewMetadata", "canViewMetadata");
+        assertMapping(0, "default", "canViewMetadata", "canViewMetadata");
     }
 
     @Test
-    public void generateFilePermissionsWithForce() throws Exception {
+    public void generateWorkAndFilePermissionsWithForce() throws Exception {
         FileUtils.write(project.getPermissionsPath().toFile(),
                 "default,canViewOriginals,canViewOriginals", StandardCharsets.UTF_8, true);
 
@@ -161,6 +160,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
         String[] args = new String[] {
                 "-w", project.getProjectPath().toString(),
                 "permissions", "generate",
+                "-ww",
                 "-wf",
                 "-e", "canViewMetadata",
                 "-a", "canViewMetadata",

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
@@ -36,8 +36,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
                 "--everyone", "canViewMetadata",
                 "--authenticated", "canViewMetadata"};
         executeExpectSuccess(args);
-        assertDefaultMapping("default", "canViewMetadata",
-                "canViewMetadata");
+        assertMapping(0, "default", "canViewMetadata", "canViewMetadata");
     }
 
     @Test
@@ -47,8 +46,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
                 "permissions", "generate",
                 "-wd"};
         executeExpectSuccess(args);
-        assertDefaultMapping("default", "canViewOriginals",
-                "canViewOriginals");
+        assertMapping(0, "default", "canViewOriginals", "canViewOriginals");
     }
 
     @Test
@@ -59,7 +57,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
                 "-wd",
                 "-so"};
         executeExpectSuccess(args);
-        assertDefaultMapping("default", "none", "none");
+        assertMapping(0, "default", "none", "none");
     }
 
     @Test
@@ -104,8 +102,91 @@ public class PermissionsCommandIT extends AbstractCommandIT {
                 "--authenticated", "canViewOriginals",
                 "--force"};
         executeExpectSuccess(args);
-        assertDefaultMapping("default", "canViewOriginals",
-                "canViewOriginals");
+        assertMapping(0, "default", "canViewOriginals", "canViewOriginals");
+    }
+
+    @Test
+    public void generateWorkPermissions() throws Exception {
+        testHelper.indexExportData("grouped_gilmer");
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "generate",
+                "-ww",
+                "--everyone", "canViewOriginals",
+                "--authenticated", "canViewOriginals"};
+        executeExpectSuccess(args);
+        assertMapping(0, "25", "canViewOriginals", "canViewOriginals");
+        assertMapping(1, "26", "canViewOriginals", "canViewOriginals");
+        assertMapping(2, "27", "canViewOriginals", "canViewOriginals");
+    }
+
+    @Test
+    public void generateWorkPermissionsWithDefault() throws Exception {
+        testHelper.indexExportData("grouped_gilmer");
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "generate",
+                "-wd",
+                "-ww",
+                "--everyone", "canViewMetadata",
+                "--authenticated", "canViewMetadata"};
+        executeExpectSuccess(args);
+        assertMapping(0, "default", "canViewMetadata", "canViewMetadata");
+        assertMapping(1, "25", "canViewMetadata", "canViewMetadata");
+        assertMapping(2, "26", "canViewMetadata", "canViewMetadata");
+        assertMapping(3, "27", "canViewMetadata", "canViewMetadata");
+    }
+
+    @Test
+    public void generateFilePermissions() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "generate",
+                "-wf",
+                "-e", "canViewMetadata",
+                "-a", "canViewMetadata"};
+        executeExpectSuccess(args);
+        assertMapping(0, "25", "canViewMetadata", "canViewMetadata");
+        assertMapping(1, "26", "canViewMetadata", "canViewMetadata");
+        assertMapping(2, "27", "canViewMetadata", "canViewMetadata");
+    }
+
+    @Test
+    public void generateFilePermissionsWithForce() throws Exception {
+        FileUtils.write(project.getPermissionsPath().toFile(),
+                "default,canViewOriginals,canViewOriginals", StandardCharsets.UTF_8, true);
+
+        testHelper.indexExportData("mini_gilmer");
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "generate",
+                "-wf",
+                "-e", "canViewMetadata",
+                "-a", "canViewMetadata",
+                "-f"};
+        executeExpectSuccess(args);
+        assertMapping(0, "25", "canViewMetadata", "canViewMetadata");
+        assertMapping(1, "26", "canViewMetadata", "canViewMetadata");
+        assertMapping(2, "27", "canViewMetadata", "canViewMetadata");
+    }
+
+    @Test
+    public void generateWorkAndFilePermissionsWithDefault() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "generate",
+                "-wd",
+                "-ww",
+                "-wf",
+                "--everyone", "canViewMetadata",
+                "--authenticated", "canViewMetadata"};
+        executeExpectSuccess(args);
+        assertMapping(0, "default", "canViewMetadata", "canViewMetadata");
+        assertMapping(1, "25", "canViewMetadata", "canViewMetadata");
+        assertMapping(2, "26", "canViewMetadata", "canViewMetadata");
+        assertMapping(3, "27", "canViewMetadata", "canViewMetadata");
     }
 
     @Test
@@ -151,12 +232,11 @@ public class PermissionsCommandIT extends AbstractCommandIT {
         assertEquals(2, output.split("    - ").length, "Must only be two errors: " + output);
     }
 
-    private void assertDefaultMapping(String defaultValue, String expectedEveryone, String expectedAuthenticated)
+    private void assertMapping(int index, String id, String expectedEveryone, String expectedAuthenticated)
             throws IOException {
         var mappings = getMappings();
-        assertMappingCount(mappings, 1);
-        PermissionsInfo.PermissionMapping mapping = mappings.get(0);
-        assertEquals(PermissionsInfo.DEFAULT_ID, mapping.getId());
+        PermissionsInfo.PermissionMapping mapping = mappings.get(index);
+        assertEquals(id, mapping.getId());
         assertEquals(expectedEveryone, mapping.getEveryone());
         assertEquals(expectedAuthenticated, mapping.getAuthenticated());
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -230,9 +230,6 @@ public class PermissionsServiceTest {
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
         assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(0));
         assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(1));
-        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(2));
-        assertIterableEquals(Arrays.asList("28", "canViewMetadata", "canViewMetadata"), rows.get(3));
-        assertIterableEquals(Arrays.asList("29", "canViewMetadata", "canViewMetadata"), rows.get(4));
     }
 
     @Test
@@ -248,11 +245,10 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("216", "canViewMetadata", "canViewMetadata"), rows.get(0));
-        assertIterableEquals(Arrays.asList("602", "canViewMetadata", "canViewMetadata"), rows.get(1));
-        assertIterableEquals(Arrays.asList("603", "canViewMetadata", "canViewMetadata"), rows.get(2));
-        assertIterableEquals(Arrays.asList("605", "canViewMetadata", "canViewMetadata"), rows.get(3));
-        assertIterableEquals(Arrays.asList("606", "canViewMetadata", "canViewMetadata"), rows.get(4));
+        assertIterableEquals(Arrays.asList("602", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("603", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("605", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("606", "canViewMetadata", "canViewMetadata"), rows.get(3));
     }
 
     @Test
@@ -270,9 +266,6 @@ public class PermissionsServiceTest {
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
         assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
-        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(1));
-        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(2));
-        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(3));
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -4,6 +4,8 @@ import edu.unc.lib.boxc.auth.api.UserRole;
 import edu.unc.lib.boxc.migration.cdm.exceptions.StateAlreadyExistsException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.PermissionsInfo;
+import edu.unc.lib.boxc.migration.cdm.options.GroupMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.options.GroupMappingSyncOptions;
 import edu.unc.lib.boxc.migration.cdm.options.PermissionMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
@@ -196,6 +198,7 @@ public class PermissionsServiceTest {
     @Test
     public void generateWorkPermissionsGroupedWorksTest() throws Exception {
         testHelper.indexExportData("grouped_gilmer");
+        setupGroupedIndex();
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
         options.setWithWorks(true);
@@ -216,6 +219,7 @@ public class PermissionsServiceTest {
     @Test
     public void generateFilePermissionsGroupedWorksTest() throws Exception {
         testHelper.indexExportData("grouped_gilmer");
+        setupGroupedIndex();
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
         options.setWithFiles(true);
@@ -392,5 +396,14 @@ public class PermissionsServiceTest {
 
         assertEquals(everyoneValue, mapping.getEveryone());
         assertEquals(authenticatedValue, mapping.getAuthenticated());
+    }
+
+    private void setupGroupedIndex() throws Exception {
+        var options = new GroupMappingOptions();
+        options.setGroupField("groupa");
+        testHelper.getGroupMappingService().generateMapping(options);
+        var syncOptions = new GroupMappingSyncOptions();
+        syncOptions.setSortField("file");
+        testHelper.getGroupMappingService().syncMappings(syncOptions);
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -209,11 +209,9 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(0));
-        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(1));
-        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(2));
-        assertIterableEquals(Arrays.asList("28", "canViewMetadata", "canViewMetadata"), rows.get(3));
-        assertIterableEquals(Arrays.asList("29", "canViewMetadata", "canViewMetadata"), rows.get(4));
+        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("28", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("29", "canViewMetadata", "canViewMetadata"), rows.get(2));
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -66,7 +66,7 @@ public class PermissionsServiceTest {
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
 
-        service.generateDefaultPermissions(options);
+        service.generatePermissions(options);
         assertTrue(Files.exists(permissionsMappingPath));
 
         try (
@@ -86,7 +86,7 @@ public class PermissionsServiceTest {
         options.setEveryone(UserRole.canViewMetadata);
         options.setAuthenticated(UserRole.canViewMetadata);
 
-        service.generateDefaultPermissions(options);
+        service.generatePermissions(options);
         assertTrue(Files.exists(permissionsMappingPath));
 
         try (
@@ -107,7 +107,7 @@ public class PermissionsServiceTest {
         var options = new PermissionMappingOptions();
         options.setWithDefault(true);
 
-        service.generateDefaultPermissions(options);
+        service.generatePermissions(options);
         assertTrue(Files.exists(permissionsMappingPath));
 
         try (
@@ -129,7 +129,7 @@ public class PermissionsServiceTest {
         options.setWithDefault(true);
         options.setStaffOnly(true);
 
-        service.generateDefaultPermissions(options);
+        service.generatePermissions(options);
         assertTrue(Files.exists(permissionsMappingPath));
 
         try (
@@ -152,7 +152,7 @@ public class PermissionsServiceTest {
         options.setAuthenticated(UserRole.canManage);
 
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            service.generateDefaultPermissions(options);
+            service.generatePermissions(options);
         });
 
         String expectedMessage = "Assigned role value is invalid. Must be one of the following patron roles: " +
@@ -171,7 +171,7 @@ public class PermissionsServiceTest {
         options.setAuthenticated(UserRole.canViewMetadata);
 
         Exception exception = assertThrows(StateAlreadyExistsException.class, () -> {
-            service.generateDefaultPermissions(options);
+            service.generatePermissions(options);
         });
 
         String expectedMessage = "Cannot create permissions, a file already exists. Use the force flag to overwrite.";
@@ -190,7 +190,7 @@ public class PermissionsServiceTest {
         options.setAuthenticated(UserRole.canViewMetadata);
         options.setForce(true);
 
-        service.generateDefaultPermissions(options);
+        service.generatePermissions(options);
         assertTrue(Files.exists(permissionsMappingPath));
 
         try (
@@ -202,6 +202,147 @@ public class PermissionsServiceTest {
         ) {
             List<CSVRecord> rows = csvParser.getRecords();
             assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        }
+    }
+
+    @Test
+    public void generateWorkPermissionsTest() throws Exception {
+        testHelper.indexExportData("grouped_gilmer");
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setWithWorks(true);
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.generatePermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        try (
+                Reader reader = Files.newBufferedReader(permissionsMappingPath);
+                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
+                        .withFirstRecordAsHeader()
+                        .withHeader(PermissionsInfo.CSV_HEADERS)
+                        .withTrim());
+        ) {
+            List<CSVRecord> rows = csvParser.getRecords();
+            assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(0));
+            assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(1));
+            assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        }
+    }
+
+    @Test
+    public void generateFilePermissionsTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setWithFiles(true);
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.generatePermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        try (
+                Reader reader = Files.newBufferedReader(permissionsMappingPath);
+                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
+                        .withFirstRecordAsHeader()
+                        .withHeader(PermissionsInfo.CSV_HEADERS)
+                        .withTrim());
+        ) {
+            List<CSVRecord> rows = csvParser.getRecords();
+            assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(0));
+            assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(1));
+            assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        }
+    }
+
+    @Test
+    public void generateFilePermissionsWithDefaultTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setWithDefault(true);
+        options.setWithFiles(true);
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.generatePermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        try (
+                Reader reader = Files.newBufferedReader(permissionsMappingPath);
+                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
+                        .withFirstRecordAsHeader()
+                        .withHeader(PermissionsInfo.CSV_HEADERS)
+                        .withTrim());
+        ) {
+            List<CSVRecord> rows = csvParser.getRecords();
+            assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
+            assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(1));
+            assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(2));
+            assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(3));
+        }
+    }
+
+    @Test
+    public void generateWorkAndFilePermissionsWithDefaultTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setWithDefault(true);
+        options.setWithFiles(true);
+        options.setWithWorks(true);
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.generatePermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        try (
+                Reader reader = Files.newBufferedReader(permissionsMappingPath);
+                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
+                        .withFirstRecordAsHeader()
+                        .withHeader(PermissionsInfo.CSV_HEADERS)
+                        .withTrim());
+        ) {
+            List<CSVRecord> rows = csvParser.getRecords();
+            assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
+            assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(1));
+            assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(2));
+            assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(3));
+        }
+    }
+
+    @Test
+    public void generateWorkAndFilePermissionsWithDefaultAndForceTest() throws Exception {
+        Path permissionsMappingPath = project.getPermissionsPath();
+        writeCsv(mappingBody("default,none,none"));
+
+        testHelper.indexExportData("mini_gilmer");
+        var options = new PermissionMappingOptions();
+        options.setWithDefault(true);
+        options.setForce(true);
+        options.setWithFiles(true);
+        options.setWithWorks(true);
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.generatePermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        try (
+                Reader reader = Files.newBufferedReader(permissionsMappingPath);
+                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
+                        .withFirstRecordAsHeader()
+                        .withHeader(PermissionsInfo.CSV_HEADERS)
+                        .withTrim());
+        ) {
+            List<CSVRecord> rows = csvParser.getRecords();
+            assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
+            assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(1));
+            assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(2));
+            assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(3));
         }
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -89,16 +89,8 @@ public class PermissionsServiceTest {
         service.generatePermissions(options);
         assertTrue(Files.exists(permissionsMappingPath));
 
-        try (
-                Reader reader = Files.newBufferedReader(permissionsMappingPath);
-                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
-                        .withFirstRecordAsHeader()
-                        .withHeader(PermissionsInfo.CSV_HEADERS)
-                        .withTrim());
-        ) {
-            List<CSVRecord> rows = csvParser.getRecords();
-            assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
-        }
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
     }
 
     @Test
@@ -110,16 +102,8 @@ public class PermissionsServiceTest {
         service.generatePermissions(options);
         assertTrue(Files.exists(permissionsMappingPath));
 
-        try (
-                Reader reader = Files.newBufferedReader(permissionsMappingPath);
-                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
-                        .withFirstRecordAsHeader()
-                        .withHeader(PermissionsInfo.CSV_HEADERS)
-                        .withTrim());
-        ) {
-            List<CSVRecord> rows = csvParser.getRecords();
-            assertIterableEquals(Arrays.asList("default", "canViewOriginals", "canViewOriginals"), rows.get(0));
-        }
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "canViewOriginals", "canViewOriginals"), rows.get(0));
     }
 
     @Test
@@ -132,16 +116,8 @@ public class PermissionsServiceTest {
         service.generatePermissions(options);
         assertTrue(Files.exists(permissionsMappingPath));
 
-        try (
-                Reader reader = Files.newBufferedReader(permissionsMappingPath);
-                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
-                        .withFirstRecordAsHeader()
-                        .withHeader(PermissionsInfo.CSV_HEADERS)
-                        .withTrim());
-        ) {
-            List<CSVRecord> rows = csvParser.getRecords();
-            assertIterableEquals(Arrays.asList("default", "none", "none"), rows.get(0));
-        }
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "none", "none"), rows.get(0));
     }
 
     @Test
@@ -193,20 +169,32 @@ public class PermissionsServiceTest {
         service.generatePermissions(options);
         assertTrue(Files.exists(permissionsMappingPath));
 
-        try (
-                Reader reader = Files.newBufferedReader(permissionsMappingPath);
-                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
-                        .withFirstRecordAsHeader()
-                        .withHeader(PermissionsInfo.CSV_HEADERS)
-                        .withTrim());
-        ) {
-            List<CSVRecord> rows = csvParser.getRecords();
-            assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
-        }
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
     }
 
     @Test
-    public void generateWorkPermissionsTest() throws Exception {
+    public void generateWorkPermissionsWithDefaultTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setWithWorks(true);
+        options.setWithDefault(true);
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.generatePermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(3));
+    }
+
+    @Test
+    public void generateWorkPermissionsGroupedWorksTest() throws Exception {
         testHelper.indexExportData("grouped_gilmer");
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
@@ -217,23 +205,17 @@ public class PermissionsServiceTest {
         service.generatePermissions(options);
         assertTrue(Files.exists(permissionsMappingPath));
 
-        try (
-                Reader reader = Files.newBufferedReader(permissionsMappingPath);
-                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
-                        .withFirstRecordAsHeader()
-                        .withHeader(PermissionsInfo.CSV_HEADERS)
-                        .withTrim());
-        ) {
-            List<CSVRecord> rows = csvParser.getRecords();
-            assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(0));
-            assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(1));
-            assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(2));
-        }
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("28", "canViewMetadata", "canViewMetadata"), rows.get(3));
+        assertIterableEquals(Arrays.asList("29", "canViewMetadata", "canViewMetadata"), rows.get(4));
     }
 
     @Test
-    public void generateFilePermissionsTest() throws Exception {
-        testHelper.indexExportData("mini_gilmer");
+    public void generateFilePermissionsGroupedWorksTest() throws Exception {
+        testHelper.indexExportData("grouped_gilmer");
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
         options.setWithFiles(true);
@@ -243,18 +225,32 @@ public class PermissionsServiceTest {
         service.generatePermissions(options);
         assertTrue(Files.exists(permissionsMappingPath));
 
-        try (
-                Reader reader = Files.newBufferedReader(permissionsMappingPath);
-                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
-                        .withFirstRecordAsHeader()
-                        .withHeader(PermissionsInfo.CSV_HEADERS)
-                        .withTrim());
-        ) {
-            List<CSVRecord> rows = csvParser.getRecords();
-            assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(0));
-            assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(1));
-            assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(2));
-        }
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("28", "canViewMetadata", "canViewMetadata"), rows.get(3));
+        assertIterableEquals(Arrays.asList("29", "canViewMetadata", "canViewMetadata"), rows.get(4));
+    }
+
+    @Test
+    public void generateFilePermissionsCompoundObjectsTest() throws Exception {
+        testHelper.indexExportData("mini_keepsakes");
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setWithFiles(true);
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.generatePermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("216", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("602", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("603", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("605", "canViewMetadata", "canViewMetadata"), rows.get(3));
+        assertIterableEquals(Arrays.asList("606", "canViewMetadata", "canViewMetadata"), rows.get(4));
     }
 
     @Test
@@ -270,19 +266,11 @@ public class PermissionsServiceTest {
         service.generatePermissions(options);
         assertTrue(Files.exists(permissionsMappingPath));
 
-        try (
-                Reader reader = Files.newBufferedReader(permissionsMappingPath);
-                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
-                        .withFirstRecordAsHeader()
-                        .withHeader(PermissionsInfo.CSV_HEADERS)
-                        .withTrim());
-        ) {
-            List<CSVRecord> rows = csvParser.getRecords();
-            assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
-            assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(1));
-            assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(2));
-            assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(3));
-        }
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(3));
     }
 
     @Test
@@ -299,19 +287,11 @@ public class PermissionsServiceTest {
         service.generatePermissions(options);
         assertTrue(Files.exists(permissionsMappingPath));
 
-        try (
-                Reader reader = Files.newBufferedReader(permissionsMappingPath);
-                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
-                        .withFirstRecordAsHeader()
-                        .withHeader(PermissionsInfo.CSV_HEADERS)
-                        .withTrim());
-        ) {
-            List<CSVRecord> rows = csvParser.getRecords();
-            assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
-            assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(1));
-            assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(2));
-            assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(3));
-        }
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(3));
     }
 
     @Test
@@ -331,19 +311,34 @@ public class PermissionsServiceTest {
         service.generatePermissions(options);
         assertTrue(Files.exists(permissionsMappingPath));
 
-        try (
-                Reader reader = Files.newBufferedReader(permissionsMappingPath);
-                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
-                        .withFirstRecordAsHeader()
-                        .withHeader(PermissionsInfo.CSV_HEADERS)
-                        .withTrim());
-        ) {
-            List<CSVRecord> rows = csvParser.getRecords();
-            assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
-            assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(1));
-            assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(2));
-            assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(3));
-        }
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(3));
+    }
+
+    @Test
+    public void generateWorkAndFilePermissionsCompoundObjectsTest() throws Exception {
+        testHelper.indexExportData("mini_keepsakes");
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setWithWorks(true);
+        options.setWithFiles(true);
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.generatePermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("216", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("602", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("603", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("604", "canViewMetadata", "canViewMetadata"), rows.get(3));
+        assertIterableEquals(Arrays.asList("605", "canViewMetadata", "canViewMetadata"), rows.get(4));
+        assertIterableEquals(Arrays.asList("606", "canViewMetadata", "canViewMetadata"), rows.get(5));
+        assertIterableEquals(Arrays.asList("607", "canViewMetadata", "canViewMetadata"), rows.get(6));
     }
 
     @Test
@@ -375,6 +370,20 @@ public class PermissionsServiceTest {
         FileUtils.write(project.getPermissionsPath().toFile(),
                 mappingBody, StandardCharsets.UTF_8);
         ProjectPropertiesSerialization.write(project);
+    }
+
+    private List<CSVRecord> listCsvRecords(Path permissionsMappingPath) throws Exception {
+        List<CSVRecord> rows;
+        try (
+                Reader reader = Files.newBufferedReader(permissionsMappingPath);
+                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
+                        .withFirstRecordAsHeader()
+                        .withHeader(PermissionsInfo.CSV_HEADERS)
+                        .withTrim());
+        ) {
+            rows = csvParser.getRecords();
+        }
+        return rows;
     }
 
     private void assertMappingPresent(PermissionsInfo info, String cdmid, String everyoneValue, String authenticatedValue) {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
@@ -319,7 +319,7 @@ public class SipServiceHelper {
         options.setWithDefault(true);
         options.setEveryone(everyone);
         options.setAuthenticated(authenticated);
-        permissionsService.generateDefaultPermissions(options);
+        permissionsService.generatePermissions(options);
     }
 
     public List<Path> populateSourceFiles(String... filenames) throws Exception {


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4411](https://unclibrary.atlassian.net/browse/BXC-4411)

- `PermissionMappingOptions`: add `--with-works` and `--with-files` flags
- `PermissionsService`: rename `generateDefaultPermissions` method to `generatePermissions`, modify `generatePermissions` to add works/files to csv, add `getIds` helper method
- add tests