### PR TITLE
BXC-4415 add object_type column to permissions csv

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/PermissionsInfo.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/PermissionsInfo.java
@@ -13,8 +13,9 @@ import java.util.List;
 public class PermissionsInfo {
     public static final String DEFAULT_ID = "default";
     public static final String ID_FIELD = "id";
+    public static final String OBJECT_TYPE = "object_type";
     public static final String[] CSV_HEADERS = new String[] {
-            ID_FIELD, PUBLIC_PRINC, AUTHENTICATED_PRINC };
+            ID_FIELD, PUBLIC_PRINC, AUTHENTICATED_PRINC, OBJECT_TYPE };
 
     private List<PermissionMapping> mappings;
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/PermissionsInfo.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/PermissionsInfo.java
@@ -15,7 +15,7 @@ public class PermissionsInfo {
     public static final String ID_FIELD = "id";
     public static final String OBJECT_TYPE = "object_type";
     public static final String[] CSV_HEADERS = new String[] {
-            ID_FIELD, PUBLIC_PRINC, AUTHENTICATED_PRINC, OBJECT_TYPE };
+            ID_FIELD, OBJECT_TYPE, PUBLIC_PRINC, AUTHENTICATED_PRINC };
 
     private List<PermissionMapping> mappings;
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidator.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidator.java
@@ -42,8 +42,8 @@ public class PermissionsValidator {
         ) {
             int i = 2;
             for (CSVRecord csvRecord : csvParser) {
-                if (csvRecord.size() != 3) {
-                    errors.add("Invalid entry at line " + i + ", must be 3 columns but were " + csvRecord.size());
+                if (csvRecord.size() != 4) {
+                    errors.add("Invalid entry at line " + i + ", must be 4 columns but were " + csvRecord.size());
                     i++;
                     continue;
                 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidator.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidator.java
@@ -48,8 +48,8 @@ public class PermissionsValidator {
                     continue;
                 }
                 String id = csvRecord.get(0);
-                String everyone = csvRecord.get(1);
-                String authenticated = csvRecord.get(2);
+                String everyone = csvRecord.get(2);
+                String authenticated = csvRecord.get(3);
 
                 // default values
                 if (PermissionsInfo.DEFAULT_ID.equals(id)) {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
@@ -283,7 +283,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
 
         // Add a duplicate default permissions mapping
         FileUtils.write(project.getPermissionsPath().toFile(),
-                "default,none,none,", StandardCharsets.UTF_8, true);
+                "default,,none,none", StandardCharsets.UTF_8, true);
 
         String[] args2 = new String[] {
                 "-w", project.getProjectPath().toString(),
@@ -299,7 +299,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
     @Test
     public void validateValidSetPermissions() throws Exception {
         FileUtils.write(project.getPermissionsPath().toFile(),
-                "25,canViewOriginals,canViewOriginals,work", StandardCharsets.UTF_8, true);
+                "25,work,canViewOriginals,canViewOriginals", StandardCharsets.UTF_8, true);
 
         testHelper.indexExportData("mini_gilmer");
         String[] args = new String[] {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
@@ -283,7 +283,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
 
         // Add a duplicate default permissions mapping
         FileUtils.write(project.getPermissionsPath().toFile(),
-                "default,none,none", StandardCharsets.UTF_8, true);
+                "default,none,none,", StandardCharsets.UTF_8, true);
 
         String[] args2 = new String[] {
                 "-w", project.getProjectPath().toString(),
@@ -299,7 +299,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
     @Test
     public void validateValidSetPermissions() throws Exception {
         FileUtils.write(project.getPermissionsPath().toFile(),
-                "25,canViewOriginals,canViewOriginals", StandardCharsets.UTF_8, true);
+                "25,canViewOriginals,canViewOriginals,work", StandardCharsets.UTF_8, true);
 
         testHelper.indexExportData("mini_gilmer");
         String[] args = new String[] {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -77,7 +77,8 @@ public class PermissionsServiceTest {
                 CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT);
         ) {
             List<CSVRecord> rows = csvParser.getRecords();
-            assertIterableEquals(Arrays.asList(PermissionsInfo.ID_FIELD, PUBLIC_PRINC, AUTHENTICATED_PRINC), rows.get(0));
+            assertIterableEquals(Arrays.asList(PermissionsInfo.ID_FIELD, PUBLIC_PRINC, AUTHENTICATED_PRINC,
+                    PermissionsInfo.OBJECT_TYPE), rows.get(0));
         }
     }
 
@@ -93,7 +94,7 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
     }
 
     @Test
@@ -106,7 +107,7 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewOriginals", "canViewOriginals"), rows.get(0));
+        assertIterableEquals(Arrays.asList("default", "canViewOriginals", "canViewOriginals", ""), rows.get(0));
     }
 
     @Test
@@ -120,7 +121,7 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "none", "none"), rows.get(0));
+        assertIterableEquals(Arrays.asList("default", "none", "none", ""), rows.get(0));
     }
 
     @Test
@@ -142,7 +143,7 @@ public class PermissionsServiceTest {
 
     @Test
     public void generateDefaultPermissionsWithoutForceFlagTest() throws Exception {
-        writeCsv(mappingBody("default,none,none"));
+        writeCsv(mappingBody("default,none,none,"));
 
         var options = new PermissionMappingOptions();
         options.setWithDefault(true);
@@ -161,7 +162,7 @@ public class PermissionsServiceTest {
     @Test
     public void generateDefaultPermissionsWithForceFlagTest() throws Exception {
         Path permissionsMappingPath = project.getPermissionsPath();
-        writeCsv(mappingBody("default,none,none"));
+        writeCsv(mappingBody("default,none,none,"));
 
         var options = new PermissionMappingOptions();
         options.setWithDefault(true);
@@ -173,7 +174,7 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
     }
 
     @Test
@@ -190,10 +191,10 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
-        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(1));
-        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(2));
-        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(3));
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata", "work"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata", "work"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata", "work"), rows.get(3));
     }
 
     @Test
@@ -210,9 +211,9 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(0));
-        assertIterableEquals(Arrays.asList("28", "canViewMetadata", "canViewMetadata"), rows.get(1));
-        assertIterableEquals(Arrays.asList("29", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata", "work"), rows.get(0));
+        assertIterableEquals(Arrays.asList("28", "canViewMetadata", "canViewMetadata", "work"), rows.get(1));
+        assertIterableEquals(Arrays.asList("29", "canViewMetadata", "canViewMetadata", "work"), rows.get(2));
     }
 
     @Test
@@ -229,8 +230,8 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(0));
-        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata", "file"), rows.get(0));
+        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata", "file"), rows.get(1));
     }
 
     @Test
@@ -246,10 +247,10 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("602", "canViewMetadata", "canViewMetadata"), rows.get(0));
-        assertIterableEquals(Arrays.asList("603", "canViewMetadata", "canViewMetadata"), rows.get(1));
-        assertIterableEquals(Arrays.asList("605", "canViewMetadata", "canViewMetadata"), rows.get(2));
-        assertIterableEquals(Arrays.asList("606", "canViewMetadata", "canViewMetadata"), rows.get(3));
+        assertIterableEquals(Arrays.asList("602", "canViewMetadata", "canViewMetadata", "file"), rows.get(0));
+        assertIterableEquals(Arrays.asList("603", "canViewMetadata", "canViewMetadata", "file"), rows.get(1));
+        assertIterableEquals(Arrays.asList("605", "canViewMetadata", "canViewMetadata", "file"), rows.get(2));
+        assertIterableEquals(Arrays.asList("606", "canViewMetadata", "canViewMetadata", "file"), rows.get(3));
     }
 
     @Test
@@ -266,7 +267,7 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
     }
 
     @Test
@@ -284,16 +285,16 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
-        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(1));
-        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(2));
-        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(3));
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata", "work"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata", "work"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata", "work"), rows.get(3));
     }
 
     @Test
     public void generateWorkAndFilePermissionsWithDefaultAndForceTest() throws Exception {
         Path permissionsMappingPath = project.getPermissionsPath();
-        writeCsv(mappingBody("default,none,none"));
+        writeCsv(mappingBody("default,none,none,"));
 
         testHelper.indexExportData("mini_gilmer");
         var options = new PermissionMappingOptions();
@@ -308,10 +309,10 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
-        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(1));
-        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata"), rows.get(2));
-        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(3));
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata", "work"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata", "work"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata", "work"), rows.get(3));
     }
 
     @Test
@@ -328,18 +329,18 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("216", "canViewMetadata", "canViewMetadata"), rows.get(0));
-        assertIterableEquals(Arrays.asList("602", "canViewMetadata", "canViewMetadata"), rows.get(1));
-        assertIterableEquals(Arrays.asList("603", "canViewMetadata", "canViewMetadata"), rows.get(2));
-        assertIterableEquals(Arrays.asList("604", "canViewMetadata", "canViewMetadata"), rows.get(3));
-        assertIterableEquals(Arrays.asList("605", "canViewMetadata", "canViewMetadata"), rows.get(4));
-        assertIterableEquals(Arrays.asList("606", "canViewMetadata", "canViewMetadata"), rows.get(5));
-        assertIterableEquals(Arrays.asList("607", "canViewMetadata", "canViewMetadata"), rows.get(6));
+        assertIterableEquals(Arrays.asList("216", "canViewMetadata", "canViewMetadata", "work"), rows.get(0));
+        assertIterableEquals(Arrays.asList("602", "canViewMetadata", "canViewMetadata", "file"), rows.get(1));
+        assertIterableEquals(Arrays.asList("603", "canViewMetadata", "canViewMetadata", "file"), rows.get(2));
+        assertIterableEquals(Arrays.asList("604", "canViewMetadata", "canViewMetadata", "work"), rows.get(3));
+        assertIterableEquals(Arrays.asList("605", "canViewMetadata", "canViewMetadata", "file"), rows.get(4));
+        assertIterableEquals(Arrays.asList("606", "canViewMetadata", "canViewMetadata", "file"), rows.get(5));
+        assertIterableEquals(Arrays.asList("607", "canViewMetadata", "canViewMetadata", "work"), rows.get(6));
     }
 
     @Test
     public void loadPermissionMappingsTest() throws Exception {
-        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata", "testId,none,none"));
+        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata,", "testId,none,none,work"));
 
         PermissionsInfo info = service.loadMappings(project);
         assertMappingPresent(info, "default", "canViewMetadata", "canViewMetadata");
@@ -359,7 +360,8 @@ public class PermissionsServiceTest {
 
     @Test
     public void setPermissionExistingEntryTest() throws Exception {
-        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata", "25,none,none", "26,none,none", "27,none,none"));
+        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata,", "25,none,none,work", "26,none,none,work",
+                "27,none,none,work"));
         testHelper.indexExportData("mini_gilmer");
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
@@ -371,15 +373,15 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
-        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata"), rows.get(1));
-        assertIterableEquals(Arrays.asList("26", "none", "none"), rows.get(2));
-        assertIterableEquals(Arrays.asList("27", "none", "none"), rows.get(3));
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata", "work"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "none", "none", "work"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "none", "none", "work"), rows.get(3));
     }
 
     @Test
     public void setPermissionsGroupedWorkEntryTest() throws Exception {
-        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata", "26,none,none", "27,none,none"));
+        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata,", "26,none,none,work", "27,none,none,work"));
         testHelper.indexExportData("grouped_gilmer");
         setupGroupedIndex();
         Path permissionsMappingPath = project.getPermissionsPath();
@@ -392,15 +394,15 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
-        assertIterableEquals(Arrays.asList("26", "none", "none"), rows.get(1));
-        assertIterableEquals(Arrays.asList("27", "none", "none"), rows.get(2));
-        assertIterableEquals(Arrays.asList("grp:groupa:group1", "canViewMetadata", "canViewMetadata"), rows.get(3));
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
+        assertIterableEquals(Arrays.asList("26", "none", "none", "work"), rows.get(1));
+        assertIterableEquals(Arrays.asList("27", "none", "none", "work"), rows.get(2));
+        assertIterableEquals(Arrays.asList("grp:groupa:group1", "canViewMetadata", "canViewMetadata", "work"), rows.get(3));
     }
 
     @Test
     public void setPermissionNewEntryTest() throws Exception {
-        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata", "25,none,none", "26,none,none"));
+        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata, ", "25,none,none,work", "26,none,none,work"));
         testHelper.indexExportData("mini_gilmer");
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
@@ -412,15 +414,15 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata"), rows.get(0));
-        assertIterableEquals(Arrays.asList("25", "none", "none"), rows.get(1));
-        assertIterableEquals(Arrays.asList("26", "none", "none"), rows.get(2));
-        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata"), rows.get(3));
+        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "none", "none", "work"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "none", "none", "work"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata", "work"), rows.get(3));
     }
 
     @Test
     public void setPermissionInvalidIdTest() throws Exception {
-        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata", "25,none,none", "26,none,none"));
+        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata,", "25,none,none,work", "26,none,none,work"));
         testHelper.indexExportData("mini_gilmer");
         var options = new PermissionMappingOptions();
         options.setCdmId("28");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -77,8 +77,8 @@ public class PermissionsServiceTest {
                 CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT);
         ) {
             List<CSVRecord> rows = csvParser.getRecords();
-            assertIterableEquals(Arrays.asList(PermissionsInfo.ID_FIELD, PUBLIC_PRINC, AUTHENTICATED_PRINC,
-                    PermissionsInfo.OBJECT_TYPE), rows.get(0));
+            assertIterableEquals(Arrays.asList(PermissionsInfo.ID_FIELD, PermissionsInfo.OBJECT_TYPE,
+                    PUBLIC_PRINC, AUTHENTICATED_PRINC), rows.get(0));
         }
     }
 
@@ -94,7 +94,7 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
     }
 
     @Test
@@ -107,7 +107,7 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewOriginals", "canViewOriginals", ""), rows.get(0));
+        assertIterableEquals(Arrays.asList("default", "", "canViewOriginals", "canViewOriginals"), rows.get(0));
     }
 
     @Test
@@ -121,7 +121,7 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "none", "none", ""), rows.get(0));
+        assertIterableEquals(Arrays.asList("default", "", "none", "none"), rows.get(0));
     }
 
     @Test
@@ -143,7 +143,7 @@ public class PermissionsServiceTest {
 
     @Test
     public void generateDefaultPermissionsWithoutForceFlagTest() throws Exception {
-        writeCsv(mappingBody("default,none,none,"));
+        writeCsv(mappingBody("default,,none,none"));
 
         var options = new PermissionMappingOptions();
         options.setWithDefault(true);
@@ -162,7 +162,7 @@ public class PermissionsServiceTest {
     @Test
     public void generateDefaultPermissionsWithForceFlagTest() throws Exception {
         Path permissionsMappingPath = project.getPermissionsPath();
-        writeCsv(mappingBody("default,none,none,"));
+        writeCsv(mappingBody("default,,none,none"));
 
         var options = new PermissionMappingOptions();
         options.setWithDefault(true);
@@ -174,7 +174,7 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
     }
 
     @Test
@@ -191,10 +191,10 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
-        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata", "work"), rows.get(1));
-        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata", "work"), rows.get(2));
-        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata", "work"), rows.get(3));
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
     }
 
     @Test
@@ -211,9 +211,9 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata", "work"), rows.get(0));
-        assertIterableEquals(Arrays.asList("28", "canViewMetadata", "canViewMetadata", "work"), rows.get(1));
-        assertIterableEquals(Arrays.asList("29", "canViewMetadata", "canViewMetadata", "work"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "work", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("28", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("29", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
     }
 
     @Test
@@ -230,8 +230,8 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata", "file"), rows.get(0));
-        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata", "file"), rows.get(1));
+        assertIterableEquals(Arrays.asList("25", "file", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("26", "file", "canViewMetadata", "canViewMetadata"), rows.get(1));
     }
 
     @Test
@@ -247,10 +247,10 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("602", "canViewMetadata", "canViewMetadata", "file"), rows.get(0));
-        assertIterableEquals(Arrays.asList("603", "canViewMetadata", "canViewMetadata", "file"), rows.get(1));
-        assertIterableEquals(Arrays.asList("605", "canViewMetadata", "canViewMetadata", "file"), rows.get(2));
-        assertIterableEquals(Arrays.asList("606", "canViewMetadata", "canViewMetadata", "file"), rows.get(3));
+        assertIterableEquals(Arrays.asList("602", "file", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("603", "file", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("605", "file", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("606", "file", "canViewMetadata", "canViewMetadata"), rows.get(3));
     }
 
     @Test
@@ -267,7 +267,7 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
     }
 
     @Test
@@ -285,10 +285,10 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
-        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata", "work"), rows.get(1));
-        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata", "work"), rows.get(2));
-        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata", "work"), rows.get(3));
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
     }
 
     @Test
@@ -309,10 +309,10 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
-        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata", "work"), rows.get(1));
-        assertIterableEquals(Arrays.asList("26", "canViewMetadata", "canViewMetadata", "work"), rows.get(2));
-        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata", "work"), rows.get(3));
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
     }
 
     @Test
@@ -329,18 +329,18 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("216", "canViewMetadata", "canViewMetadata", "work"), rows.get(0));
-        assertIterableEquals(Arrays.asList("602", "canViewMetadata", "canViewMetadata", "file"), rows.get(1));
-        assertIterableEquals(Arrays.asList("603", "canViewMetadata", "canViewMetadata", "file"), rows.get(2));
-        assertIterableEquals(Arrays.asList("604", "canViewMetadata", "canViewMetadata", "work"), rows.get(3));
-        assertIterableEquals(Arrays.asList("605", "canViewMetadata", "canViewMetadata", "file"), rows.get(4));
-        assertIterableEquals(Arrays.asList("606", "canViewMetadata", "canViewMetadata", "file"), rows.get(5));
-        assertIterableEquals(Arrays.asList("607", "canViewMetadata", "canViewMetadata", "work"), rows.get(6));
+        assertIterableEquals(Arrays.asList("216", "work", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("602", "file", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("603", "file", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("604", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
+        assertIterableEquals(Arrays.asList("605", "file", "canViewMetadata", "canViewMetadata"), rows.get(4));
+        assertIterableEquals(Arrays.asList("606", "file", "canViewMetadata", "canViewMetadata"), rows.get(5));
+        assertIterableEquals(Arrays.asList("607", "work", "canViewMetadata", "canViewMetadata"), rows.get(6));
     }
 
     @Test
     public void loadPermissionMappingsTest() throws Exception {
-        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata,", "testId,none,none,work"));
+        writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "testId,work,none,none"));
 
         PermissionsInfo info = service.loadMappings(project);
         assertMappingPresent(info, "default", "canViewMetadata", "canViewMetadata");
@@ -360,8 +360,8 @@ public class PermissionsServiceTest {
 
     @Test
     public void setPermissionExistingEntryTest() throws Exception {
-        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata,", "25,none,none,work", "26,none,none,work",
-                "27,none,none,work"));
+        writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "25,work,none,none", "26,work,none,none",
+                "27,work,none,none"));
         testHelper.indexExportData("mini_gilmer");
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
@@ -373,15 +373,15 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
-        assertIterableEquals(Arrays.asList("25", "canViewMetadata", "canViewMetadata", "work"), rows.get(1));
-        assertIterableEquals(Arrays.asList("26", "none", "none", "work"), rows.get(2));
-        assertIterableEquals(Arrays.asList("27", "none", "none", "work"), rows.get(3));
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "work", "none", "none"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "work", "none", "none"), rows.get(3));
     }
 
     @Test
     public void setPermissionsGroupedWorkEntryTest() throws Exception {
-        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata,", "26,none,none,work", "27,none,none,work"));
+        writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "26,work,none,none", "27,work,none,none"));
         testHelper.indexExportData("grouped_gilmer");
         setupGroupedIndex();
         Path permissionsMappingPath = project.getPermissionsPath();
@@ -394,15 +394,15 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
-        assertIterableEquals(Arrays.asList("26", "none", "none", "work"), rows.get(1));
-        assertIterableEquals(Arrays.asList("27", "none", "none", "work"), rows.get(2));
-        assertIterableEquals(Arrays.asList("grp:groupa:group1", "canViewMetadata", "canViewMetadata", "work"), rows.get(3));
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("26", "work", "none", "none"), rows.get(1));
+        assertIterableEquals(Arrays.asList("27", "work", "none", "none"), rows.get(2));
+        assertIterableEquals(Arrays.asList("grp:groupa:group1", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
     }
 
     @Test
     public void setPermissionNewEntryTest() throws Exception {
-        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata, ", "25,none,none,work", "26,none,none,work"));
+        writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "25,work,none,none", "26,work,none,none"));
         testHelper.indexExportData("mini_gilmer");
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
@@ -414,15 +414,15 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("default", "canViewMetadata", "canViewMetadata", ""), rows.get(0));
-        assertIterableEquals(Arrays.asList("25", "none", "none", "work"), rows.get(1));
-        assertIterableEquals(Arrays.asList("26", "none", "none", "work"), rows.get(2));
-        assertIterableEquals(Arrays.asList("27", "canViewMetadata", "canViewMetadata", "work"), rows.get(3));
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "work", "none", "none"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "work", "none", "none"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
     }
 
     @Test
     public void setPermissionInvalidIdTest() throws Exception {
-        writeCsv(mappingBody("default,canViewMetadata,canViewMetadata,", "25,none,none,work", "26,none,none,work"));
+        writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "25,work,none,none", "26,work,none,none"));
         testHelper.indexExportData("mini_gilmer");
         var options = new PermissionMappingOptions();
         options.setCdmId("28");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidatorTest.java
@@ -43,7 +43,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void validMappingsTest() throws Exception {
-        writeCsv(mappingBody("25,none,none,work"));
+        writeCsv(mappingBody("25,work,none,none"));
         List<String> errors = validator.validateMappings();
         assertNumberErrors(errors, 0);
     }
@@ -65,7 +65,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void blankIdTest() throws Exception {
-        writeCsv(mappingBody(",none,none,"));
+        writeCsv(mappingBody(",,none,none"));
         List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid blank id at line 2");
         assertNumberErrors(errors, 1);
@@ -73,7 +73,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void blankEveryoneTest() throws Exception {
-        writeCsv(mappingBody("25,,none,work"));
+        writeCsv(mappingBody("25,work,,none"));
         List<String> errors = validator.validateMappings();
         assertHasError(errors, "No 'everyone' permission mapped at line 2");
         assertNumberErrors(errors, 1);
@@ -81,7 +81,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void invalidEveryoneTest() throws Exception {
-        writeCsv(mappingBody("default,okaynope,none,"));
+        writeCsv(mappingBody("default,,okaynope,none"));
         List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid 'everyone' permission at line 2, okaynope is not a valid patron permission");
         assertNumberErrors(errors, 1);
@@ -89,7 +89,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void blankAuthenticatedTest() throws Exception {
-        writeCsv(mappingBody("default,none,,"));
+        writeCsv(mappingBody("default,,none,"));
         List<String> errors = validator.validateMappings();
         assertHasError(errors, "No 'authenticated' permission mapped at line 2");
         assertNumberErrors(errors, 1);
@@ -97,7 +97,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void invalidAuthenticatedTest() throws Exception {
-        writeCsv(mappingBody("26,none,okaynope,work"));
+        writeCsv(mappingBody("26,work,none,okaynope"));
         List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid 'authenticated' permission at line 2, " +
                 "okaynope is not a valid patron permission");
@@ -106,8 +106,8 @@ public class PermissionsValidatorTest {
 
     @Test
     public void multipleDefaultsTest() throws Exception {
-        writeCsv(mappingBody("default,none,none,",
-                "default,canViewOriginals,canViewOriginals,"));
+        writeCsv(mappingBody("default,,none,none",
+                "default,,canViewOriginals,canViewOriginals"));
         List<String> errors = validator.validateMappings();
         assertHasErrorMatching(errors, "Can only map default permissions once.*at line 3");
         assertNumberErrors(errors, 1);
@@ -123,7 +123,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void tooManyColumnsTest() throws Exception {
-        writeCsv(mappingBody("25,none,none,work,none"));
+        writeCsv(mappingBody("25,work,none,none,none"));
         List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid entry at line 2, must be 4 columns but were 5");
         assertNumberErrors(errors, 1);
@@ -131,7 +131,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void errorsOnSameLineTest() throws Exception {
-        writeCsv(mappingBody("26,okaynope,,"));
+        writeCsv(mappingBody("26,,okaynope,"));
         List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid 'everyone' permission at line 2, " +
                 "okaynope is not a valid patron permission");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidatorTest.java
@@ -43,7 +43,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void validMappingsTest() throws Exception {
-        writeCsv(mappingBody("25,none,none"));
+        writeCsv(mappingBody("25,none,none,work"));
         List<String> errors = validator.validateMappings();
         assertNumberErrors(errors, 0);
     }
@@ -65,7 +65,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void blankIdTest() throws Exception {
-        writeCsv(mappingBody(",none,none"));
+        writeCsv(mappingBody(",none,none,"));
         List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid blank id at line 2");
         assertNumberErrors(errors, 1);
@@ -73,7 +73,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void blankEveryoneTest() throws Exception {
-        writeCsv(mappingBody("25,,none"));
+        writeCsv(mappingBody("25,,none,work"));
         List<String> errors = validator.validateMappings();
         assertHasError(errors, "No 'everyone' permission mapped at line 2");
         assertNumberErrors(errors, 1);
@@ -81,7 +81,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void invalidEveryoneTest() throws Exception {
-        writeCsv(mappingBody("default,okaynope,none"));
+        writeCsv(mappingBody("default,okaynope,none,"));
         List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid 'everyone' permission at line 2, okaynope is not a valid patron permission");
         assertNumberErrors(errors, 1);
@@ -89,7 +89,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void blankAuthenticatedTest() throws Exception {
-        writeCsv(mappingBody("default,none,"));
+        writeCsv(mappingBody("default,none,,"));
         List<String> errors = validator.validateMappings();
         assertHasError(errors, "No 'authenticated' permission mapped at line 2");
         assertNumberErrors(errors, 1);
@@ -97,7 +97,7 @@ public class PermissionsValidatorTest {
 
     @Test
     public void invalidAuthenticatedTest() throws Exception {
-        writeCsv(mappingBody("26,none,okaynope"));
+        writeCsv(mappingBody("26,none,okaynope,work"));
         List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid 'authenticated' permission at line 2, " +
                 "okaynope is not a valid patron permission");
@@ -106,8 +106,8 @@ public class PermissionsValidatorTest {
 
     @Test
     public void multipleDefaultsTest() throws Exception {
-        writeCsv(mappingBody("default,none,none",
-                "default,canViewOriginals,canViewOriginals"));
+        writeCsv(mappingBody("default,none,none,",
+                "default,canViewOriginals,canViewOriginals,"));
         List<String> errors = validator.validateMappings();
         assertHasErrorMatching(errors, "Can only map default permissions once.*at line 3");
         assertNumberErrors(errors, 1);
@@ -115,23 +115,23 @@ public class PermissionsValidatorTest {
 
     @Test
     public void tooFewColumnsTest() throws Exception {
-        writeCsv(mappingBody("default,none"));
+        writeCsv(mappingBody("default,none,"));
         List<String> errors = validator.validateMappings();
-        assertHasError(errors, "Invalid entry at line 2, must be 3 columns but were 2");
+        assertHasError(errors, "Invalid entry at line 2, must be 4 columns but were 3");
         assertNumberErrors(errors, 1);
     }
 
     @Test
     public void tooManyColumnsTest() throws Exception {
-        writeCsv(mappingBody("25,none,none,none"));
+        writeCsv(mappingBody("25,none,none,work,none"));
         List<String> errors = validator.validateMappings();
-        assertHasError(errors, "Invalid entry at line 2, must be 3 columns but were 4");
+        assertHasError(errors, "Invalid entry at line 2, must be 4 columns but were 5");
         assertNumberErrors(errors, 1);
     }
 
     @Test
     public void errorsOnSameLineTest() throws Exception {
-        writeCsv(mappingBody("26,okaynope,"));
+        writeCsv(mappingBody("26,okaynope,,"));
         List<String> errors = validator.validateMappings();
         assertHasError(errors, "Invalid 'everyone' permission at line 2, " +
                 "okaynope is not a valid patron permission");


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4415](https://unclibrary.atlassian.net/browse/BXC-4415)

- `PermissionsInfo`: add object_type column to csv headers
- `PermissionsService`: add object_type column to permissions csv, modify `queryForMappedIds` to return a map of mapped ids and object types, add `isWork` helper method
- `PermissionsValidator`: change csvRecord size from 3 to 4
- update tests