### PR TITLE
BXC-4412 basic set command

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommand.java
@@ -53,6 +53,26 @@ public class PermissionsCommand {
         }
     }
 
+    @Command(name = "set",
+            description = "Add or update an entry in an existing permissions mapping file")
+    public int set(@Mixin PermissionMappingOptions options) throws Exception {
+        try {
+            initialize();
+
+            permissionsService.capturePreviousState();
+            permissionsService.setPermissions(options);
+            outputLogger.info("Permissions mapping generated for cdmId {}", options.getCdmId());
+            return 0;
+        } catch (MigrationException | IllegalArgumentException e) {
+            outputLogger.info("Cannot set mappings: {}", e.getMessage());
+            return 1;
+        } catch (Exception e) {
+            log.error("Failed to set mappings", e);
+            outputLogger.info("Failed to set mappings: {}", e.getMessage(), e);
+            return 1;
+        }
+    }
+
     @Command(name = "validate",
             description = "Validate the permissions mapping file for this project")
     public int validate() throws Exception {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommand.java
@@ -59,7 +59,6 @@ public class PermissionsCommand {
         try {
             initialize();
 
-            permissionsService.capturePreviousState();
             permissionsService.setPermissions(options);
             outputLogger.info("Permissions mapping generated for cdmId {}", options.getCdmId());
             return 0;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
@@ -17,6 +17,10 @@ public class PermissionMappingOptions {
             description = "Add entry for every file (compound children and grouped children) to CSV mapping")
     private boolean withFiles;
 
+    @Option(names = {"-id", "--cdm-id"},
+            description = "Work or File to add or update, can be cdmId or group work identifier")
+    private String cdmId;
+
     @Option(names = {"-e", "--everyone"},
             description = "The patron access role assigned to the “everyone” group.")
     private UserRole everyone;
@@ -51,6 +55,14 @@ public class PermissionMappingOptions {
 
     public boolean isWithFiles() {
         return withFiles;
+    }
+
+    public String getCdmId() {
+        return cdmId;
+    }
+
+    public void setCdmId(String cdmId) {
+        this.cdmId = cdmId;
     }
 
     public void setWithFiles(boolean withFiles) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
@@ -248,7 +248,6 @@ public class PermissionsService {
     private boolean doesIdExistInIndex(String id) {
         String query = "select " + CdmFieldInfo.CDM_ID + " from " + CdmIndexService.TB_NAME
                 + " where " + CdmFieldInfo.CDM_ID + " = ?";
-        boolean idExists = false;
 
         getIndexService();
         try (Connection conn = indexService.openDbConnection()) {
@@ -257,10 +256,10 @@ public class PermissionsService {
             var rs = stmt.executeQuery();
             while (rs.next()) {
                 if (!rs.getString(1).isEmpty()) {
-                    idExists = true;
+                    return true;
                 }
             }
-            return idExists;
+            return false;
         } catch (SQLException e) {
             throw new MigrationException("Error interacting with export index", e);
         }
@@ -276,7 +275,7 @@ public class PermissionsService {
         // update existing entry
         for (CSVRecord record : previousRecords) {
             cdmIds.add(record.get(0));
-            if (record.get(0).contains(options.getCdmId())) {
+            if (record.get(0).equals(options.getCdmId())) {
                 updatedRecords.add(Arrays.asList(record.get(0), everyoneField, authenticatedField));
             } else {
                 updatedRecords.add(Arrays.asList(record.get(0), record.get(1), record.get(2)));

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
@@ -101,7 +101,7 @@ public class PermissionsService {
         }
 
         // add or update permission for a specific cdmId
-        List<List<String>> records = updateCsvRecords(options, permissionsMappingPath);
+        List<List<String>> records = updateCsvRecords(options);
 
         try (
             BufferedWriter writer = Files.newBufferedWriter(permissionsMappingPath);
@@ -265,7 +265,7 @@ public class PermissionsService {
         }
     }
 
-    private List<List<String>> updateCsvRecords(PermissionMappingOptions options, Path permissionsMappingPath) throws Exception {
+    private List<List<String>> updateCsvRecords(PermissionMappingOptions options) {
         List<CSVRecord> previousRecords = getPermissions();
         List<List<String>> updatedRecords = new ArrayList<>();
         Set<String> cdmIds = new HashSet<>();

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
@@ -92,7 +92,7 @@ public class PermissionsService {
      */
     public void setPermissions(PermissionMappingOptions options) throws Exception {
         String cdmIdsQuery = "select " + CdmFieldInfo.CDM_ID + " from " + CdmIndexService.TB_NAME
-                + " where " + CdmFieldInfo.CDM_ID + " = " + options.getCdmId();
+                + " where " + CdmFieldInfo.CDM_ID + " = '" + options.getCdmId() + "'";
         List<String> cdmIds = getIds(cdmIdsQuery);
         if (!cdmIds.contains(options.getCdmId())) {
             throw new IllegalArgumentException("Id " + options.getCdmId() + " does not exist in this project.");
@@ -198,8 +198,8 @@ public class PermissionsService {
 
         getIndexService();
         try (Connection conn = indexService.openDbConnection()) {
-            Statement stmt = conn.createStatement();
-            ResultSet rs = stmt.executeQuery(query);
+            var stmt = conn.prepareStatement(query);
+            var rs = stmt.executeQuery();
             while (rs.next()) {
                 if (!rs.getString(1).isEmpty()) {
                     ids.add(rs.getString(1));

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/DestinationsCommandIT.java
@@ -449,12 +449,14 @@ public class DestinationsCommandIT extends AbstractCommandIT {
 
     private void assertArchivalCollectionMapping(String defaultDest, String defaultColl) throws Exception {
         var mappings = getMappings();
-        assertMappingCount(mappings, 3);
-        DestinationMapping group2Mapping = mappings.get(0);
+        assertMappingCount(mappings, 4);
+        DestinationMapping group11Mapping = mappings.get(0);
+        assertEquals("groupa:group11", group11Mapping.getId());
+        DestinationMapping group2Mapping = mappings.get(1);
         assertEquals("groupa:group2", group2Mapping.getId());
-        DestinationMapping group1Mapping = mappings.get(1);
+        DestinationMapping group1Mapping = mappings.get(2);
         assertEquals("groupa:group1", group1Mapping.getId());
-        DestinationMapping defaultMapping = mappings.get(2);
+        DestinationMapping defaultMapping = mappings.get(3);
         assertEquals(DestinationsInfo.DEFAULT_ID, defaultMapping.getId());
         assertEquals(defaultDest, defaultMapping.getDestination());
         assertEquals(defaultColl, defaultMapping.getCollectionId());
@@ -489,6 +491,11 @@ public class DestinationsCommandIT extends AbstractCommandIT {
                         .withHeader("Content-Type", "application/octet-stream")));
         //groupa:group2
         stubFor(get(urlEqualTo("/solr/select?q=collectionId%3Agroup2&fq=resourceType%3ACollection&wt=javabin&version=2"))
+                .willReturn(aResponse()
+                        .withBodyFile("arc_coll_resp_group2.bin")
+                        .withHeader("Content-Type", "application/octet-stream")));
+        //groupa:group11
+        stubFor(get(urlEqualTo("/solr/select?q=collectionId%3Agroup11&fq=resourceType%3ACollection&wt=javabin&version=2"))
                 .willReturn(aResponse()
                         .withBodyFile("arc_coll_resp_group2.bin")
                         .withHeader("Content-Type", "application/octet-stream")));

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/FilterIndexCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/FilterIndexCommandIT.java
@@ -141,9 +141,9 @@ public class FilterIndexCommandIT extends AbstractCommandIT {
                 "-e", ""};
         executeExpectSuccess(args);
 
-        assertOutputContains("Filtering index from 5 to 1 remaining entries");
+        assertOutputContains("Filtering index from 5 to 2 remaining entries");
         assertOutputContains("Filtering of index for my_proj completed");
-        assertRemaining(1);
+        assertRemaining(2);
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
@@ -13,8 +13,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class PermissionsCommandIT extends AbstractCommandIT {
     @BeforeEach

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
@@ -13,6 +13,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class PermissionsCommandIT extends AbstractCommandIT {
     @BeforeEach
@@ -250,6 +252,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
         executeExpectSuccess(args2);
         assertMapping(0, "default", "canViewOriginals", "canViewOriginals");
         assertMapping(1, "grp:groupa:group1", "canViewMetadata", "canViewMetadata");
+        assertMappingCount(2);
     }
 
     @Test
@@ -329,6 +332,11 @@ public class PermissionsCommandIT extends AbstractCommandIT {
     private List<PermissionsInfo.PermissionMapping> getMappings() throws IOException {
         PermissionsInfo info = PermissionsService.loadMappings(project);
         return info.getMappings();
+    }
+
+    private void assertMappingCount(int count) throws IOException {
+        var mappings = getMappings();
+        assertEquals(count, mappings.size());
     }
 
     private void setupGroupedIndex() throws Exception {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
@@ -305,8 +305,4 @@ public class PermissionsCommandIT extends AbstractCommandIT {
         PermissionsInfo info = PermissionsService.loadMappings(project);
         return info.getMappings();
     }
-
-    private void assertMappingCount(List<PermissionsInfo.PermissionMapping> mappings, int count) {
-        assertEquals(count, mappings.size());
-    }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsServiceTest.java
@@ -105,7 +105,7 @@ public class ArchivalDestinationsServiceTest {
         options.setFieldName("groupa");
 
         var result = service.generateCollectionNumbersList(options);
-        assertIterableEquals(Arrays.asList("group1", "group2"), result);
+        assertIterableEquals(Arrays.asList("group1", "group2", "group11"), result);
     }
 
     @Test
@@ -161,6 +161,7 @@ public class ArchivalDestinationsServiceTest {
         Map<String, String> expected = new HashMap<>();
         expected.put("group1", DEST_UUID);
         expected.put("group2", DEST_UUID2);
+        expected.put("group11", DEST_UUID2);
 
         var options = new DestinationMappingOptions();
         options.setFieldName("groupa");
@@ -214,8 +215,9 @@ public class ArchivalDestinationsServiceTest {
                         .withTrim());
         ) {
             List<CSVRecord> rows = csvParser.getRecords();
-            assertIterableEquals(Arrays.asList("groupa:group2", DEST_UUID2, ""), rows.get(0));
-            assertIterableEquals(Arrays.asList("groupa:group1", DEST_UUID, ""), rows.get(1));
+            assertIterableEquals(Arrays.asList("groupa:group11", DEST_UUID2, ""), rows.get(0));
+            assertIterableEquals(Arrays.asList("groupa:group2", DEST_UUID2, ""), rows.get(1));
+            assertIterableEquals(Arrays.asList("groupa:group1", DEST_UUID, ""), rows.get(2));
         }
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/IndexFilteringServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/IndexFilteringServiceTest.java
@@ -67,7 +67,7 @@ public class IndexFilteringServiceTest {
         options.setIncludeValues(Arrays.asList("group1", ""));
         var result = service.calculateRemainder(options);
         assertEquals(result.get("total"), 5);
-        assertEquals(result.get("remainder"), 4);
+        assertEquals(result.get("remainder"), 3);
     }
 
     @Test
@@ -80,7 +80,7 @@ public class IndexFilteringServiceTest {
         options.setIncludeValues(Arrays.asList("group1", "group2", ""));
         var result = service.calculateRemainder(options);
         assertEquals(result.get("total"), 5);
-        assertEquals(result.get("remainder"), 5);
+        assertEquals(result.get("remainder"), 4);
     }
 
     @Test
@@ -168,7 +168,7 @@ public class IndexFilteringServiceTest {
         options.setIncludeValues(Arrays.asList("group1", ""));
         service.filterIndex(options);
         var remaining = getRemainingIds();
-        assertIterableEquals(Arrays.asList("25", "26", "28", "29"), remaining);
+        assertIterableEquals(Arrays.asList("25", "26", "29"), remaining);
     }
 
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -378,6 +378,27 @@ public class PermissionsServiceTest {
     }
 
     @Test
+    public void setPermissionsGroupedWorkEntryTest() throws Exception {
+        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata", "26,none,none", "27,none,none"));
+        testHelper.indexExportData("grouped_gilmer");
+        setupGroupedIndex();
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setCdmId("grp:groupa:group1");
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.setPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("26", "none", "none"), rows.get(1));
+        assertIterableEquals(Arrays.asList("27", "none", "none"), rows.get(2));
+        assertIterableEquals(Arrays.asList("grp:groupa:group1", "canViewMetadata", "canViewMetadata"), rows.get(3));
+    }
+
+    @Test
     public void setPermissionNewEntryTest() throws Exception {
         writeCsv(mappingBody("default,canViewMetadata,canViewMetadata", "25,none,none", "26,none,none"));
         testHelper.indexExportData("mini_gilmer");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -1,6 +1,7 @@
 package edu.unc.lib.boxc.migration.cdm.services;
 
 import edu.unc.lib.boxc.auth.api.UserRole;
+import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.exceptions.StateAlreadyExistsException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.PermissionsInfo;
@@ -354,6 +355,82 @@ public class PermissionsServiceTest {
         PermissionsInfo.PermissionMapping testMapping = info.getMappingByCdmId("testId");
         assertEquals("none", testMapping.getEveryone());
         assertEquals("none", testMapping.getAuthenticated());
+    }
+
+    @Test
+    public void setPermissionExistingEntryTest() throws Exception {
+        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata", "25,none,none", "26,none,none", "27,none,none"));
+        service.capturePreviousState();
+        testHelper.indexExportData("mini_gilmer");
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setCdmId("25");
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.setPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "none", "none"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "none", "none"), rows.get(3));
+    }
+
+    @Test
+    public void setPermissionNewEntryTest() throws Exception {
+        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata", "25,none,none", "26,none,none"));
+        service.capturePreviousState();
+        testHelper.indexExportData("mini_gilmer");
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setCdmId("27");
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.setPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "none", "none"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "none", "none"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(3));
+    }
+
+    @Test
+    public void setPermissionInvalidIdTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        var options = new PermissionMappingOptions();
+        options.setCdmId("28");
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            service.setPermissions(options);
+        });
+
+        String expectedMessage = "Id 28 does not exist in this project.";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
+    }
+
+    @Test
+    public void setPermissionNoCsvTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        var options = new PermissionMappingOptions();
+        options.setCdmId("27");
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        Exception exception = assertThrows(InvalidProjectStateException.class, () -> {
+            service.setPermissions(options);
+        });
+
+        String expectedMessage = "Permissions csv does not exist.";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
     }
 
     private String mappingBody(String... rows) {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -360,7 +360,6 @@ public class PermissionsServiceTest {
     @Test
     public void setPermissionExistingEntryTest() throws Exception {
         writeCsv(mappingBody("default,canViewMetadata,canViewMetadata", "25,none,none", "26,none,none", "27,none,none"));
-        service.capturePreviousState();
         testHelper.indexExportData("mini_gilmer");
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
@@ -381,7 +380,6 @@ public class PermissionsServiceTest {
     @Test
     public void setPermissionNewEntryTest() throws Exception {
         writeCsv(mappingBody("default,canViewMetadata,canViewMetadata", "25,none,none", "26,none,none"));
-        service.capturePreviousState();
         testHelper.indexExportData("mini_gilmer");
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
@@ -401,6 +399,7 @@ public class PermissionsServiceTest {
 
     @Test
     public void setPermissionInvalidIdTest() throws Exception {
+        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata", "25,none,none", "26,none,none"));
         testHelper.indexExportData("mini_gilmer");
         var options = new PermissionMappingOptions();
         options.setCdmId("28");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -956,14 +956,14 @@ public class SipServiceTest {
         List<MigrationSip> sips = service.generateSips(makeOptions());
         assertEquals(3, sips.size());
 
-        // groupa:group2
+        // groupa:group2 and groupa:group11
         MigrationSip sip1 = sips.get(0);
         assertTrue(Files.exists(sip1.getSipPath()));
         assertEquals(DEST_UUID2, sip1.getDestinationPid().getUUID());
         Model model = testHelper.getSipModel(sip1);
         Bag depBag = model.getBag(sip1.getDepositPid().getRepositoryPath());
         List<RDFNode> depBagChildren = depBag.iterator().toList();
-        assertEquals(1, depBagChildren.size());
+        assertEquals(2, depBagChildren.size());
         assertPersistedSipInfoMatches(sip1);
 
         // groupa:group1
@@ -983,7 +983,7 @@ public class SipServiceTest {
         Model model3 = testHelper.getSipModel(sip3);
         Bag depBag3 = model3.getBag(sip3.getDepositPid().getRepositoryPath());
         List<RDFNode> depBagChildren3 = depBag3.iterator().toList();
-        assertEquals(2, depBagChildren3.size());
+        assertEquals(1, depBagChildren3.size());
         assertPersistedSipInfoMatches(sip3);
     }
 

--- a/src/test/resources/descriptions/grouped_gilmer/index/description/desc.all
+++ b/src/test/resources/descriptions/grouped_gilmer/index/description/desc.all
@@ -246,7 +246,7 @@
 <coloa>RGB</coloa>
 <fila>TIFF</fila>
 <filb>TIFF</filb>
-<groupa></groupa>
+<groupa>group11</groupa>
 <full>/shc/gilmer_maps/</full>
 <fullrs>276_241_E.tif</fullrs>
 <find>74.jp2</find>


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4412](https://unclibrary.atlassian.net/browse/BXC-4412)

- `PermissionsCommand`: add `set` command
- `PermissionMappingOption`: add `--cdm-id` option
- `PermissionsService`: add `setPermissions` method, `updateCsvRecords` helper method, `previousStatePermissions` instance variable
- add tests