### PR TITLE
BXC-4603 group by multiple fields

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommand.java
@@ -120,7 +120,7 @@ public class GroupMappingCommand {
     }
 
     private void validateOptions(GroupMappingOptions options) {
-        if (StringUtils.isBlank(options.getGroupField())) {
+        if (options.getGroupField().size() == 0) {
             throw new IllegalArgumentException("Must provide an group field name");
         }
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommand.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import edu.unc.lib.boxc.migration.cdm.options.GroupMappingSyncOptions;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
@@ -120,7 +119,7 @@ public class GroupMappingCommand {
     }
 
     private void validateOptions(GroupMappingOptions options) {
-        if (options.getGroupField().size() == 0) {
+        if (options.getGroupFields().isEmpty()) {
             throw new IllegalArgumentException("Must provide an group field name");
         }
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/GroupMappingInfo.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/GroupMappingInfo.java
@@ -12,10 +12,11 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class GroupMappingInfo {
     public static final String GROUPED_WORK_PREFIX = "grp:";
-    public static final String GROUP_KEY = "group";
+    public static final String GROUP_KEY1 = "group1";
+    public static final String GROUP_KEY2 = "group2";
     public static final String ID_FIELD = "id";
     public static final String[] CSV_HEADERS = new String[] {
-            ID_FIELD, GROUP_KEY };
+            ID_FIELD, GROUP_KEY1, GROUP_KEY2 };
 
     private Map<String, List<String>> groupedMappings = new HashMap<>();
     private List<GroupMapping> mappings = new ArrayList<>();
@@ -52,7 +53,8 @@ public class GroupMappingInfo {
 
     public static class GroupMapping {
         private String cdmId;
-        private String groupKey;
+        private String groupKey1;
+        private String groupKey2;
 
         public String getCdmId() {
             return cdmId;
@@ -62,15 +64,27 @@ public class GroupMappingInfo {
             this.cdmId = cdmId;
         }
 
-        public String getGroupKey() {
-            return groupKey;
+        public String getGroupKey1() {
+            return groupKey1;
         }
 
-        public void setGroupKey(String groupKey) {
-            if (StringUtils.isBlank(groupKey)) {
-                this.groupKey = null;
+        public void setGroupKey1(String groupKey1) {
+            if (StringUtils.isBlank(groupKey1)) {
+                this.groupKey1 = null;
             } else {
-                this.groupKey = groupKey;
+                this.groupKey1 = groupKey1;
+            }
+        }
+
+        public String getGroupKey2() {
+            return groupKey2;
+        }
+
+        public void setGroupKey2(String groupKey2) {
+            if (StringUtils.isBlank(groupKey2)) {
+                this.groupKey2 = null;
+            } else {
+                this.groupKey2 = groupKey2;
             }
         }
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/GroupMappingInfo.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/GroupMappingInfo.java
@@ -12,11 +12,10 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class GroupMappingInfo {
     public static final String GROUPED_WORK_PREFIX = "grp:";
-    public static final String GROUP_KEY1 = "group1";
-    public static final String GROUP_KEY2 = "group2";
+    public static final String GROUP_KEY = "group";
     public static final String ID_FIELD = "id";
     public static final String[] CSV_HEADERS = new String[] {
-            ID_FIELD, GROUP_KEY1, GROUP_KEY2 };
+            ID_FIELD, GROUP_KEY };
 
     private Map<String, List<String>> groupedMappings = new HashMap<>();
     private List<GroupMapping> mappings = new ArrayList<>();
@@ -53,8 +52,7 @@ public class GroupMappingInfo {
 
     public static class GroupMapping {
         private String cdmId;
-        private String groupKey1;
-        private String groupKey2;
+        private String groupKey;
 
         public String getCdmId() {
             return cdmId;
@@ -64,27 +62,15 @@ public class GroupMappingInfo {
             this.cdmId = cdmId;
         }
 
-        public String getGroupKey1() {
-            return groupKey1;
+        public String getGroupKey() {
+            return groupKey;
         }
 
-        public void setGroupKey1(String groupKey1) {
-            if (StringUtils.isBlank(groupKey1)) {
-                this.groupKey1 = null;
+        public void setGroupKey(String groupKey) {
+            if (StringUtils.isBlank(groupKey)) {
+                this.groupKey = null;
             } else {
-                this.groupKey1 = groupKey1;
-            }
-        }
-
-        public String getGroupKey2() {
-            return groupKey2;
-        }
-
-        public void setGroupKey2(String groupKey2) {
-            if (StringUtils.isBlank(groupKey2)) {
-                this.groupKey2 = null;
-            } else {
-                this.groupKey2 = groupKey2;
+                this.groupKey = groupKey;
             }
         }
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/GroupMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/GroupMappingOptions.java
@@ -12,6 +12,7 @@ import java.util.List;
 public class GroupMappingOptions {
 
     @Option(names = {"-n", "--field-name"},
+            split = ",",
             description = {
                     "Name(s) of the CDM export field to perform grouping on."},
             defaultValue = "file")

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/GroupMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/GroupMappingOptions.java
@@ -2,6 +2,8 @@ package edu.unc.lib.boxc.migration.cdm.options;
 
 import picocli.CommandLine.Option;
 
+import java.util.List;
+
 /**
  * Options for generating object grouping mappings
  *
@@ -11,9 +13,9 @@ public class GroupMappingOptions {
 
     @Option(names = {"-n", "--field-name"},
             description = {
-                    "Name of the CDM export field to perform grouping on."},
+                    "Name(s) of the CDM export field to perform grouping on."},
             defaultValue = "file")
-    private String groupField;
+    private List<String> groupField;
 
     @Option(names = {"-u", "--update"},
             description = {
@@ -31,11 +33,11 @@ public class GroupMappingOptions {
             description = "Overwrite mapping file if one already exists")
     private boolean force;
 
-    public String getGroupField() {
+    public List<String> getGroupField() {
         return groupField;
     }
 
-    public void setGroupField(String groupField) {
+    public void setGroupField(List<String> groupField) {
         this.groupField = groupField;
     }
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/GroupMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/GroupMappingOptions.java
@@ -15,7 +15,7 @@ public class GroupMappingOptions {
             description = {
                     "Name(s) of the CDM export field to perform grouping on."},
             defaultValue = "file")
-    private List<String> groupField;
+    private List<String> groupFields;
 
     @Option(names = {"-u", "--update"},
             description = {
@@ -33,12 +33,12 @@ public class GroupMappingOptions {
             description = "Overwrite mapping file if one already exists")
     private boolean force;
 
-    public List<String> getGroupField() {
-        return groupField;
+    public List<String> getGroupFields() {
+        return groupFields;
     }
 
-    public void setGroupField(List<String> groupField) {
-        this.groupField = groupField;
+    public void setGroupFields(List<String> groupFields) {
+        this.groupFields = groupFields;
     }
 
     public boolean getUpdate() {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingService.java
@@ -187,7 +187,7 @@ public class GroupMappingService {
 
     private String buildKey(List<String> values) {
         String joinedValues = null;
-        if (!values.isEmpty()) {
+        if (!values.stream().allMatch(String::isEmpty)) {
             joinedValues = String.join(",", values);
         }
         return joinedValues;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingService.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 import edu.unc.lib.boxc.migration.cdm.options.GroupMappingSyncOptions;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingService.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 import edu.unc.lib.boxc.migration.cdm.options.GroupMappingSyncOptions;
@@ -58,7 +59,7 @@ public class GroupMappingService {
     private CdmFieldService fieldService;
     private List<String> exportFields;
 
-    public void generateMapping(GroupMappingOptions options) throws IOException {
+    public void generateMapping(GroupMappingOptions options) throws Exception {
         assertProjectStateValid();
         ensureMappingState(options);
 
@@ -89,79 +90,9 @@ public class GroupMappingService {
             // Return set of all group keys that have at least 2 records in them
             var multiMemberGroupSet = new HashSet<String>();
             if (options.getGroupField().size() == 1) {
-                ResultSet groupRs = stmt.executeQuery("select " + options.getGroupField().get(0)
-                        + " from " + CdmIndexService.TB_NAME
-                        + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " is null"
-                        + " group by " + options.getGroupField().get(0)
-                        + " having count(*) > 1");
-                while (groupRs.next()) {
-                    var groupValue = groupRs.getString(1);
-                    if (StringUtils.isBlank(groupValue)) {
-                        continue;
-                    }
-                    multiMemberGroupSet.add(groupValue);
-                }
-
-                ResultSet rs = stmt.executeQuery("select " + CdmFieldInfo.CDM_ID + ", " + options.getGroupField().get(0)
-                        + " from " + CdmIndexService.TB_NAME
-                        + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " is null"
-                        + " order by " + CdmFieldInfo.CDM_ID + " ASC");
-                while (rs.next()) {
-                    String cdmId = rs.getString(1);
-                    String matchedValue = rs.getString(2);
-
-                    // Add empty mapping for records either not in groups or in groups with fewer than 2 members
-                    if (StringUtils.isBlank(matchedValue) || !multiMemberGroupSet.contains(matchedValue)) {
-                        log.debug("No matching field for object {}", cdmId);
-                        csvPrinter.printRecord(cdmId, null);
-                        continue;
-                    }
-
-                    String groupKey1 = GroupMappingInfo.GROUPED_WORK_PREFIX + options.getGroupField().get(0) + ":" + matchedValue;
-                    //String groupKey2 = GroupMappingInfo.GROUPED_WORK_PREFIX + null + ":" + null;
-                    csvPrinter.printRecord(cdmId, groupKey1);
-                }
-            } else if (options.getGroupField().size() == 2) {
-                ResultSet groupRs = stmt.executeQuery("select " + options.getGroupField().get(0)
-                        + ", " + options.getGroupField().get(1)
-                        + " from " + CdmIndexService.TB_NAME
-                        + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " is null"
-                        + " group by " + options.getGroupField().get(0) + ", " + options.getGroupField().get(1)
-                        + " having count(*) > 1");
-                while (groupRs.next()) {
-                    var groupValue1 = groupRs.getString(1);
-                    var groupValue2 = groupRs.getString(2);
-                    if (StringUtils.isBlank(groupValue1) || StringUtils.isBlank(groupValue2)) {
-                        continue;
-                    }
-                    multiMemberGroupSet.add(groupValue1);
-                    multiMemberGroupSet.add(groupValue2);
-                }
-
-                ResultSet rs = stmt.executeQuery("select " + CdmFieldInfo.CDM_ID + ", "
-                        + options.getGroupField().get(0) + ", " + options.getGroupField().get(1)
-                        + " from " + CdmIndexService.TB_NAME
-                        + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " is null"
-                        + " order by " + CdmFieldInfo.CDM_ID + " ASC");
-                while (rs.next()) {
-                    String cdmId = rs.getString(1);
-                    String matchedValue1 = rs.getString(2);
-                    String matchedValue2 = rs.getString(3);
-
-                    // Add empty mapping for records either not in groups or in groups with fewer than 2 members
-                    if (StringUtils.isBlank(matchedValue1) || StringUtils.isBlank(matchedValue2) ||
-                            !multiMemberGroupSet.contains(matchedValue1) || !multiMemberGroupSet.contains(matchedValue2)) {
-                        log.debug("No matching field for object {}", cdmId);
-                        csvPrinter.printRecord(cdmId, null);
-                        continue;
-                    }
-
-                    String groupKey1 = GroupMappingInfo.GROUPED_WORK_PREFIX + options.getGroupField().get(0) + ":"
-                            + matchedValue1;
-                    String groupKey2 = GroupMappingInfo.GROUPED_WORK_PREFIX + options.getGroupField().get(1) + ":"
-                            + matchedValue2;
-                    csvPrinter.printRecord(cdmId, groupKey1, groupKey2);
-                }
+                generateOneGroupMapping(options, stmt, multiMemberGroupSet, csvPrinter);
+            } else if (options.getGroupField().size() >= 2) {
+               generateMultipleGroupMapping(options, stmt, multiMemberGroupSet, csvPrinter);
             }
         } catch (SQLException e) {
             throw new MigrationException("Error interacting with export index", e);
@@ -176,6 +107,91 @@ public class GroupMappingService {
 
         if (!options.getDryRun()) {
             setUpdatedDate(Instant.now());
+        }
+    }
+
+    private void generateOneGroupMapping(GroupMappingOptions options, Statement stmt,
+                                         HashSet<String> multiMemberGroupSet, CSVPrinter csvPrinter) throws Exception {
+        ResultSet groupRs = stmt.executeQuery("select " + options.getGroupField().get(0)
+                + " from " + CdmIndexService.TB_NAME
+                + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " is null"
+                + " group by " + options.getGroupField().get(0)
+                + " having count(*) > 1");
+        while (groupRs.next()) {
+            var groupValue = groupRs.getString(1);
+            if (StringUtils.isBlank(groupValue)) {
+                continue;
+            }
+            multiMemberGroupSet.add(groupValue);
+        }
+
+        ResultSet rs = stmt.executeQuery("select " + CdmFieldInfo.CDM_ID + ", " + options.getGroupField().get(0)
+                + " from " + CdmIndexService.TB_NAME
+                + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " is null"
+                + " order by " + CdmFieldInfo.CDM_ID + " ASC");
+        while (rs.next()) {
+            String cdmId = rs.getString(1);
+            String matchedValue = rs.getString(2);
+
+            // Add empty mapping for records either not in groups or in groups with fewer than 2 members
+            if (StringUtils.isBlank(matchedValue) || !multiMemberGroupSet.contains(matchedValue)) {
+                log.debug("No matching field for object {}", cdmId);
+                csvPrinter.printRecord(cdmId, null);
+                continue;
+            }
+
+            String groupKey = GroupMappingInfo.GROUPED_WORK_PREFIX + options.getGroupField().get(0) + ":" + matchedValue;
+            csvPrinter.printRecord(cdmId, groupKey);
+        }
+    }
+
+    private void generateMultipleGroupMapping(GroupMappingOptions options, Statement stmt,
+                                              HashSet<String> multiMemberGroupSet, CSVPrinter csvPrinter) throws Exception {
+        int numberGroups = options.getGroupField().size();
+        String multipleGroups = String.join(", ", options.getGroupField());
+
+        ResultSet groupRs = stmt.executeQuery("select " + multipleGroups
+                + " from " + CdmIndexService.TB_NAME
+                + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " is null"
+                + " group by " + multipleGroups
+                + " having count(*) > 1");
+        while (groupRs.next()) {
+            for (int i = 1; i < numberGroups + 1; i++) {
+                var groupValue = groupRs.getString(i);
+                if (StringUtils.isBlank(groupValue)) {
+                    continue;
+                }
+                multiMemberGroupSet.add(groupValue);
+            }
+        }
+
+        ResultSet rs = stmt.executeQuery("select " + CdmFieldInfo.CDM_ID + ", " + multipleGroups
+                + " from " + CdmIndexService.TB_NAME
+                + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " is null"
+                + " order by " + CdmFieldInfo.CDM_ID + " ASC");
+        while (rs.next()) {
+            String cdmId = rs.getString(1);
+            List<String> matchedValues = new ArrayList<>();
+            for (int i = 2; i < numberGroups + 2; i++) {
+                var matchedValue = rs.getString(i);
+                if (!StringUtils.isBlank(matchedValue)) {
+                    matchedValues.add(matchedValue);
+                }
+            }
+
+                // Add empty mapping for records either not in groups or in groups with fewer than 2 members
+                if (matchedValues.isEmpty() || !matchedValues.containsAll(multiMemberGroupSet)) {
+                    log.debug("No matching field for object {}", cdmId);
+                    csvPrinter.printRecord(cdmId, null);
+                    continue;
+                }
+
+            List<String> listGroups = new ArrayList<>();
+            for (int i = 0; i < numberGroups; i++) {
+                listGroups.add(options.getGroupField().get(i) + ":" + matchedValues.get(i));
+            }
+            String groupKey = GroupMappingInfo.GROUPED_WORK_PREFIX + String.join(",", listGroups);
+            csvPrinter.printRecord(cdmId, groupKey);
         }
     }
 
@@ -242,14 +258,11 @@ public class GroupMappingService {
             for (CSVRecord originalRecord : originalParser) {
                 GroupMapping origMapping = new GroupMapping();
                 origMapping.setCdmId(originalRecord.get(0));
-                origMapping.setGroupKey1(originalRecord.get(1));
-                if (originalRecord.size() == 3) {
-                    origMapping.setGroupKey2(originalRecord.get(2));
-                }
+                origMapping.setGroupKey(originalRecord.get(1));
 
                 GroupMapping updateMapping = updateInfo.getMappingByCdmId(origMapping.getCdmId());
-                if (updateMapping != null && updateMapping.getGroupKey1() != null) {
-                    if (options.getForce() || origMapping.getGroupKey1() == null) {
+                if (updateMapping != null && updateMapping.getGroupKey() != null) {
+                    if (options.getForce() || origMapping.getGroupKey() == null) {
                         // overwrite entry with updated mapping if using force or original didn't have a group
                         writeMapping(mergedPrinter, updateMapping);
                     } else {
@@ -280,7 +293,7 @@ public class GroupMappingService {
     }
 
     private void writeMapping(CSVPrinter csvPrinter, GroupMapping mapping) throws IOException {
-        csvPrinter.printRecord(mapping.getCdmId(), mapping.getGroupKey1(), mapping.getGroupKey2());
+        csvPrinter.printRecord(mapping.getCdmId(), mapping.getGroupKey());
     }
 
     protected void setUpdatedDate(Instant timestamp) throws IOException {
@@ -311,20 +324,15 @@ public class GroupMappingService {
             info.setGroupedMappings(grouped);
             for (CSVRecord csvRecord : csvParser) {
                 String id = csvRecord.get(0);
-                String groupKey1 = csvRecord.get(1);
-                String groupKey2 = null;
-                if (csvRecord.size() > 2) {
-                    groupKey2 = csvRecord.get(2);
-                }
+                String groupKey = csvRecord.get(1);
                 GroupMapping mapping = new GroupMapping();
                 mapping.setCdmId(id);
-                mapping.setGroupKey1(groupKey1);
-                mapping.setGroupKey2(groupKey2);
+                mapping.setGroupKey(groupKey);
                 mappings.add(mapping);
-                if (StringUtils.isBlank(groupKey1)) {
+                if (StringUtils.isBlank(groupKey)) {
                     continue;
                 }
-                List<String> ids = grouped.computeIfAbsent(groupKey1, v -> new ArrayList<>());
+                List<String> ids = grouped.computeIfAbsent(groupKey, v -> new ArrayList<>());
                 ids.add(id);
             }
             return info;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGenerator.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGenerator.java
@@ -4,7 +4,6 @@ import edu.unc.lib.boxc.auth.api.UserRole;
 import edu.unc.lib.boxc.deposit.impl.model.DepositModelHelpers;
 import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.model.DestinationSipEntry;
-import edu.unc.lib.boxc.migration.cdm.model.GroupMappingInfo;
 import edu.unc.lib.boxc.migration.cdm.model.PermissionsInfo;
 import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo;
 import edu.unc.lib.boxc.migration.cdm.options.SipGenerationOptions;

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommandIT.java
@@ -53,7 +53,7 @@ public class GroupMappingCommandIT extends AbstractCommandIT {
         String[] args = new String[] {
                 "-w", project.getProjectPath().toString(),
                 "group_mapping", "generate",
-                "-n", "groupa, dcmi"};
+                "-n", "groupa,dcmi"};
         executeExpectSuccess(args);
 
         assertTrue(Files.exists(project.getGroupMappingPath()));

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommandIT.java
@@ -87,6 +87,33 @@ public class GroupMappingCommandIT extends AbstractCommandIT {
     }
 
     @Test
+    public void generateAndSyncMultipleGroupsTest() throws Exception {
+        indexExportSamples();
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "group_mapping", "generate",
+                "-n", "groupa,dcmi" };
+        executeExpectSuccess(args);
+
+        assertTrue(Files.exists(project.getGroupMappingPath()));
+
+        String[] args2 = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "group_mapping", "sync" };
+        executeExpectSuccess(args2);
+
+        var indexService = new CdmIndexService();
+        indexService.setProject(project);
+        Connection conn = null;
+        try {
+            conn = indexService.openDbConnection();
+            assertFilesGrouped(conn, "25", "26");
+        } finally {
+            CdmIndexService.closeDbConnection(conn);
+        }
+    }
+
+    @Test
     public void statusNotGenerated() throws Exception {
         String[] args = new String[] {
                 "-w", project.getProjectPath().toString(),

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/GroupMappingCommandIT.java
@@ -48,6 +48,18 @@ public class GroupMappingCommandIT extends AbstractCommandIT {
     }
 
     @Test
+    public void generateMultipleMatchSucceedsTest() throws Exception {
+        indexExportSamples();
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "group_mapping", "generate",
+                "-n", "groupa, dcmi"};
+        executeExpectSuccess(args);
+
+        assertTrue(Files.exists(project.getGroupMappingPath()));
+    }
+
+    @Test
     public void generateAndSyncTest() throws Exception {
         indexExportSamples();
         String[] args = new String[] {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -404,7 +405,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
 
     private void setupGroupedIndex() throws Exception {
         var options = new GroupMappingOptions();
-        options.setGroupField("groupa");
+        options.setGroupField(Arrays.asList("groupa"));
         testHelper.getGroupMappingService().generateMapping(options);
         var syncOptions = new GroupMappingSyncOptions();
         syncOptions.setSortField("file");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
@@ -405,7 +405,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
 
     private void setupGroupedIndex() throws Exception {
         var options = new GroupMappingOptions();
-        options.setGroupField(Arrays.asList("groupa"));
+        options.setGroupFields(Arrays.asList("groupa"));
         testHelper.getGroupMappingService().generateMapping(options);
         var syncOptions = new GroupMappingSyncOptions();
         syncOptions.setSortField("file");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/AggregateFileMappingServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/AggregateFileMappingServiceTest.java
@@ -210,7 +210,7 @@ public class AggregateFileMappingServiceTest {
 
     private void setupGroupedIndex() throws Exception {
         var options = new GroupMappingOptions();
-        options.setGroupField(Arrays.asList("groupa"));
+        options.setGroupFields(Arrays.asList("groupa"));
         testHelper.getGroupMappingService().generateMapping(options);
         var syncOptions = new GroupMappingSyncOptions();
         syncOptions.setSortField("file");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/AggregateFileMappingServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/AggregateFileMappingServiceTest.java
@@ -210,7 +210,7 @@ public class AggregateFileMappingServiceTest {
 
     private void setupGroupedIndex() throws Exception {
         var options = new GroupMappingOptions();
-        options.setGroupField("groupa");
+        options.setGroupField(Arrays.asList("groupa"));
         testHelper.getGroupMappingService().generateMapping(options);
         var syncOptions = new GroupMappingSyncOptions();
         syncOptions.setSortField("file");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
@@ -158,14 +158,14 @@ public class GroupMappingServiceTest {
 
         // Mapping state should have been overwritten
         GroupMappingInfo info2 = service.loadMappings();
-        assertMappingPresent(info2, "25", "digitc:2005-11-10", null);
-        assertMappingPresent(info2, "26", null, null);
-        assertMappingPresent(info2, "27", null, null);
-        assertMappingPresent(info2, "28", "digitc:2005-11-10", null);
-        assertMappingPresent(info2, "29", "digitc:2005-11-10", null);
+        assertMappingPresent(info2, "25", "digitc:2005-11-10");
+        assertMappingPresent(info2, "26", null);
+        assertMappingPresent(info2, "27", null);
+        assertMappingPresent(info2, "28", "digitc:2005-11-10");
+        assertMappingPresent(info2, "29", "digitc:2005-11-10");
         assertEquals(5, info2.getMappings().size());
 
-        assertGroupingPresent(info2, "digitc:2005-11-10", "null", "25", "28", "29");
+        assertGroupingPresent(info2, "digitc:2005-11-10", "25", "28", "29");
         assertEquals(1, info2.getGroupedMappings().size());
 
         assertMappedDatePresent();
@@ -187,11 +187,11 @@ public class GroupMappingServiceTest {
 
         // Mapping state should have been overwritten
         GroupMappingInfo info2 = service.loadMappings();
-        assertMappingPresent(info2, "25", "groupa:group1", null);
-        assertMappingPresent(info2, "26", "groupa:group1", null);
-        assertMappingPresent(info2, "27", null, null);
-        assertMappingPresent(info2, "28", "digitc:2005-11-10", null);
-        assertMappingPresent(info2, "29", "digitc:2005-11-10", null);
+        assertMappingPresent(info2, "25", "groupa:group1");
+        assertMappingPresent(info2, "26", "groupa:group1");
+        assertMappingPresent(info2, "27", null);
+        assertMappingPresent(info2, "28", "digitc:2005-11-10");
+        assertMappingPresent(info2, "29", "digitc:2005-11-10");
         assertEquals(5, info2.getMappings().size());
 
         assertMappedDatePresent();
@@ -205,11 +205,11 @@ public class GroupMappingServiceTest {
         service.generateMapping(options);
 
         GroupMappingInfo info = service.loadMappings();
-        assertMappingPresent(info, "25", "digitc:2005-11-10", null);
-        assertMappingPresent(info, "26", null, null);
-        assertMappingPresent(info, "27", null, null);
-        assertMappingPresent(info, "28", "digitc:2005-11-10", null);
-        assertMappingPresent(info, "29", "digitc:2005-11-10", null);
+        assertMappingPresent(info, "25", "digitc:2005-11-10");
+        assertMappingPresent(info, "26", null);
+        assertMappingPresent(info, "27", null);
+        assertMappingPresent(info, "28", "digitc:2005-11-10");
+        assertMappingPresent(info, "29", "digitc:2005-11-10");
         assertEquals(5, info.getMappings().size());
 
         options.setUpdate(true);
@@ -218,11 +218,11 @@ public class GroupMappingServiceTest {
         service.generateMapping(options);
 
         GroupMappingInfo info2 = service.loadMappings();
-        assertMappingPresent(info2, "25", "groupa:group1", null);
-        assertMappingPresent(info2, "26", "groupa:group1", null);
-        assertMappingPresent(info2, "27", null, null);
-        assertMappingPresent(info2, "28", "digitc:2005-11-10", null);
-        assertMappingPresent(info2, "29", "digitc:2005-11-10", null);
+        assertMappingPresent(info2, "25", "groupa:group1");
+        assertMappingPresent(info2, "26", "groupa:group1");
+        assertMappingPresent(info2, "27", null);
+        assertMappingPresent(info2, "28", "digitc:2005-11-10");
+        assertMappingPresent(info2, "29", "digitc:2005-11-10");
         assertEquals(5, info2.getMappings().size());
 
         assertMappedDatePresent();
@@ -343,7 +343,7 @@ public class GroupMappingServiceTest {
             assertNumberOfGroups(conn, 1);
             assertParentIdsPresent(conn, "groupa:group1", null);
 
-            assertGroupingPresent(info, "groupa:group1", "null", "25", "26");
+            assertGroupingPresent(info, "groupa:group1", "25", "26");
             assertEquals(1, info.getGroupedMappings().size());
 
             assertSyncedDatePresent();
@@ -361,14 +361,14 @@ public class GroupMappingServiceTest {
 
         GroupMappingInfo info = service.loadMappings();
 
-        assertMappingPresent(info, "25", "groupa:group1", "dcmi:Image");
-        assertMappingPresent(info, "26", "groupa:group1", "dcmi:Image");
-        assertMappingPresent(info, "27", null, null);
-        assertMappingPresent(info, "28", null, null);
-        assertMappingPresent(info, "29", null, null);
+        assertMappingPresent(info, "25", "groupa:group1,dcmi:Image");
+        assertMappingPresent(info, "26", "groupa:group1,dcmi:Image");
+        assertMappingPresent(info, "27", null);
+        assertMappingPresent(info, "28", null);
+        assertMappingPresent(info, "29", null);
         assertEquals(5, info.getMappings().size());
 
-        assertGroupingPresent(info, "groupa:group1", "dcmi:Image", "25", "26");
+        assertGroupingPresent(info, "groupa:group1,dcmi:Image", "25", "26");
         assertEquals(1, info.getGroupedMappings().size());
 
         assertMappedDatePresent();
@@ -389,12 +389,12 @@ public class GroupMappingServiceTest {
             conn = indexService.openDbConnection();
             assertWorkSynced(conn, "groupa:group1", "Redoubt C", "2005-11-23");
             assertWorkSynced(conn, "dcmi:Image", "Redoubt C", "2005-11-23");
-            assertFilesGrouped(conn, "groupa:group1", "25", "26");
+            assertFilesGrouped(conn, "groupa:group1,dcmi:Image", "25", "26");
             assertFileHasOrder(conn, "25", 1);
             assertFileHasOrder(conn, "26", 0);
             // Group key with a single child should not be grouped
             assertNumberOfGroups(conn, 1);
-            assertParentIdsPresent(conn, "groupa:group1", null);
+            assertParentIdsPresent(conn, "groupa:group1,dcmi:Image", null);
             assertSyncedDatePresent();
         } finally {
             CdmIndexService.closeDbConnection(conn);
@@ -418,11 +418,11 @@ public class GroupMappingServiceTest {
 
         // Mapping state should have been overwritten
         GroupMappingInfo info2 = service.loadMappings();
-        assertMappingPresent(info2, "25", "groupa:group1", "dcmi:Image");
-        assertMappingPresent(info2, "26", "groupa:group1", "dcmi:Image");
-        assertMappingPresent(info2, "27", null, null);
-        assertMappingPresent(info2, "28", null, null);
-        assertMappingPresent(info2, "29", null, null);
+        assertMappingPresent(info2, "25", "groupa:group1,dcmi:Image");
+        assertMappingPresent(info2, "26", "groupa:group1,dcmi:Image");
+        assertMappingPresent(info2, "27", null);
+        assertMappingPresent(info2, "28", null);
+        assertMappingPresent(info2, "29", null);
         assertEquals(5, info2.getMappings().size());
 
         assertMappedDatePresent();
@@ -528,23 +528,21 @@ public class GroupMappingServiceTest {
                 "Expected message exception to contain '" + expected + "', but was: " + e.getMessage());
     }
 
-    private void assertMappingPresent(GroupMappingInfo info, String id, String expectedMatchedVal1,
-                                      String expectedMatchedVal2) {
+    private void assertMappingPresent(GroupMappingInfo info, String id, String expectedMatchedVal) {
         GroupMapping mapping = info.getMappingByCdmId(id);
         assertNotNull(mapping);
         assertEquals(id, mapping.getCdmId());
-        assertEquals(asGroupKey(expectedMatchedVal1), mapping.getGroupKey1());
-        assertEquals(asGroupKey(expectedMatchedVal2), mapping.getGroupKey2());
+        assertEquals(asGroupKey(expectedMatchedVal), mapping.getGroupKey());
     }
 
-    private void assertGroupingPresent(GroupMappingInfo groupedInfo, String groupKey1, String groupKey2, String... cdmIds) {
+    private void assertGroupingPresent(GroupMappingInfo groupedInfo, String groupKey, String... cdmIds) {
         Map<String, List<String>> groupedMappings = groupedInfo.getGroupedMappings();
-        List<String> objIds = groupedMappings.get(asGroupKey(groupKey1));
+        List<String> objIds = groupedMappings.get(asGroupKey(groupKey));
         List<String> expectedIds = Arrays.asList(cdmIds);
         assertTrue(objIds.containsAll(expectedIds),
-                "Expected group " + groupKey1 + " to contain " + expectedIds + " but contained " + objIds);
+                "Expected group " + groupKey + " to contain " + expectedIds + " but contained " + objIds);
         assertEquals(expectedIds.size(), objIds.size(),
-                "Expected group " + groupKey1 + " to contain " + expectedIds + " but contained " + objIds);
+                "Expected group " + groupKey + " to contain " + expectedIds + " but contained " + objIds);
     }
 
     private void assertMappedDatePresent() throws Exception {
@@ -568,15 +566,15 @@ public class GroupMappingServiceTest {
     }
 
     private void assertGroupAMappingsPresent(GroupMappingInfo info) {
-        assertMappingPresent(info, "25", "groupa:group1", null);
-        assertMappingPresent(info, "26", "groupa:group1", null);
+        assertMappingPresent(info, "25", "groupa:group1");
+        assertMappingPresent(info, "26", "groupa:group1");
         // Single member group should not be mapped
-        assertMappingPresent(info, "27", null, null);
-        assertMappingPresent(info, "28", null, null);
-        assertMappingPresent(info, "29", null, null);
+        assertMappingPresent(info, "27", null);
+        assertMappingPresent(info, "28", null);
+        assertMappingPresent(info, "29", null);
         assertEquals(5, info.getMappings().size());
 
-        assertGroupingPresent(info, "groupa:group1", null, "25", "26");
+        assertGroupingPresent(info, "groupa:group1", "25", "26");
         assertEquals(1, info.getGroupedMappings().size());
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
@@ -152,7 +152,7 @@ public class GroupMappingServiceTest {
         assertGroupAMappingsPresent(info);
 
         options.setForce(true);
-        options.setGroupField(Arrays.asList("digitc"));
+        options.setGroupFields(Arrays.asList("digitc"));
 
         service.generateMapping(options);
 
@@ -181,7 +181,7 @@ public class GroupMappingServiceTest {
         assertEquals(5, info.getMappings().size());
 
         options.setUpdate(true);
-        options.setGroupField(Arrays.asList("digitc"));
+        options.setGroupFields(Arrays.asList("digitc"));
 
         service.generateMapping(options);
 
@@ -201,7 +201,7 @@ public class GroupMappingServiceTest {
     public void generateUpdateForceRunTest() throws Exception {
         indexExportSamples();
         GroupMappingOptions options = makeDefaultOptions();
-        options.setGroupField(Arrays.asList("digitc"));
+        options.setGroupFields(Arrays.asList("digitc"));
         service.generateMapping(options);
 
         GroupMappingInfo info = service.loadMappings();
@@ -214,7 +214,7 @@ public class GroupMappingServiceTest {
 
         options.setUpdate(true);
         options.setForce(true);
-        options.setGroupField(Arrays.asList("groupa"));
+        options.setGroupFields(Arrays.asList("groupa"));
         service.generateMapping(options);
 
         GroupMappingInfo info2 = service.loadMappings();
@@ -305,7 +305,7 @@ public class GroupMappingServiceTest {
     public void syncSecondRunWithCleanupTest() throws Exception {
         indexExportSamples();
         GroupMappingOptions options = makeDefaultOptions();
-        options.setGroupField(Arrays.asList("digitc"));
+        options.setGroupFields(Arrays.asList("digitc"));
         service.generateMapping(options);
 
         service.syncMappings(makeDefaultSyncOptions());
@@ -326,7 +326,7 @@ public class GroupMappingServiceTest {
             CdmIndexService.closeDbConnection(conn);
         }
 
-        options.setGroupField(Arrays.asList("groupa"));
+        options.setGroupFields(Arrays.asList("groupa"));
         options.setForce(true);
         service.generateMapping(options);
 
@@ -356,7 +356,7 @@ public class GroupMappingServiceTest {
     public void generateSingleRunMultipleGroupsTest() throws Exception {
         indexExportSamples();
         GroupMappingOptions options = new GroupMappingOptions();
-        options.setGroupField(Arrays.asList("groupa", "dcmi"));
+        options.setGroupFields(Arrays.asList("groupa", "dcmi"));
         service.generateMapping(options);
 
         GroupMappingInfo info = service.loadMappings();
@@ -378,7 +378,7 @@ public class GroupMappingServiceTest {
     public void syncSingleRunMultipleGroupsTest() throws Exception {
         indexExportSamples();
         GroupMappingOptions options = new GroupMappingOptions();
-        options.setGroupField(Arrays.asList("groupa", "dcmi"));
+        options.setGroupFields(Arrays.asList("groupa", "dcmi"));
         service.generateMapping(options);
 
         service.syncMappings(makeDefaultSyncOptions());
@@ -412,7 +412,7 @@ public class GroupMappingServiceTest {
 
         options.setUpdate(true);
         options.setForce(true);
-        options.setGroupField(Arrays.asList("groupa", "dcmi"));
+        options.setGroupFields(Arrays.asList("groupa", "dcmi"));
 
         service.generateMapping(options);
 
@@ -513,7 +513,7 @@ public class GroupMappingServiceTest {
 
     private GroupMappingOptions makeDefaultOptions() {
         GroupMappingOptions options = new GroupMappingOptions();
-        options.setGroupField(Arrays.asList("groupa"));
+        options.setGroupFields(Arrays.asList("groupa"));
         return options;
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
@@ -152,20 +152,20 @@ public class GroupMappingServiceTest {
         assertGroupAMappingsPresent(info);
 
         options.setForce(true);
-        options.setGroupField("digitc");
+        options.setGroupField(Arrays.asList("digitc"));
 
         service.generateMapping(options);
 
         // Mapping state should have been overwritten
         GroupMappingInfo info2 = service.loadMappings();
-        assertMappingPresent(info2, "25", "digitc:2005-11-10");
-        assertMappingPresent(info2, "26", null);
-        assertMappingPresent(info2, "27", null);
-        assertMappingPresent(info2, "28", "digitc:2005-11-10");
-        assertMappingPresent(info2, "29", "digitc:2005-11-10");
+        assertMappingPresent(info2, "25", "digitc:2005-11-10", null);
+        assertMappingPresent(info2, "26", null, null);
+        assertMappingPresent(info2, "27", null, null);
+        assertMappingPresent(info2, "28", "digitc:2005-11-10", null);
+        assertMappingPresent(info2, "29", "digitc:2005-11-10", null);
         assertEquals(5, info2.getMappings().size());
 
-        assertGroupingPresent(info2, "digitc:2005-11-10", "25", "28", "29");
+        assertGroupingPresent(info2, "digitc:2005-11-10", "null", "25", "28", "29");
         assertEquals(1, info2.getGroupedMappings().size());
 
         assertMappedDatePresent();
@@ -181,17 +181,17 @@ public class GroupMappingServiceTest {
         assertEquals(5, info.getMappings().size());
 
         options.setUpdate(true);
-        options.setGroupField("digitc");
+        options.setGroupField(Arrays.asList("digitc"));
 
         service.generateMapping(options);
 
         // Mapping state should have been overwritten
         GroupMappingInfo info2 = service.loadMappings();
-        assertMappingPresent(info2, "25", "groupa:group1");
-        assertMappingPresent(info2, "26", "groupa:group1");
-        assertMappingPresent(info2, "27", null);
-        assertMappingPresent(info2, "28", "digitc:2005-11-10");
-        assertMappingPresent(info2, "29", "digitc:2005-11-10");
+        assertMappingPresent(info2, "25", "groupa:group1", null);
+        assertMappingPresent(info2, "26", "groupa:group1", null);
+        assertMappingPresent(info2, "27", null, null);
+        assertMappingPresent(info2, "28", "digitc:2005-11-10", null);
+        assertMappingPresent(info2, "29", "digitc:2005-11-10", null);
         assertEquals(5, info2.getMappings().size());
 
         assertMappedDatePresent();
@@ -201,28 +201,28 @@ public class GroupMappingServiceTest {
     public void generateUpdateForceRunTest() throws Exception {
         indexExportSamples();
         GroupMappingOptions options = makeDefaultOptions();
-        options.setGroupField("digitc");
+        options.setGroupField(Arrays.asList("digitc"));
         service.generateMapping(options);
 
         GroupMappingInfo info = service.loadMappings();
-        assertMappingPresent(info, "25", "digitc:2005-11-10");
-        assertMappingPresent(info, "26", null);
-        assertMappingPresent(info, "27", null);
-        assertMappingPresent(info, "28", "digitc:2005-11-10");
-        assertMappingPresent(info, "29", "digitc:2005-11-10");
+        assertMappingPresent(info, "25", "digitc:2005-11-10", null);
+        assertMappingPresent(info, "26", null, null);
+        assertMappingPresent(info, "27", null, null);
+        assertMappingPresent(info, "28", "digitc:2005-11-10", null);
+        assertMappingPresent(info, "29", "digitc:2005-11-10", null);
         assertEquals(5, info.getMappings().size());
 
         options.setUpdate(true);
         options.setForce(true);
-        options.setGroupField("groupa");
+        options.setGroupField(Arrays.asList("groupa"));
         service.generateMapping(options);
 
         GroupMappingInfo info2 = service.loadMappings();
-        assertMappingPresent(info2, "25", "groupa:group1");
-        assertMappingPresent(info2, "26", "groupa:group1");
-        assertMappingPresent(info2, "27", null);
-        assertMappingPresent(info2, "28", "digitc:2005-11-10");
-        assertMappingPresent(info2, "29", "digitc:2005-11-10");
+        assertMappingPresent(info2, "25", "groupa:group1", null);
+        assertMappingPresent(info2, "26", "groupa:group1", null);
+        assertMappingPresent(info2, "27", null, null);
+        assertMappingPresent(info2, "28", "digitc:2005-11-10", null);
+        assertMappingPresent(info2, "29", "digitc:2005-11-10", null);
         assertEquals(5, info2.getMappings().size());
 
         assertMappedDatePresent();
@@ -305,7 +305,7 @@ public class GroupMappingServiceTest {
     public void syncSecondRunWithCleanupTest() throws Exception {
         indexExportSamples();
         GroupMappingOptions options = makeDefaultOptions();
-        options.setGroupField("digitc");
+        options.setGroupField(Arrays.asList("digitc"));
         service.generateMapping(options);
 
         service.syncMappings(makeDefaultSyncOptions());
@@ -326,7 +326,7 @@ public class GroupMappingServiceTest {
             CdmIndexService.closeDbConnection(conn);
         }
 
-        options.setGroupField("groupa");
+        options.setGroupField(Arrays.asList("groupa"));
         options.setForce(true);
         service.generateMapping(options);
 
@@ -343,13 +343,89 @@ public class GroupMappingServiceTest {
             assertNumberOfGroups(conn, 1);
             assertParentIdsPresent(conn, "groupa:group1", null);
 
-            assertGroupingPresent(info, "groupa:group1", "25", "26");
+            assertGroupingPresent(info, "groupa:group1", "null", "25", "26");
             assertEquals(1, info.getGroupedMappings().size());
 
             assertSyncedDatePresent();
         } finally {
             CdmIndexService.closeDbConnection(conn);
         }
+    }
+
+    @Test
+    public void generateSingleRunMultipleGroupsTest() throws Exception {
+        indexExportSamples();
+        GroupMappingOptions options = new GroupMappingOptions();
+        options.setGroupField(Arrays.asList("groupa", "dcmi"));
+        service.generateMapping(options);
+
+        GroupMappingInfo info = service.loadMappings();
+
+        assertMappingPresent(info, "25", "groupa:group1", "dcmi:Image");
+        assertMappingPresent(info, "26", "groupa:group1", "dcmi:Image");
+        assertMappingPresent(info, "27", null, null);
+        assertMappingPresent(info, "28", null, null);
+        assertMappingPresent(info, "29", null, null);
+        assertEquals(5, info.getMappings().size());
+
+        assertGroupingPresent(info, "groupa:group1", "dcmi:Image", "25", "26");
+        assertEquals(1, info.getGroupedMappings().size());
+
+        assertMappedDatePresent();
+    }
+
+    @Test
+    public void syncSingleRunMultipleGroupsTest() throws Exception {
+        indexExportSamples();
+        GroupMappingOptions options = new GroupMappingOptions();
+        options.setGroupField(Arrays.asList("groupa", "dcmi"));
+        service.generateMapping(options);
+
+        service.syncMappings(makeDefaultSyncOptions());
+
+        Connection conn = null;
+        try {
+            GroupMappingInfo info = service.loadMappings();
+            conn = indexService.openDbConnection();
+            assertWorkSynced(conn, "groupa:group1", "Redoubt C", "2005-11-23");
+            assertWorkSynced(conn, "dcmi:Image", "Redoubt C", "2005-11-23");
+            assertFilesGrouped(conn, "groupa:group1", "25", "26");
+            assertFileHasOrder(conn, "25", 1);
+            assertFileHasOrder(conn, "26", 0);
+            // Group key with a single child should not be grouped
+            assertNumberOfGroups(conn, 1);
+            assertParentIdsPresent(conn, "groupa:group1", null);
+            assertSyncedDatePresent();
+        } finally {
+            CdmIndexService.closeDbConnection(conn);
+        }
+    }
+
+    @Test
+    public void generateMultipleGroupsForceUpdateRunTest() throws Exception {
+        indexExportSamples();
+        GroupMappingOptions options = makeDefaultOptions();
+        service.generateMapping(options);
+
+        GroupMappingInfo info = service.loadMappings();
+        assertEquals(5, info.getMappings().size());
+
+        options.setUpdate(true);
+        options.setForce(true);
+        options.setGroupField(Arrays.asList("groupa", "dcmi"));
+
+        service.generateMapping(options);
+
+        // Mapping state should have been overwritten
+        GroupMappingInfo info2 = service.loadMappings();
+        assertMappingPresent(info2, "25", "groupa:group1", "dcmi:Image");
+        assertMappingPresent(info2, "26", "groupa:group1", "dcmi:Image");
+        assertMappingPresent(info2, "27", null, null);
+        assertMappingPresent(info2, "28", null, null);
+        assertMappingPresent(info2, "29", null, null);
+        assertEquals(5, info2.getMappings().size());
+
+        assertMappedDatePresent();
     }
 
     private void assertWorkSynced(Connection conn, String workId, String expectedTitle, String expectedCreated)
@@ -437,7 +513,7 @@ public class GroupMappingServiceTest {
 
     private GroupMappingOptions makeDefaultOptions() {
         GroupMappingOptions options = new GroupMappingOptions();
-        options.setGroupField("groupa");
+        options.setGroupField(Arrays.asList("groupa"));
         return options;
     }
 
@@ -452,21 +528,23 @@ public class GroupMappingServiceTest {
                 "Expected message exception to contain '" + expected + "', but was: " + e.getMessage());
     }
 
-    private void assertMappingPresent(GroupMappingInfo info, String id, String expectedMatchedVal) {
+    private void assertMappingPresent(GroupMappingInfo info, String id, String expectedMatchedVal1,
+                                      String expectedMatchedVal2) {
         GroupMapping mapping = info.getMappingByCdmId(id);
         assertNotNull(mapping);
         assertEquals(id, mapping.getCdmId());
-        assertEquals(asGroupKey(expectedMatchedVal), mapping.getGroupKey());
+        assertEquals(asGroupKey(expectedMatchedVal1), mapping.getGroupKey1());
+        assertEquals(asGroupKey(expectedMatchedVal2), mapping.getGroupKey2());
     }
 
-    private void assertGroupingPresent(GroupMappingInfo groupedInfo, String groupKey, String... cdmIds) {
+    private void assertGroupingPresent(GroupMappingInfo groupedInfo, String groupKey1, String groupKey2, String... cdmIds) {
         Map<String, List<String>> groupedMappings = groupedInfo.getGroupedMappings();
-        List<String> objIds = groupedMappings.get(asGroupKey(groupKey));
+        List<String> objIds = groupedMappings.get(asGroupKey(groupKey1));
         List<String> expectedIds = Arrays.asList(cdmIds);
         assertTrue(objIds.containsAll(expectedIds),
-                "Expected group " + groupKey + " to contain " + expectedIds + " but contained " + objIds);
+                "Expected group " + groupKey1 + " to contain " + expectedIds + " but contained " + objIds);
         assertEquals(expectedIds.size(), objIds.size(),
-                "Expected group " + groupKey + " to contain " + expectedIds + " but contained " + objIds);
+                "Expected group " + groupKey1 + " to contain " + expectedIds + " but contained " + objIds);
     }
 
     private void assertMappedDatePresent() throws Exception {
@@ -490,15 +568,15 @@ public class GroupMappingServiceTest {
     }
 
     private void assertGroupAMappingsPresent(GroupMappingInfo info) {
-        assertMappingPresent(info, "25", "groupa:group1");
-        assertMappingPresent(info, "26", "groupa:group1");
+        assertMappingPresent(info, "25", "groupa:group1", null);
+        assertMappingPresent(info, "26", "groupa:group1", null);
         // Single member group should not be mapped
-        assertMappingPresent(info, "27", null);
-        assertMappingPresent(info, "28", null);
-        assertMappingPresent(info, "29", null);
+        assertMappingPresent(info, "27", null, null);
+        assertMappingPresent(info, "28", null, null);
+        assertMappingPresent(info, "29", null, null);
         assertEquals(5, info.getMappings().size());
 
-        assertGroupingPresent(info, "groupa:group1", "25", "26");
+        assertGroupingPresent(info, "groupa:group1", null, "25", "26");
         assertEquals(1, info.getGroupedMappings().size());
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -599,7 +599,7 @@ public class PermissionsServiceTest {
 
     private void setupGroupedIndex() throws Exception {
         var options = new GroupMappingOptions();
-        options.setGroupField(Arrays.asList("groupa"));
+        options.setGroupFields(Arrays.asList("groupa"));
         testHelper.getGroupMappingService().generateMapping(options);
         var syncOptions = new GroupMappingSyncOptions();
         syncOptions.setSortField("file");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -599,7 +599,7 @@ public class PermissionsServiceTest {
 
     private void setupGroupedIndex() throws Exception {
         var options = new GroupMappingOptions();
-        options.setGroupField("groupa");
+        options.setGroupField(Arrays.asList("groupa"));
         testHelper.getGroupMappingService().generateMapping(options);
         var syncOptions = new GroupMappingSyncOptions();
         syncOptions.setSortField("file");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -1496,7 +1496,7 @@ public class SipServiceTest {
         return options;
     }
 
-    private void setupGroupIndex() throws IOException {
+    private void setupGroupIndex() throws Exception {
         GroupMappingOptions groupOptions = new GroupMappingOptions();
         groupOptions.setGroupField(Arrays.asList("groupa"));
         GroupMappingService groupService = testHelper.getGroupMappingService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -1498,7 +1498,7 @@ public class SipServiceTest {
 
     private void setupGroupIndex() throws IOException {
         GroupMappingOptions groupOptions = new GroupMappingOptions();
-        groupOptions.setGroupField("groupa");
+        groupOptions.setGroupField(Arrays.asList("groupa"));
         GroupMappingService groupService = testHelper.getGroupMappingService();
         groupService.generateMapping(groupOptions);
         groupService.syncMappings(makeDefaultSyncOptions());

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -1498,7 +1498,7 @@ public class SipServiceTest {
 
     private void setupGroupIndex() throws Exception {
         GroupMappingOptions groupOptions = new GroupMappingOptions();
-        groupOptions.setGroupField(Arrays.asList("groupa"));
+        groupOptions.setGroupFields(Arrays.asList("groupa"));
         GroupMappingService groupService = testHelper.getGroupMappingService();
         groupService.generateMapping(groupOptions);
         groupService.syncMappings(makeDefaultSyncOptions());


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4603](https://unclibrary.atlassian.net/browse/BXC-4603)

- `GroupMappingOptions`: modify`groupField` option to accept a list
- `GroupMappingService`: update `generateMapping` method to use helper methods `generateOneGroupMapping` or `generateMultipleGroupMappings` depending on number of group fields
- add/fix tests