### PR TITLE
BXC-4512 permit streaming metadata for source file validation

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/AggregateFilesCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/AggregateFilesCommand.java
@@ -5,10 +5,8 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.options.AggregateFileMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
 import edu.unc.lib.boxc.migration.cdm.services.AggregateFileMappingService;
-import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
 import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
-import edu.unc.lib.boxc.migration.cdm.services.StreamingMetadataService;
 import edu.unc.lib.boxc.migration.cdm.status.SourceFilesSummaryService;
 import edu.unc.lib.boxc.migration.cdm.validators.AggregateFilesValidator;
 import org.apache.commons.lang3.StringUtils;
@@ -37,9 +35,7 @@ public class AggregateFilesCommand {
 
     private MigrationProject project;
     private AggregateFileMappingService aggregateService;
-    private CdmFieldService fieldService;
     private CdmIndexService indexService;
-    private StreamingMetadataService streamingMetadataService;
     private SourceFilesSummaryService summaryService;
 
     @CommandLine.Command(name = "generate",
@@ -95,7 +91,6 @@ public class AggregateFilesCommand {
             initialize(sortBottom, false);
             var validator = new AggregateFilesValidator(sortBottom);
             validator.setProject(project);
-            validator.setStreamingMetadataService(streamingMetadataService);
             List<String> errors = validator.validateMappings(force);
 
             var mappingPath = sortBottom ? project.getAggregateBottomMappingPath()
@@ -136,7 +131,6 @@ public class AggregateFilesCommand {
     private void initialize(boolean sortBottom, boolean dryRun) throws IOException {
         Path currentPath = parentCommand.getWorkingDirectory();
         project = MigrationProjectFactory.loadMigrationProject(currentPath);
-        fieldService = new CdmFieldService();
         indexService = new CdmIndexService();
         indexService.setProject(project);
         aggregateService = new AggregateFileMappingService(sortBottom);
@@ -146,9 +140,5 @@ public class AggregateFilesCommand {
         summaryService.setProject(project);
         summaryService.setDryRun(dryRun);
         summaryService.setSourceFileService(aggregateService);
-        streamingMetadataService = new StreamingMetadataService();
-        streamingMetadataService.setProject(project);
-        streamingMetadataService.setFieldService(fieldService);
-        streamingMetadataService.setIndexService(indexService);
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/AggregateFilesCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/AggregateFilesCommand.java
@@ -5,8 +5,10 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.options.AggregateFileMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
 import edu.unc.lib.boxc.migration.cdm.services.AggregateFileMappingService;
+import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
 import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.services.StreamingMetadataService;
 import edu.unc.lib.boxc.migration.cdm.status.SourceFilesSummaryService;
 import edu.unc.lib.boxc.migration.cdm.validators.AggregateFilesValidator;
 import org.apache.commons.lang3.StringUtils;
@@ -35,7 +37,9 @@ public class AggregateFilesCommand {
 
     private MigrationProject project;
     private AggregateFileMappingService aggregateService;
+    private CdmFieldService fieldService;
     private CdmIndexService indexService;
+    private StreamingMetadataService streamingMetadataService;
     private SourceFilesSummaryService summaryService;
 
     @CommandLine.Command(name = "generate",
@@ -91,6 +95,7 @@ public class AggregateFilesCommand {
             initialize(sortBottom, false);
             var validator = new AggregateFilesValidator(sortBottom);
             validator.setProject(project);
+            validator.setStreamingMetadataService(streamingMetadataService);
             List<String> errors = validator.validateMappings(force);
 
             var mappingPath = sortBottom ? project.getAggregateBottomMappingPath()
@@ -131,6 +136,7 @@ public class AggregateFilesCommand {
     private void initialize(boolean sortBottom, boolean dryRun) throws IOException {
         Path currentPath = parentCommand.getWorkingDirectory();
         project = MigrationProjectFactory.loadMigrationProject(currentPath);
+        fieldService = new CdmFieldService();
         indexService = new CdmIndexService();
         indexService.setProject(project);
         aggregateService = new AggregateFileMappingService(sortBottom);
@@ -140,5 +146,9 @@ public class AggregateFilesCommand {
         summaryService.setProject(project);
         summaryService.setDryRun(dryRun);
         summaryService.setSourceFileService(aggregateService);
+        streamingMetadataService = new StreamingMetadataService();
+        streamingMetadataService.setProject(project);
+        streamingMetadataService.setFieldService(fieldService);
+        streamingMetadataService.setIndexService(indexService);
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/StatusCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/StatusCommand.java
@@ -9,7 +9,10 @@ import java.util.concurrent.Callable;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
+import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.services.StreamingMetadataService;
 import edu.unc.lib.boxc.migration.cdm.status.ProjectStatusService;
 import org.slf4j.Logger;
 import picocli.CommandLine.Command;
@@ -26,6 +29,9 @@ public class StatusCommand implements Callable<Integer>  {
     private CLIMain parentCommand;
 
     private ProjectStatusService statusService;
+    private CdmFieldService fieldService;
+    private CdmIndexService indexService;
+    private StreamingMetadataService streamingMetadataService;
     private MigrationProject project;
 
     @Override
@@ -47,7 +53,15 @@ public class StatusCommand implements Callable<Integer>  {
         Path currentPath = parentCommand.getWorkingDirectory();
         project = MigrationProjectFactory.loadMigrationProject(currentPath);
 
+        fieldService = new CdmFieldService();
+        indexService = new CdmIndexService();
+        indexService.setProject(project);
+        streamingMetadataService = new StreamingMetadataService();
+        streamingMetadataService.setProject(project);
+        streamingMetadataService.setFieldService(fieldService);
+        streamingMetadataService.setIndexService(indexService);
         statusService = new ProjectStatusService();
         statusService.setProject(project);
+        statusService.setStreamingMetadataService(streamingMetadataService);
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
@@ -221,7 +221,8 @@ public class SipService {
         if (props.getDescriptionsExpandedDate() == null) {
             throw new InvalidProjectStateException("Descriptions must be created and expanded");
         }
-        if (props.getSourceFilesUpdatedDate() == null) {
+        if (props.getSourceFilesUpdatedDate() == null || (props.getSourceFilesUpdatedDate() == null
+                && !streamingMetadataService.hasProjectStreamingMetadataField())) {
             throw new InvalidProjectStateException("Source files must be mapped");
         }
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
@@ -221,10 +221,6 @@ public class SipService {
         if (props.getDescriptionsExpandedDate() == null) {
             throw new InvalidProjectStateException("Descriptions must be created and expanded");
         }
-        if (props.getSourceFilesUpdatedDate() == null || (props.getSourceFilesUpdatedDate() == null
-                && !streamingMetadataService.hasProjectStreamingMetadataField())) {
-            throw new InvalidProjectStateException("Source files must be mapped");
-        }
     }
 
     private void initializeDestinations(SipGenerationOptions options) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/StreamingMetadataService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/StreamingMetadataService.java
@@ -49,7 +49,7 @@ public class StreamingMetadataService {
         return streamingFields[0] != null && streamingFields[1] != null;
     }
 
-    private boolean hasProjectStreamingMetadataField() {
+    public boolean hasProjectStreamingMetadataField() {
         if (projectHasStreamingMetadata == null) {
             // check if project has streamingFile field and duracloudSpace field
             fieldService.validateFieldsFile(project);

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/ProjectStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/ProjectStatusService.java
@@ -14,6 +14,7 @@ import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
 import edu.unc.lib.boxc.migration.cdm.services.DescriptionsService;
 import edu.unc.lib.boxc.migration.cdm.services.SipService;
+import edu.unc.lib.boxc.migration.cdm.services.StreamingMetadataService;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -23,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class ProjectStatusService extends AbstractStatusService {
     private CdmFieldService fieldService;
+    private StreamingMetadataService streamingMetadataService;
 
     public void report() {
         outputLogger.info("Status for project {}", project.getProjectName());
@@ -116,6 +118,7 @@ public class ProjectStatusService extends AbstractStatusService {
         SourceFilesStatusService statusService = new SourceFilesStatusService();
         statusService.setProject(project);
         statusService.setQueryService(getQueryService());
+        statusService.setStreamingMetadataService(streamingMetadataService);
         statusService.reportStats(totalObjects, Verbosity.QUIET);
     }
 
@@ -123,6 +126,7 @@ public class ProjectStatusService extends AbstractStatusService {
         AccessFilesStatusService statusService = new AccessFilesStatusService();
         statusService.setProject(project);
         statusService.setQueryService(getQueryService());
+        statusService.setStreamingMetadataService(streamingMetadataService);
         statusService.reportStats(totalObjects, Verbosity.QUIET);
     }
 
@@ -141,5 +145,9 @@ public class ProjectStatusService extends AbstractStatusService {
         descStatus.setDescriptionsService(descService);
         descStatus.setQueryService(getQueryService());
         descStatus.reportStats(totalObjects, Verbosity.QUIET);
+    }
+
+    public void setStreamingMetadataService(StreamingMetadataService streamingMetadataService) {
+        this.streamingMetadataService = streamingMetadataService;
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusService.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang3.StringUtils;
 import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo;
 import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo.SourceFileMapping;
 import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
+import edu.unc.lib.boxc.migration.cdm.services.StreamingMetadataService;
 import edu.unc.lib.boxc.migration.cdm.services.SourceFileService;
 import edu.unc.lib.boxc.migration.cdm.validators.SourceFilesValidator;
 import org.slf4j.Logger;
@@ -25,6 +26,9 @@ import org.slf4j.Logger;
  */
 public class SourceFilesStatusService extends AbstractStatusService {
     private static final Logger log = getLogger(SourceFilesStatusService.class);
+
+    private StreamingMetadataService streamingMetadataService;
+
     /**
      * Display a stand alone report of the source file mapping status
      * @param verbosity
@@ -48,6 +52,7 @@ public class SourceFilesStatusService extends AbstractStatusService {
         }
         SourceFilesValidator validator = getValidator();
         validator.setProject(project);
+        validator.setStreamingMetadataService(streamingMetadataService);
         List<String> errors = validator.validateMappings(forceValidation());
         int numErrors = errors.size();
         if (numErrors == 0) {
@@ -114,6 +119,10 @@ public class SourceFilesStatusService extends AbstractStatusService {
 
     protected SourceFileService getMappingService() {
         return new SourceFileService();
+    }
+
+    public void setStreamingMetadataService(StreamingMetadataService streamingMetadataService) {
+        this.streamingMetadataService = streamingMetadataService;
     }
 
     protected boolean forceValidation() {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AggregateFilesCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AggregateFilesCommandIT.java
@@ -153,7 +153,7 @@ public class AggregateFilesCommandIT extends AbstractCommandIT {
 
         // This should produce a duplicate
         Files.writeString(project.getAggregateTopMappingPath(),
-                "\nsomeid,somefield," + aggrPath2 + "|" + aggrPath1 + ",",
+                "\n2,somefield," + aggrPath2 + "|" + aggrPath1 + ",",
                 StandardOpenOption.APPEND);
 
         String[] args = new String[] {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
@@ -496,8 +496,7 @@ public class SourceFilesCommandIT extends AbstractCommandIT {
         assertOutputContains("FAIL: Source file mapping at path " + project.getSourceFilesMappingPath()
                 + " is invalid");
         assertOutputContains("- No path mapped at line 3");
-        assertOutputContains("- No path mapped at line 4");
-        assertEquals(3, output.split("    - ").length, "Must only be two errors: " + output);
+        assertEquals(2, output.split("    - ").length, "Must only be two errors: " + output);
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/SourceFilesCommandIT.java
@@ -499,6 +499,27 @@ public class SourceFilesCommandIT extends AbstractCommandIT {
         assertEquals(2, output.split("    - ").length, "Must only be two errors: " + output);
     }
 
+
+    @Test
+    public void validateStreamingMetadataTest() throws Exception {
+        indexExportSamples();
+        addSourceFile("276_182_E.tif");
+        addSourceFile("276_183_E.tif");
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "source_files", "generate",
+                "-b", basePath.toString()};
+        executeExpectSuccess(args);
+
+        String[] args2 = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "source_files", "validate" };
+        executeExpectSuccess(args2);
+
+        assertOutputContains("PASS: Source file mapping at path " + project.getSourceFilesMappingPath() + " is valid");
+    }
+
     @Test
     public void statusValidTest() throws Exception {
         indexExportSamples();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -166,7 +166,7 @@ public class SipServiceTest {
             service.generateSips(makeOptions());
             fail();
         } catch (InvalidProjectStateException e) {
-            assertTrue(e.getMessage().contains("Source files must be mapped"),
+            assertTrue(e.getMessage().contains("Cannot transform object 25, no source file has been mapped"),
                     "Unexpected message: " + e.getMessage());
         }
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusServiceTest.java
@@ -41,6 +41,7 @@ public class SourceFilesStatusServiceTest extends AbstractOutputTest {
         testHelper = new SipServiceHelper(project, tmpFolder);
         statusService = new SourceFilesStatusService();
         statusService.setProject(project);
+        statusService.setStreamingMetadataService(testHelper.getStreamingMetadataService());
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
@@ -546,6 +546,10 @@ public class SipServiceHelper {
         return indexService;
     }
 
+    public StreamingMetadataService getStreamingMetadataService() {
+        return streamingMetadataService;
+    }
+
     public PIDMinter getPidMinter() {
         return pidMinter;
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/SourceFilesValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/SourceFilesValidatorTest.java
@@ -221,6 +221,18 @@ public class SourceFilesValidatorTest {
         assertNumberErrors(errors, 0);
     }
 
+    @Test
+    public void streamingMetadataAndInvalidSourcePathTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        Path path = testHelper.addSourceFile("25.txt");
+        Path path2 = testHelper.addSourceFile("27.txt");
+        Files.delete(path2);
+        writeCsv(mappingBody("25,," + path + ",", "27,," + path2 + ","));
+        List<String> errors = validator.validateMappings(false);
+        assertHasError(errors, "Invalid path at line 3, file does not exist");
+        assertNumberErrors(errors, 1);
+    }
+
     private void assertHasError(List<String> errors, String expected) {
         assertTrue(errors.contains(expected),
                 "Expected error:\n" + expected + "\nBut the returned errors were:\n" + String.join("\n", errors));

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/SourceFilesValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/SourceFilesValidatorTest.java
@@ -40,9 +40,10 @@ public class SourceFilesValidatorTest {
         project = MigrationProjectFactory.createMigrationProject(
                 tmpFolder, PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
 
+        testHelper = new SipServiceHelper(project, tmpFolder);
         validator = new SourceFilesValidator();
         validator.setProject(project);
-        testHelper = new SipServiceHelper(project, tmpFolder);
+        validator.setStreamingMetadataService(testHelper.getStreamingMetadataService());
     }
 
     @Test
@@ -62,6 +63,7 @@ public class SourceFilesValidatorTest {
 
     @Test
     public void blankIdTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
         Path path = testHelper.addSourceFile("25.txt");
         writeCsv(mappingBody(",," + path + ","));
         List<String> errors = validator.validateMappings(false);
@@ -71,6 +73,7 @@ public class SourceFilesValidatorTest {
 
     @Test
     public void blankPathTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
         writeCsv(mappingBody("25,,,"));
         List<String> errors = validator.validateMappings(false);
         assertHasError(errors, "No path mapped at line 2");
@@ -79,6 +82,7 @@ public class SourceFilesValidatorTest {
 
     @Test
     public void invalidRelativePathTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
         writeCsv(mappingBody("25,,path/is/relative.txt,"));
         List<String> errors = validator.validateMappings(false);
         assertHasError(errors, "Invalid path at line 2, path is not absolute");
@@ -87,6 +91,7 @@ public class SourceFilesValidatorTest {
 
     @Test
     public void pathDoesNotExistTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
         Path path = testHelper.addSourceFile("25.txt");
         Files.delete(path);
         writeCsv(mappingBody("25,," + path + ","));
@@ -97,6 +102,7 @@ public class SourceFilesValidatorTest {
 
     @Test
     public void pathIsDirectoryTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
         Path path = testHelper.addSourceFile("25.txt");
         Files.delete(path);
         Files.createDirectory(path);
@@ -128,6 +134,7 @@ public class SourceFilesValidatorTest {
 
     @Test
     public void duplicateIdTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
         Path path1 = testHelper.addSourceFile("25.txt");
         Path path2 = testHelper.addSourceFile("26.txt");
         writeCsv(mappingBody("25,," + path1 + ",",
@@ -139,6 +146,7 @@ public class SourceFilesValidatorTest {
 
     @Test
     public void duplicatePathTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
         Path path1 = testHelper.addSourceFile("25.txt");
         writeCsv(mappingBody("25,," + path1 + ",",
                 "26,," + path1 + ","));
@@ -149,6 +157,7 @@ public class SourceFilesValidatorTest {
 
     @Test
     public void validMappingsTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
         Path path1 = testHelper.addSourceFile("25.txt");
         Path path2 = testHelper.addSourceFile("26.txt");
         writeCsv(mappingBody("25,," + path1 + ",",
@@ -159,6 +168,7 @@ public class SourceFilesValidatorTest {
 
     @Test
     public void errorsOnMultipleLinesTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
         Path path1 = testHelper.addSourceFile("25.txt");
         Path path2 = testHelper.addSourceFile("26.txt");
         writeCsv(mappingBody(",," + path1 + ",",
@@ -171,6 +181,7 @@ public class SourceFilesValidatorTest {
 
     @Test
     public void errorsOnSameLineTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
         Path path1 = testHelper.addSourceFile("25.txt");
         writeCsv(mappingBody("25,," + path1 + ",",
                              "25,," + path1 + ","));
@@ -182,6 +193,7 @@ public class SourceFilesValidatorTest {
 
     @Test
     public void ignorableErrorsWithoutForceTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
         Path path2 = testHelper.addSourceFile("26.txt");
         writeCsv(mappingBody("25,,,",
                              "26,," + path2 + ","));
@@ -192,10 +204,20 @@ public class SourceFilesValidatorTest {
 
     @Test
     public void ignorableErrorsWithForceTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
         Path path2 = testHelper.addSourceFile("26.txt");
         writeCsv(mappingBody("25,,,",
                              "26,," + path2 + ","));
         List<String> errors = validator.validateMappings(true);
+        assertNumberErrors(errors, 0);
+    }
+
+    @Test
+    public void streamingMetadataTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        Path path2 = testHelper.addSourceFile("26.txt");
+        writeCsv(mappingBody("26,," + path2 + ",", "27,,,"));
+        List<String> errors = validator.validateMappings(false);
         assertNumberErrors(errors, 0);
     }
 


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4512](https://unclibrary.atlassian.net/browse/BXC-4512)

- `SipService` and `SourceFilesValidator`; update validation process in sip generation to consider a file to have a source file mapped to it if streaming metadata fields are present
- `StreamingMetadataService`: switch private method `hasProjectStreamingMetadataField` to public
- add setters/initialize `StreamingMetadataService` in `AggregateFilesCommand`, `SourceFilesCommand`, `StatusCommand`, `ProjectStatusService`, `SourceFilesStatusService`
- fix tests