### PR TITLE
BXC-4511 add streaming metadata to SIPS

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/SipsCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/SipsCommand.java
@@ -8,6 +8,8 @@ import java.nio.file.Path;
 import java.util.List;
 
 import edu.unc.lib.boxc.migration.cdm.services.AggregateFileMappingService;
+import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
+import edu.unc.lib.boxc.migration.cdm.services.StreamingMetadataService;
 import org.slf4j.Logger;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
@@ -46,6 +48,8 @@ public class SipsCommand {
     private CdmIndexService indexService;
     private AggregateFileMappingService aggregateTopMappingService;
     private AggregateFileMappingService aggregateBottomMappingService;
+    private CdmFieldService fieldService;
+    private StreamingMetadataService streamingMetadataService;
     private PIDMinter pidMinter;
     private PremisLoggerFactoryImpl premisLoggerFactory;
     private SipService sipService;
@@ -135,6 +139,11 @@ public class SipsCommand {
         aggregateBottomMappingService = new AggregateFileMappingService(true);
         aggregateBottomMappingService.setIndexService(indexService);
         aggregateBottomMappingService.setProject(project);
+        fieldService = new CdmFieldService();
+        streamingMetadataService = new StreamingMetadataService();
+        streamingMetadataService.setProject(project);
+        streamingMetadataService.setFieldService(fieldService);
+        streamingMetadataService.setIndexService(indexService);
 
         sipService = new SipService();
         sipService.setIndexService(indexService);
@@ -147,5 +156,6 @@ public class SipsCommand {
         sipService.setChompbConfig(parentCommand.getChompbConfig());
         sipService.setAggregateTopMappingService(aggregateTopMappingService);
         sipService.setAggregateBottomMappingService(aggregateBottomMappingService);
+        sipService.setStreamingMetadataService(streamingMetadataService);
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
@@ -72,6 +72,7 @@ public class SipService {
     private MigrationProject project;
     private ChompbConfigService.ChompbConfig chompbConfig;
     private PermissionsService permissionsService;
+    private StreamingMetadataService streamingMetadataService;
     private PIDMinter pidMinter;
     private CdmToDestMapper cdmToDestMapper = new CdmToDestMapper();
     private WorkGeneratorFactory workGeneratorFactory;
@@ -104,6 +105,7 @@ public class SipService {
         workGeneratorFactory.setPostMigrationReportService(postMigrationReportService);
         workGeneratorFactory.setAggregateTopMappingService(aggregateTopMappingService);
         workGeneratorFactory.setAggregateBottomMappingService(aggregateBottomMappingService);
+        workGeneratorFactory.setStreamingMetadataService(streamingMetadataService);
         try {
             workGeneratorFactory.setPermissionsInfo(permissionsService.loadMappings(project));
         } catch (NoSuchFileException e) {
@@ -376,6 +378,10 @@ public class SipService {
 
     public void setPermissionsService(PermissionsService permissionsService) {
         this.permissionsService = permissionsService;
+    }
+
+    public void setStreamingMetadataService(StreamingMetadataService streamingMetadataService) {
+        this.streamingMetadataService = streamingMetadataService;
     }
 
     public void setPidMinter(PIDMinter pidMinter) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGenerator.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGenerator.java
@@ -12,6 +12,7 @@ import edu.unc.lib.boxc.migration.cdm.services.DescriptionsService;
 import edu.unc.lib.boxc.migration.cdm.services.PostMigrationReportService;
 import edu.unc.lib.boxc.migration.cdm.services.RedirectMappingService;
 import edu.unc.lib.boxc.migration.cdm.services.SipService;
+import edu.unc.lib.boxc.migration.cdm.services.StreamingMetadataService;
 import edu.unc.lib.boxc.model.api.DatastreamType;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.ids.PIDMinter;
@@ -58,6 +59,7 @@ public class WorkGenerator {
     protected AccessFileService accessFileService;
     protected PostMigrationReportService postMigrationReportService;
     protected PermissionsInfo permissionsInfo;
+    protected StreamingMetadataService streamingMetadataService;
 
     protected String cdmId;
     protected String cdmCreated;
@@ -175,6 +177,9 @@ public class WorkGenerator {
         // Add permission to source file
         addFilePermission(cdmId, fileObjResc);
 
+        // Add streamingUrl
+        addStreamingMetadata(cdmId, fileObjResc);
+
         // Link access file
         if (accessFilesInfo != null) {
             SourceFilesInfo.SourceFileMapping accessMapping = accessFilesInfo.getMappingByCdmId(cdmId);
@@ -227,6 +232,17 @@ public class WorkGenerator {
                 resource.addLiteral(everyoneValue, PUBLIC_PRINC);
                 resource.addLiteral(authenticatedValue, AUTHENTICATED_PRINC);
             }
+        }
+    }
+
+    protected void addStreamingMetadata(String cdmId, Resource resource) {
+        if (streamingMetadataService.verifyRecordHasStreamingMetadata(cdmId)) {
+            String[] streamingMetadata = streamingMetadataService.getStreamingMetadata(cdmId);
+            String duracloudSpace = streamingMetadata[1];
+            String streamingFile = streamingMetadata[0];
+            String streamingUrlValue = "https://durastream.lib.unc.edu/player?spaceId=" + duracloudSpace
+                    + "&filename=" + streamingFile;
+            resource.addProperty(Cdr.streamingUrl, streamingUrlValue);
         }
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGenerator.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGenerator.java
@@ -101,6 +101,9 @@ public class WorkGenerator {
         // add permission to work
         addPermission(cdmId, workBag);
 
+        // Add streamingUrl
+        addStreamingMetadata(cdmId, workBag);
+
         // Copy description to SIP
         copyDescriptionToSip(workPid, expDescPath);
 
@@ -180,9 +183,6 @@ public class WorkGenerator {
 
         // Add permission to source file
         addFilePermission(cdmId, fileObjResc);
-
-        // Add streamingUrl
-        addStreamingMetadata(cdmId, fileObjResc);
 
         // Link access file
         if (accessFilesInfo != null) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGenerator.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGenerator.java
@@ -4,6 +4,7 @@ import edu.unc.lib.boxc.auth.api.UserRole;
 import edu.unc.lib.boxc.deposit.impl.model.DepositModelHelpers;
 import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.model.DestinationSipEntry;
+import edu.unc.lib.boxc.migration.cdm.model.GroupMappingInfo;
 import edu.unc.lib.boxc.migration.cdm.model.PermissionsInfo;
 import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo;
 import edu.unc.lib.boxc.migration.cdm.options.SipGenerationOptions;
@@ -102,7 +103,9 @@ public class WorkGenerator {
         addPermission(cdmId, workBag);
 
         // Add streamingUrl
-        addStreamingMetadata(cdmId, workBag);
+        if (!cdmId.startsWith(GroupMappingInfo.GROUPED_WORK_PREFIX)) {
+            addStreamingMetadata(cdmId, workBag);
+        }
 
         // Copy description to SIP
         copyDescriptionToSip(workPid, expDescPath);
@@ -183,6 +186,9 @@ public class WorkGenerator {
 
         // Add permission to source file
         addFilePermission(cdmId, fileObjResc);
+
+        // Add streamingUrl
+        addStreamingMetadata(cdmId, fileObjResc);
 
         // Link access file
         if (accessFilesInfo != null) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGenerator.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGenerator.java
@@ -102,11 +102,6 @@ public class WorkGenerator {
         // add permission to work
         addPermission(cdmId, workBag);
 
-        // Add streamingUrl
-        if (!cdmId.startsWith(GroupMappingInfo.GROUPED_WORK_PREFIX)) {
-            addStreamingMetadata(cdmId, workBag);
-        }
-
         // Copy description to SIP
         copyDescriptionToSip(workPid, expDescPath);
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGenerator.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGenerator.java
@@ -37,6 +37,7 @@ import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.AUTHENTICATED_P
 import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.PUBLIC_PRINC;
 import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
 import static edu.unc.lib.boxc.model.api.DatastreamType.ORIGINAL_FILE;
+import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -46,6 +47,9 @@ import static org.slf4j.LoggerFactory.getLogger;
  */
 public class WorkGenerator {
     private static final Logger log = getLogger(WorkGenerator.class);
+    // use local streamingUrl property for now because Cdr.streamingUrl only exists in a feature branch
+    public static final Property streamingUrl = createProperty(
+            "http://cdr.unc.edu/definitions/model#streamingUrl");
     protected PIDMinter pidMinter;
     protected RedirectMappingService redirectMappingService;
     protected SourceFilesInfo sourceFilesInfo;
@@ -242,7 +246,7 @@ public class WorkGenerator {
             String streamingFile = streamingMetadata[0];
             String streamingUrlValue = "https://durastream.lib.unc.edu/player?spaceId=" + duracloudSpace
                     + "&filename=" + streamingFile;
-            resource.addProperty(Cdr.streamingUrl, streamingUrlValue);
+            resource.addProperty(streamingUrl, streamingUrlValue);
         }
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGeneratorFactory.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGeneratorFactory.java
@@ -9,6 +9,7 @@ import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
 import edu.unc.lib.boxc.migration.cdm.services.DescriptionsService;
 import edu.unc.lib.boxc.migration.cdm.services.PostMigrationReportService;
 import edu.unc.lib.boxc.migration.cdm.services.RedirectMappingService;
+import edu.unc.lib.boxc.migration.cdm.services.StreamingMetadataService;
 import edu.unc.lib.boxc.model.api.ids.PIDMinter;
 
 import java.io.IOException;
@@ -34,6 +35,7 @@ public class WorkGeneratorFactory {
     private AggregateFileMappingService aggregateBottomMappingService;
     private PIDMinter pidMinter;
     private PermissionsInfo permissionsInfo;
+    private StreamingMetadataService streamingMetadataService;
 
     public WorkGenerator create(String cdmId, String cdmCreated, String entryType) throws IOException {
         WorkGenerator gen;
@@ -58,6 +60,7 @@ public class WorkGeneratorFactory {
         gen.redirectMappingService = redirectMappingService;
         gen.postMigrationReportService = postMigrationReportService;
         gen.permissionsInfo = permissionsInfo;
+        gen.streamingMetadataService = streamingMetadataService;
         return gen;
     }
 
@@ -115,5 +118,9 @@ public class WorkGeneratorFactory {
 
     public void setPermissionsInfo(PermissionsInfo permissionsInfo) {
         this.permissionsInfo = permissionsInfo;
+    }
+
+    public void setStreamingMetadataService(StreamingMetadataService streamingMetadataService) {
+        this.streamingMetadataService = streamingMetadataService;
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -1406,7 +1406,12 @@ public class SipServiceTest {
                 "spaceId=open-hls&filename=gilmer_recording-playlist.m3u8"));
         Resource workResc3 = testHelper.getResourceByCreateTime(depBagChildren, "2005-12-08");
         testHelper.assertObjectPopulatedInSip(workResc3, dirManager, model, stagingLocs.get(2), null, "27");
-        assertTrue(workResc3.hasProperty(streamingUrl, "https://durastream.lib.unc.edu/player?" +
+        // assert file in workResc3 has streamingUrl
+        Bag workResc3Bag = model.getBag(workResc3);
+        List<RDFNode> workChildren = workResc3Bag.iterator().toList();
+        assertEquals(1, workChildren.size());
+        Resource fileObjResc = workChildren.get(0).asResource();
+        assertTrue(fileObjResc.hasProperty(streamingUrl, "https://durastream.lib.unc.edu/player?" +
                 "spaceId=open-hls&filename=gilmer_recording-playlist.m3u8"));
 
         assertPersistedSipInfoMatches(sip);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -1398,20 +1398,27 @@ public class SipServiceTest {
 
         Resource workResc1 = testHelper.getResourceByCreateTime(depBagChildren, "2005-11-23");
         testHelper.assertObjectPopulatedInSip(workResc1, dirManager, model, stagingLocs.get(0), null, "25");
-        assertFalse(workResc1.hasProperty(streamingUrl, "https://durastream.lib.unc.edu/player?" +
+        Bag workResc1Bag = model.getBag(workResc1);
+        List<RDFNode> workResc1Children = workResc1Bag.iterator().toList();
+        assertEquals(1, workResc1Children.size());
+        Resource workResc1FileObj = workResc1Children.get(0).asResource();
+        assertFalse(workResc1FileObj.hasProperty(streamingUrl, "https://durastream.lib.unc.edu/player?" +
                 "spaceId=open-hls&filename=gilmer_recording-playlist.m3u8"));
         Resource workResc2 = testHelper.getResourceByCreateTime(depBagChildren, "2005-11-24");
         testHelper.assertObjectPopulatedInSip(workResc2, dirManager, model, stagingLocs.get(1), null, "26");
-        assertFalse(workResc2.hasProperty(streamingUrl, "https://durastream.lib.unc.edu/player?" +
+        Bag workResc2Bag = model.getBag(workResc2);
+        List<RDFNode> workResc2Children = workResc2Bag.iterator().toList();
+        assertEquals(1, workResc2Children.size());
+        Resource workResc2FileObj = workResc2Children.get(0).asResource();
+        assertFalse(workResc2FileObj.hasProperty(streamingUrl, "https://durastream.lib.unc.edu/player?" +
                 "spaceId=open-hls&filename=gilmer_recording-playlist.m3u8"));
         Resource workResc3 = testHelper.getResourceByCreateTime(depBagChildren, "2005-12-08");
         testHelper.assertObjectPopulatedInSip(workResc3, dirManager, model, stagingLocs.get(2), null, "27");
-        // assert file in workResc3 has streamingUrl
         Bag workResc3Bag = model.getBag(workResc3);
-        List<RDFNode> workChildren = workResc3Bag.iterator().toList();
-        assertEquals(1, workChildren.size());
-        Resource fileObjResc = workChildren.get(0).asResource();
-        assertTrue(fileObjResc.hasProperty(streamingUrl, "https://durastream.lib.unc.edu/player?" +
+        List<RDFNode> workResc3Children = workResc3Bag.iterator().toList();
+        assertEquals(1, workResc3Children.size());
+        Resource workResc3FileObj = workResc3Children.get(0).asResource();
+        assertTrue(workResc3FileObj.hasProperty(streamingUrl, "https://durastream.lib.unc.edu/player?" +
                 "spaceId=open-hls&filename=gilmer_recording-playlist.m3u8"));
 
         assertPersistedSipInfoMatches(sip);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -60,6 +60,7 @@ import java.util.stream.Collectors;
 
 import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.AUTHENTICATED_PRINC;
 import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.PUBLIC_PRINC;
+import static edu.unc.lib.boxc.migration.cdm.services.sips.WorkGenerator.streamingUrl;
 import static edu.unc.lib.boxc.migration.cdm.test.PostMigrationReportTestHelper.assertContainsRow;
 import static java.nio.file.StandardOpenOption.APPEND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1397,15 +1398,15 @@ public class SipServiceTest {
 
         Resource workResc1 = testHelper.getResourceByCreateTime(depBagChildren, "2005-11-23");
         testHelper.assertObjectPopulatedInSip(workResc1, dirManager, model, stagingLocs.get(0), null, "25");
-        assertFalse(workResc1.hasProperty(Cdr.streamingUrl, "https://durastream.lib.unc.edu/player?" +
+        assertFalse(workResc1.hasProperty(streamingUrl, "https://durastream.lib.unc.edu/player?" +
                 "spaceId=open-hls&filename=gilmer_recording-playlist.m3u8"));
         Resource workResc2 = testHelper.getResourceByCreateTime(depBagChildren, "2005-11-24");
         testHelper.assertObjectPopulatedInSip(workResc2, dirManager, model, stagingLocs.get(1), null, "26");
-        assertFalse(workResc2.hasProperty(Cdr.streamingUrl, "https://durastream.lib.unc.edu/player?" +
+        assertFalse(workResc2.hasProperty(streamingUrl, "https://durastream.lib.unc.edu/player?" +
                 "spaceId=open-hls&filename=gilmer_recording-playlist.m3u8"));
         Resource workResc3 = testHelper.getResourceByCreateTime(depBagChildren, "2005-12-08");
         testHelper.assertObjectPopulatedInSip(workResc3, dirManager, model, stagingLocs.get(2), null, "27");
-        assertTrue(workResc3.hasProperty(Cdr.streamingUrl, "https://durastream.lib.unc.edu/player?" +
+        assertTrue(workResc3.hasProperty(streamingUrl, "https://durastream.lib.unc.edu/player?" +
                 "spaceId=open-hls&filename=gilmer_recording-playlist.m3u8"));
 
         assertPersistedSipInfoMatches(sip);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
@@ -28,6 +28,7 @@ import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
 import edu.unc.lib.boxc.migration.cdm.services.ChompbConfigService;
 import edu.unc.lib.boxc.migration.cdm.services.GroupMappingService;
 import edu.unc.lib.boxc.migration.cdm.services.PermissionsService;
+import edu.unc.lib.boxc.migration.cdm.services.StreamingMetadataService;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
@@ -91,6 +92,7 @@ public class SipServiceHelper {
     private CdmIndexService indexService;
     private GroupMappingService groupMappingService;
     private PermissionsService permissionsService;
+    private StreamingMetadataService streamingMetadataService;
     private PIDMinter pidMinter;
     private PremisLoggerFactoryImpl premisLoggerFactory;
     private ChompbConfigService.ChompbConfig chompbConfig;
@@ -125,6 +127,10 @@ public class SipServiceHelper {
         archivalDestinationsService.setDestinationsService(destinationsService);
         permissionsService = new PermissionsService();
         permissionsService.setProject(project);
+        streamingMetadataService = new StreamingMetadataService();
+        streamingMetadataService.setProject(project);
+        streamingMetadataService.setFieldService(fieldService);
+        streamingMetadataService.setIndexService(indexService);
 
         Files.createDirectories(project.getExportPath());
     }
@@ -142,6 +148,7 @@ public class SipServiceHelper {
         service.setAggregateTopMappingService(getAggregateFileMappingService());
         service.setAggregateBottomMappingService(getAggregateBottomMappingService());
         service.setPermissionsService(permissionsService);
+        service.setStreamingMetadataService(streamingMetadataService);
         return service;
     }
 


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4511](https://unclibrary.atlassian.net/browse/BXC-4511)

- `WorkGenerator`: `addStreamingMetadata` method to add `streamingUrl` property to file objects
- add test