### PR TITLE
BXC-4486 add with-works and with-files to perms set cmd

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
@@ -26,6 +26,8 @@ import java.sql.SQLException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -102,10 +104,8 @@ public class PermissionsService {
      * @param options permission mapping options
      */
     public void setPermissions(PermissionMappingOptions options) throws Exception {
-        if (options.getCdmId() != null) {
-            if (!doesIdExistInIndex(options.getCdmId())) {
-                throw new IllegalArgumentException("Id " + options.getCdmId() + " does not exist in this project.");
-            }
+        if (options.getCdmId() != null && !doesIdExistInIndex(options.getCdmId())) {
+            throw new IllegalArgumentException("Id " + options.getCdmId() + " does not exist in this project.");
         }
 
         Path permissionsMappingPath = project.getPermissionsPath();
@@ -332,6 +332,7 @@ public class PermissionsService {
             for (Map.Entry<String, String> workFileRecord : addWorkFileRecords) {
                 updatedRecords.add(Arrays.asList(workFileRecord.getKey(), workFileRecord.getValue(), everyoneField, authenticatedField));
             }
+            Collections.sort(updatedRecords, Comparator.comparing(e -> e.get(0)));
         }
 
         return updatedRecords;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
@@ -28,13 +28,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -114,7 +112,7 @@ public class PermissionsService {
             throw new InvalidProjectStateException("Permissions csv does not exist.");
         }
 
-        // add or update permission for a specific cdmId
+        // add or update permission for a specific cdmId, works, and files
         List<List<String>> records = updateCsvRecords(options);
 
         try (

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
@@ -333,6 +333,11 @@ public class PermissionsService {
                 updatedRecords.add(Arrays.asList(workFileRecord.getKey(), workFileRecord.getValue(), everyoneField, authenticatedField));
             }
             Collections.sort(updatedRecords, Comparator.comparing(e -> e.get(0)));
+            // move default entry to top if it exists
+            if (previousIds.contains(PermissionsInfo.DEFAULT_ID)) {
+               List<String> defaultEntry = updatedRecords.remove(updatedRecords.size() - 1);
+               updatedRecords.add(0, defaultEntry);
+            }
         }
 
         return updatedRecords;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
@@ -299,10 +299,11 @@ public class PermissionsService {
 
         // addedAndUpdatedIds: list of all ids that need to be added and updated
         if (options.getCdmId() != null) {
+            workAndFileRecords.add(new AbstractMap.SimpleEntry<>(options.getCdmId(), getObjectType(options.getCdmId())));
             addedAndUpdatedIds.add(options.getCdmId());
         }
         if (options.isWithWorks() || options.isWithFiles()) {
-            workAndFileRecords = queryForMappedIds(options);
+            workAndFileRecords.addAll(queryForMappedIds(options));
             Set<String> workFileIds = workAndFileRecords.stream().map(Map.Entry::getKey).collect(Collectors.toSet());
             addedAndUpdatedIds.addAll(workFileIds);
         }
@@ -318,12 +319,6 @@ public class PermissionsService {
             }
         }
 
-        // add one new entry
-        if (addedAndUpdatedIds.contains(options.getCdmId())) {
-            String objectType = getObjectType(options.getCdmId());
-            updatedRecords.add(Arrays.asList(options.getCdmId(), objectType, everyoneField, authenticatedField));
-        }
-
         // add new works or files entries
         for (Map.Entry<String, String> workAndFileRecord : workAndFileRecords) {
             if (addedAndUpdatedIds.contains(workAndFileRecord.getKey())) {
@@ -335,13 +330,9 @@ public class PermissionsService {
         updatedRecords.sort(Comparator.comparing(entry -> entry.get(0)));
         // move default entry to top if it exists
         List<String> updatedIds = updatedRecords.stream().map(entry -> entry.get(0)).collect(Collectors.toList());
-        int i = 0;
-        for (String id : updatedIds) {
-            if (id.equals(PermissionsInfo.DEFAULT_ID)) {
-                List<String> defaultEntry = updatedRecords.remove(i);
-                updatedRecords.add(0, defaultEntry);
-            }
-            i++;
+        if (updatedIds.contains(PermissionsInfo.DEFAULT_ID)) {
+            List<String> defaultEntry = updatedRecords.remove(updatedIds.indexOf(PermissionsInfo.DEFAULT_ID));
+            updatedRecords.add(0, defaultEntry);
         }
 
         return updatedRecords;

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
@@ -78,7 +78,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
     @Test
     public void generateDefaultPermissionsWithoutForceFlag() throws Exception {
         FileUtils.write(project.getPermissionsPath().toFile(),
-                "default,canViewMetadata,canViewMetadata", StandardCharsets.UTF_8, true);
+                "default,,canViewMetadata,canViewMetadata", StandardCharsets.UTF_8, true);
 
         String[] args = new String[] {
                 "-w", project.getProjectPath().toString(),
@@ -94,7 +94,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
     @Test
     public void generateDefaultPermissionsWithForceFlag() throws Exception {
         FileUtils.write(project.getPermissionsPath().toFile(),
-                "default,canViewMetadata,canViewMetadata", StandardCharsets.UTF_8, true);
+                "default,,canViewMetadata,canViewMetadata", StandardCharsets.UTF_8, true);
 
         String[] args = new String[] {
                 "-w", project.getProjectPath().toString(),
@@ -156,7 +156,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
     @Test
     public void generateWorkAndFilePermissionsWithForce() throws Exception {
         FileUtils.write(project.getPermissionsPath().toFile(),
-                "default,canViewOriginals,canViewOriginals", StandardCharsets.UTF_8, true);
+                "default,,canViewOriginals,canViewOriginals", StandardCharsets.UTF_8, true);
 
         testHelper.indexExportData("mini_gilmer");
         String[] args = new String[] {
@@ -194,7 +194,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
     @Test
     public void setPermissionExistingEntry() throws Exception {
         FileUtils.write(project.getPermissionsPath().toFile(),
-                "25,canViewOriginals,canViewOriginals", StandardCharsets.UTF_8, true);
+                "25,,canViewOriginals,canViewOriginals", StandardCharsets.UTF_8, true);
 
         testHelper.indexExportData("mini_gilmer");
         String[] args = new String[] {
@@ -251,6 +251,71 @@ public class PermissionsCommandIT extends AbstractCommandIT {
         assertMapping(0, "default", "canViewOriginals", "canViewOriginals");
         assertMapping(1, "grp:groupa:group1", "canViewMetadata", "canViewMetadata");
         assertMappingCount(2);
+    }
+
+    @Test
+    public void setPermissionsWithWorks() throws Exception {
+        FileUtils.write(project.getPermissionsPath().toFile(),
+                "25,,canViewOriginals,canViewOriginals", StandardCharsets.UTF_8, true);
+
+        testHelper.indexExportData("mini_gilmer");
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "set",
+                "-ww",
+                "-e", "canViewMetadata",
+                "-a", "canViewMetadata"};
+        executeExpectSuccess(args);
+        assertMapping(0, "25", "canViewMetadata", "canViewMetadata");
+        assertMapping(1, "26", "canViewMetadata", "canViewMetadata");
+        assertMapping(2, "27", "canViewMetadata", "canViewMetadata");
+    }
+
+    @Test
+    public void setPermissionsWithFiles() throws Exception {
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "generate",
+                "-wd",
+                "--everyone", "canViewOriginals",
+                "--authenticated", "canViewOriginals"};
+        executeExpectSuccess(args);
+
+        testHelper.indexExportData("grouped_gilmer");
+        setupGroupedIndex();
+        String[] args2 = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "set",
+                "-wf",
+                "-e", "canViewMetadata",
+                "-a", "canViewMetadata"};
+        executeExpectSuccess(args2);
+        assertMapping(0, "default", "canViewOriginals", "canViewOriginals");
+        assertMapping(1, "25", "canViewMetadata", "canViewMetadata");
+        assertMapping(2, "26", "canViewMetadata", "canViewMetadata");
+    }
+
+    @Test
+    public void setPermissionsWithWorksAndFiles() throws Exception {
+        FileUtils.write(project.getPermissionsPath().toFile(),
+                "603,file,canViewOriginals,canViewOriginals", StandardCharsets.UTF_8, true);
+
+        testHelper.indexExportData("mini_keepsakes");
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "set",
+                "-ww",
+                "-wf",
+                "-e", "canViewMetadata",
+                "-a", "canViewMetadata"};
+        executeExpectSuccess(args);
+        assertMapping(0, "216", "canViewMetadata", "canViewMetadata");
+        assertMapping(1, "602", "canViewMetadata", "canViewMetadata");
+        assertMapping(2, "603", "canViewMetadata", "canViewMetadata");
+        assertMapping(3, "604", "canViewMetadata", "canViewMetadata");
+        assertMapping(4, "605", "canViewMetadata", "canViewMetadata");
+        assertMapping(5, "606", "canViewMetadata", "canViewMetadata");
+        assertMapping(6, "607", "canViewMetadata", "canViewMetadata");
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -541,7 +541,7 @@ public class PermissionsServiceTest {
 
     @Test
     public void setPermissionsExistingWorksNewFiles() throws Exception {
-        writeCsv(mappingBody("216,work,canViewMetadata,canViewMetadata",
+        writeCsv(mappingBody("default,,none,none", "216,work,canViewMetadata,canViewMetadata",
                 "604,work,canViewMetadata,canViewMetadata", "607,work,canViewMetadata,canViewMetadata"));
         testHelper.indexExportData("mini_keepsakes");
         Path permissionsMappingPath = project.getPermissionsPath();
@@ -554,13 +554,14 @@ public class PermissionsServiceTest {
         assertTrue(Files.exists(permissionsMappingPath));
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
-        assertIterableEquals(Arrays.asList("216", "work", "canViewMetadata", "canViewMetadata"), rows.get(0));
-        assertIterableEquals(Arrays.asList("602", "file", "canViewMetadata", "canViewMetadata"), rows.get(1));
-        assertIterableEquals(Arrays.asList("603", "file", "canViewMetadata", "canViewMetadata"), rows.get(2));
-        assertIterableEquals(Arrays.asList("604", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
-        assertIterableEquals(Arrays.asList("605", "file", "canViewMetadata", "canViewMetadata"), rows.get(4));
-        assertIterableEquals(Arrays.asList("606", "file", "canViewMetadata", "canViewMetadata"), rows.get(5));
-        assertIterableEquals(Arrays.asList("607", "work", "canViewMetadata", "canViewMetadata"), rows.get(6));
+        assertIterableEquals(Arrays.asList("default", "", "none", "none"), rows.get(0));
+        assertIterableEquals(Arrays.asList("216", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("602", "file", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("603", "file", "canViewMetadata", "canViewMetadata"), rows.get(3));
+        assertIterableEquals(Arrays.asList("604", "work", "canViewMetadata", "canViewMetadata"), rows.get(4));
+        assertIterableEquals(Arrays.asList("605", "file", "canViewMetadata", "canViewMetadata"), rows.get(5));
+        assertIterableEquals(Arrays.asList("606", "file", "canViewMetadata", "canViewMetadata"), rows.get(6));
+        assertIterableEquals(Arrays.asList("607", "work", "canViewMetadata", "canViewMetadata"), rows.get(7));
     }
 
     private String mappingBody(String... rows) {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -455,6 +455,90 @@ public class PermissionsServiceTest {
         assertEquals(expectedMessage, actualMessage);
     }
 
+    @Test
+    public void setPermissionWithWorksDefault() throws Exception {
+        writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "26,work,none,none"));
+        testHelper.indexExportData("mini_gilmer");
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setWithWorks(true);
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.setPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
+    }
+
+    @Test
+    public void setPermissionsWithFilesGroupedWork() throws Exception {
+        writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata"));
+        testHelper.indexExportData("grouped_gilmer");
+        setupGroupedIndex();
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setWithFiles(true);
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.setPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "file", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "file", "canViewMetadata", "canViewMetadata"), rows.get(2));
+    }
+
+    @Test
+    public void setPermissionsWithFilesCompoundObjects() throws Exception {
+        writeCsv(mappingBody("603,file,canViewMetadata,canViewMetadata"));
+        testHelper.indexExportData("mini_keepsakes");
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setWithFiles(true);
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.setPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("602", "file", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("603", "file", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("605", "file", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("606", "file", "canViewMetadata", "canViewMetadata"), rows.get(3));
+    }
+
+    @Test
+    public void setPermissionsWithWorksAndFiles() throws Exception {
+        writeCsv(mappingBody("604,work,canViewMetadata,canViewMetadata"));
+        testHelper.indexExportData("mini_keepsakes");
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setWithWorks(true);
+        options.setWithFiles(true);
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.setPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("216", "work", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("602", "file", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("603", "file", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("604", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
+        assertIterableEquals(Arrays.asList("605", "file", "canViewMetadata", "canViewMetadata"), rows.get(4));
+        assertIterableEquals(Arrays.asList("606", "file", "canViewMetadata", "canViewMetadata"), rows.get(5));
+        assertIterableEquals(Arrays.asList("607", "work", "canViewMetadata", "canViewMetadata"), rows.get(6));
+    }
+
     private String mappingBody(String... rows) {
         return String.join(",", PermissionsInfo.CSV_HEADERS) + "\n"
                 + String.join("\n", rows);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -539,6 +539,30 @@ public class PermissionsServiceTest {
         assertIterableEquals(Arrays.asList("607", "work", "canViewMetadata", "canViewMetadata"), rows.get(6));
     }
 
+    @Test
+    public void setPermissionsExistingWorksNewFiles() throws Exception {
+        writeCsv(mappingBody("216,work,canViewMetadata,canViewMetadata",
+                "604,work,canViewMetadata,canViewMetadata", "607,work,canViewMetadata,canViewMetadata"));
+        testHelper.indexExportData("mini_keepsakes");
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setWithFiles(true);
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.setPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("216", "work", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("602", "file", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("603", "file", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("604", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
+        assertIterableEquals(Arrays.asList("605", "file", "canViewMetadata", "canViewMetadata"), rows.get(4));
+        assertIterableEquals(Arrays.asList("606", "file", "canViewMetadata", "canViewMetadata"), rows.get(5));
+        assertIterableEquals(Arrays.asList("607", "work", "canViewMetadata", "canViewMetadata"), rows.get(6));
+    }
+
     private String mappingBody(String... rows) {
         return String.join(",", PermissionsInfo.CSV_HEADERS) + "\n"
                 + String.join("\n", rows);


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4486](https://unclibrary.atlassian.net/browse/BXC-4486)

- `PermissionsService`: modify `updateCsvRecords` to accept `--with-works` and `--with-files` options
- add and modify tests