### PR TITLE
BXC-4635 init project from filesystem

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommand.java
@@ -96,12 +96,15 @@ public class InitializeProjectCommand implements Callable<Integer> {
 
         Path currentPath = parentCommand.getWorkingDirectory();
         String projDisplayName = projectName == null ? currentPath.getFileName().toString() : projectName;
-        Integer integer = null;
+        Integer integer = -1;
 
-        if (projectSource.equalsIgnoreCase("cdm")) {
+        if (projectSource.equalsIgnoreCase(MigrationProject.PROJECT_SOURCE_CDM)) {
             integer = initCdmProject(config, currentPath, projDisplayName, start);
-        } else if (projectSource.equalsIgnoreCase("files")) {
+        } else if (projectSource.equalsIgnoreCase(MigrationProject.PROJECT_SOURCE_FILES)) {
             integer = initFilesProject(currentPath, projDisplayName, start);
+        } else {
+            log.error("Invalid project source: {}", projectSource);
+            outputLogger.info("Invalid project source: {}", projectSource);
         }
 
         return integer;
@@ -125,7 +128,7 @@ public class InitializeProjectCommand implements Callable<Integer> {
         }
 
         // Instantiate the project
-        MigrationProject project = null;
+        MigrationProject project;
         try {
             project = MigrationProjectFactory.createCdmMigrationProject(
                     currentPath, projectName, cdmCollectionId, username, cdmEnvId, bxcEnvId);
@@ -156,8 +159,7 @@ public class InitializeProjectCommand implements Callable<Integer> {
         String username = System.getProperty("user.name");
 
         try {
-            MigrationProjectFactory.createFilesMigrationProject(
-                    currentPath, projectName, null, username,  bxcEnvId, projectSource);
+            MigrationProjectFactory.createFilesMigrationProject(currentPath, projectName, username,  bxcEnvId);
         } catch (InvalidProjectStateException e) {
             outputLogger.info("Failed to initialize project {}: {}", projDisplayName, e.getMessage());
             return 1;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommand.java
@@ -2,7 +2,6 @@ package edu.unc.lib.boxc.migration.cdm;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
-import edu.unc.lib.boxc.migration.cdm.model.CdmEnvironment;
 import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
@@ -25,6 +25,8 @@ public class MigrationProject {
     public static final String REDIRECT_MAPPING_FILENAME = "redirect_mappings.csv";
     public static final String POST_MIGR_REPORT_FILENAME = "post_migration_report.csv";
     public static final String PERMISSIONS_FILENAME = "patron_permissions.csv";
+    public static final String PROJECT_SOURCE_CDM = "cdm";
+    public static final String PROJECT_SOURCE_FILES = "files";
 
     private Path projectPath;
     private MigrationProjectProperties properties;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
@@ -28,6 +28,7 @@ public class MigrationProjectProperties {
     private String collectionNumber;
     private String cdmEnvironmentId;
     private String bxcEnvironmentId;
+    private String projectSource;
 
     public MigrationProjectProperties() {
         sipsSubmitted = new HashSet<>();
@@ -229,5 +230,13 @@ public class MigrationProjectProperties {
 
     public void setBxcEnvironmentId(String bxcEnvironmentId) {
         this.bxcEnvironmentId = bxcEnvironmentId;
+    }
+
+    public String getProjectSource() {
+        return projectSource;
+    }
+
+    public void setProjectSource(String projectSource) {
+        this.projectSource = projectSource;
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactory.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactory.java
@@ -21,18 +21,17 @@ public class MigrationProjectFactory {
     private MigrationProjectFactory() {
     }
 
-    public static MigrationProject createCdmMigrationProject(Path path, String name,
-                                                             String collectionId, String user,
-                                                             String cdmEnvId, String bxcEnvId)
+    public static MigrationProject createCdmMigrationProject(Path path, String name, String collectionId,
+                                                             String user, String cdmEnvId, String bxcEnvId)
             throws IOException {
-        return createMigrationProject(path, name, collectionId, user, cdmEnvId, bxcEnvId, "cdm");
+        return createMigrationProject(path, name, collectionId, user, cdmEnvId, bxcEnvId,
+                MigrationProject.PROJECT_SOURCE_CDM);
     }
 
-    public static MigrationProject createFilesMigrationProject(Path path, String name,
-                                                          String collectionId, String user,
-                                                               String bxcEnvId, String projectSource)
+    public static MigrationProject createFilesMigrationProject(Path path, String name, String user, String bxcEnvId)
             throws IOException {
-        return createMigrationProject(path, name, collectionId, user, null, bxcEnvId, projectSource);
+        return createMigrationProject(path, name, null, user, null, bxcEnvId,
+                MigrationProject.PROJECT_SOURCE_FILES);
     }
 
     /**
@@ -81,7 +80,7 @@ public class MigrationProjectFactory {
         properties.setCreator(user);
         properties.setCreatedDate(Instant.now());
         properties.setName(projectName);
-        if (projectSource.equalsIgnoreCase("cdm")) {
+        if (projectSource.equalsIgnoreCase(MigrationProject.PROJECT_SOURCE_CDM)) {
             properties.setCdmCollectionId(collectionId == null ? projectName : collectionId);
         } else {
             properties.setCdmCollectionId(null);

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactory.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactory.java
@@ -73,7 +73,11 @@ public class MigrationProjectFactory {
         properties.setCreator(user);
         properties.setCreatedDate(Instant.now());
         properties.setName(projectName);
-        properties.setCdmCollectionId(collectionId == null ? projectName : collectionId);
+        if (cdmEnvId == null) {
+            properties.setCdmCollectionId(null);
+        } else {
+            properties.setCdmCollectionId(collectionId == null ? projectName : collectionId);
+        }
         properties.setCdmEnvironmentId(cdmEnvId);
         properties.setBxcEnvironmentId(bxcEnvId);
         project.setProjectProperties(properties);

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactory.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactory.java
@@ -21,10 +21,18 @@ public class MigrationProjectFactory {
     private MigrationProjectFactory() {
     }
 
-    public static MigrationProject createMigrationProject(Path path, String name,
-                                                          String collectionId, String user, String cdmEnvId)
+    public static MigrationProject createCdmMigrationProject(Path path, String name,
+                                                             String collectionId, String user,
+                                                             String cdmEnvId, String bxcEnvId)
             throws IOException {
-        return createMigrationProject(path, name, collectionId, user, cdmEnvId, null);
+        return createMigrationProject(path, name, collectionId, user, cdmEnvId, bxcEnvId, "cdm");
+    }
+
+    public static MigrationProject createFilesMigrationProject(Path path, String name,
+                                                          String collectionId, String user,
+                                                               String bxcEnvId, String projectSource)
+            throws IOException {
+        return createMigrationProject(path, name, collectionId, user, null, bxcEnvId, projectSource);
     }
 
     /**
@@ -40,7 +48,7 @@ public class MigrationProjectFactory {
      */
     public static MigrationProject createMigrationProject(Path path, String name,
                                                           String collectionId, String user,
-                                                          String cdmEnvId, String bxcEnvId)
+                                                          String cdmEnvId, String bxcEnvId, String projectSource)
             throws IOException {
         Assert.notNull(path, "Project path not set");
         Assert.notNull(user, "Username not set");
@@ -73,13 +81,14 @@ public class MigrationProjectFactory {
         properties.setCreator(user);
         properties.setCreatedDate(Instant.now());
         properties.setName(projectName);
-        if (cdmEnvId == null) {
-            properties.setCdmCollectionId(null);
-        } else {
+        if (projectSource.equalsIgnoreCase("cdm")) {
             properties.setCdmCollectionId(collectionId == null ? projectName : collectionId);
+        } else {
+            properties.setCdmCollectionId(null);
         }
         properties.setCdmEnvironmentId(cdmEnvId);
         properties.setBxcEnvironmentId(bxcEnvId);
+        properties.setProjectSource(projectSource);
         project.setProjectProperties(properties);
         ProjectPropertiesSerialization.write(propertiesPath, properties);
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractCommandIT.java
@@ -28,7 +28,6 @@ public class AbstractCommandIT extends AbstractOutputTest {
     protected final static String PROJECT_ID = "my_proj";
     protected final static String USERNAME = "theuser";
     private final String initialUser = System.getProperty("user.name");
-    private static final String PROJECT_SOURCE = "cdm";
 
     protected CommandLine migrationCommand;
     protected SipServiceHelper testHelper;
@@ -53,7 +52,8 @@ public class AbstractCommandIT extends AbstractOutputTest {
 
     protected void initProject() throws IOException {
         project = MigrationProjectFactory.createMigrationProject(baseDir, PROJECT_ID, defaultCollectionId, USERNAME,
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID,
+                MigrationProject.PROJECT_SOURCE_CDM);
     }
 
     protected void initProjectAndHelper() throws IOException {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AbstractCommandIT.java
@@ -28,6 +28,7 @@ public class AbstractCommandIT extends AbstractOutputTest {
     protected final static String PROJECT_ID = "my_proj";
     protected final static String USERNAME = "theuser";
     private final String initialUser = System.getProperty("user.name");
+    private static final String PROJECT_SOURCE = "cdm";
 
     protected CommandLine migrationCommand;
     protected SipServiceHelper testHelper;
@@ -52,7 +53,7 @@ public class AbstractCommandIT extends AbstractOutputTest {
 
     protected void initProject() throws IOException {
         project = MigrationProjectFactory.createMigrationProject(baseDir, PROJECT_ID, defaultCollectionId, USERNAME,
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
     }
 
     protected void initProjectAndHelper() throws IOException {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmExportCommandIT.java
@@ -6,6 +6,7 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.TestSshServer;
 import org.apache.commons.io.FileUtils;
@@ -182,8 +183,9 @@ public class CdmExportCommandIT extends AbstractCommandIT {
     }
 
     private Path createProject(String collId) throws Exception {
-        MigrationProject project = MigrationProjectFactory.createMigrationProject(
-                baseDir, collId, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        MigrationProject project = MigrationProjectFactory.createCdmMigrationProject(
+                baseDir, collId, null, USERNAME,
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
         CdmFieldInfo fieldInfo = new CdmFieldInfo();
         CdmFieldEntry fieldEntry = new CdmFieldEntry();
         fieldEntry.setNickName("title");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommandIT.java
@@ -105,7 +105,7 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
     }
 
     @Test
-    public void initCdmCollectioNotFoundTest() throws Exception {
+    public void initCdmCollectionNotFoundTest() throws Exception {
         String[] initArgs = new String[] {
                 "-w", baseDir.toString(),
                 "--env-config", chompbConfigPath,
@@ -186,6 +186,23 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
         assertProjectDirectoryNotCreate();
     }
 
+    @Test
+    public void initNewProjectTest() throws Exception {
+        String[] initArgs = new String[] {
+                "-w", baseDir.toString(),
+                "--env-config", chompbConfigPath,
+                "init",
+                "-p", "test_file_project",
+                "-s", "files" };
+        executeExpectSuccess(initArgs);
+
+        MigrationProject project = MigrationProjectFactory.loadMigrationProject(baseDir.resolve("test_file_project"));
+        MigrationProjectProperties properties = project.getProjectProperties();
+        assertNewProjectPropertiesSet(properties, "test_file_project", null);
+
+        assertTrue(Files.exists(project.getDescriptionsPath()), "Description folder not created");
+    }
+
     private void assertProjectDirectoryNotCreate() throws IOException {
         try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(baseDir)) {
             for (Path path : dirStream) {
@@ -203,6 +220,17 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
         assertNull(properties.getHookId());
         assertNull(properties.getCollectionNumber());
         assertEquals(CdmEnvironmentHelper.DEFAULT_ENV_ID, properties.getCdmEnvironmentId());
+        assertEquals(BxcEnvironmentHelper.DEFAULT_ENV_ID, properties.getBxcEnvironmentId());
+    }
+
+    private void assertNewProjectPropertiesSet(MigrationProjectProperties properties, String expName, String expCollId) {
+        assertEquals(USERNAME, properties.getCreator());
+        assertEquals(expName, properties.getName(), "Project name did not match expected value");
+        assertEquals(expCollId, properties.getCdmCollectionId(), "CDM Collection ID did not match expected value");
+        assertNotNull(properties.getCreatedDate(), "Created date not set");
+        assertNull(properties.getHookId());
+        assertNull(properties.getCollectionNumber());
+        assertNull(properties.getCdmEnvironmentId());
         assertEquals(BxcEnvironmentHelper.DEFAULT_ENV_ID, properties.getBxcEnvironmentId());
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommandIT.java
@@ -196,8 +196,14 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
 
         MigrationProject project = MigrationProjectFactory.loadMigrationProject(baseDir.resolve("test_file_project"));
         MigrationProjectProperties properties = project.getProjectProperties();
-        assertNewProjectPropertiesSet(properties, "test_file_project", null);
-
+        assertEquals(USERNAME, properties.getCreator());
+        assertEquals("test_file_project", properties.getName(), "Project name did not match expected value");
+        assertNull(properties.getCdmCollectionId(), "CDM Collection ID did not match expected value");
+        assertNotNull(properties.getCreatedDate(), "Created date not set");
+        assertNull(properties.getHookId());
+        assertNull(properties.getCollectionNumber());
+        assertNull(properties.getCdmEnvironmentId());
+        assertEquals(BxcEnvironmentHelper.DEFAULT_ENV_ID, properties.getBxcEnvironmentId());
         assertTrue(Files.exists(project.getDescriptionsPath()), "Description folder not created");
     }
 
@@ -218,17 +224,6 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
         assertNull(properties.getHookId());
         assertNull(properties.getCollectionNumber());
         assertEquals(CdmEnvironmentHelper.DEFAULT_ENV_ID, properties.getCdmEnvironmentId());
-        assertEquals(BxcEnvironmentHelper.DEFAULT_ENV_ID, properties.getBxcEnvironmentId());
-    }
-
-    private void assertNewProjectPropertiesSet(MigrationProjectProperties properties, String expName, String expCollId) {
-        assertEquals(USERNAME, properties.getCreator());
-        assertEquals(expName, properties.getName(), "Project name did not match expected value");
-        assertEquals(expCollId, properties.getCdmCollectionId(), "CDM Collection ID did not match expected value");
-        assertNotNull(properties.getCreatedDate(), "Created date not set");
-        assertNull(properties.getHookId());
-        assertNull(properties.getCollectionNumber());
-        assertNull(properties.getCdmEnvironmentId());
         assertEquals(BxcEnvironmentHelper.DEFAULT_ENV_ID, properties.getBxcEnvironmentId());
     }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommandIT.java
@@ -19,8 +19,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.unc.lib.boxc.migration.cdm.services.ChompbConfigService;
 import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.IOUtils;
@@ -187,7 +185,7 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
     }
 
     @Test
-    public void initNewProjectTest() throws Exception {
+    public void initNewProjectFromFilesystemTest() throws Exception {
         String[] initArgs = new String[] {
                 "-w", baseDir.toString(),
                 "--env-config", chompbConfigPath,

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/InitializeProjectCommandIT.java
@@ -198,7 +198,7 @@ public class InitializeProjectCommandIT extends AbstractCommandIT {
         MigrationProjectProperties properties = project.getProjectProperties();
         assertEquals(USERNAME, properties.getCreator());
         assertEquals("test_file_project", properties.getName(), "Project name did not match expected value");
-        assertNull(properties.getCdmCollectionId(), "CDM Collection ID did not match expected value");
+        assertNull(properties.getCdmCollectionId());
         assertNotNull(properties.getCreatedDate(), "Created date not set");
         assertNull(properties.getHookId());
         assertNull(properties.getCollectionNumber());

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/AggregateFileMappingServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/AggregateFileMappingServiceTest.java
@@ -6,6 +6,7 @@ import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo;
 import edu.unc.lib.boxc.migration.cdm.options.AggregateFileMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.options.GroupMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.options.GroupMappingSyncOptions;
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,8 +39,9 @@ public class AggregateFileMappingServiceTest {
 
     @BeforeEach
     public void init() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, "user",
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
         basePath = tmpFolder.resolve("testFolder");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsServiceTest.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.when;
 
 public class ArchivalDestinationsServiceTest {
     private static final String PROJECT_NAME = "proj";
+    protected final static String PROJECT_SOURCE = "cdm";
     private static final String DEST_UUID = "bfe93126-849a-43a5-b9d9-391e18ffacc6";
     private static final String DEST_UUID2 = "8ae56bbc-400e-496d-af4b-3c585e20dba1";
     private static final String DEST_UUID3 = "bdbd99af-36a5-4bab-9785-e3a802d3737e";
@@ -71,7 +72,7 @@ public class ArchivalDestinationsServiceTest {
         closeable = openMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
                 tmpFolder, PROJECT_NAME, null, "user",
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
         testHelper = new SipServiceHelper(project, tmpFolder);
         service = new ArchivalDestinationsService();
         service.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ArchivalDestinationsServiceTest.java
@@ -47,7 +47,6 @@ import static org.mockito.Mockito.when;
 
 public class ArchivalDestinationsServiceTest {
     private static final String PROJECT_NAME = "proj";
-    protected final static String PROJECT_SOURCE = "cdm";
     private static final String DEST_UUID = "bfe93126-849a-43a5-b9d9-391e18ffacc6";
     private static final String DEST_UUID2 = "8ae56bbc-400e-496d-af4b-3c585e20dba1";
     private static final String DEST_UUID3 = "bdbd99af-36a5-4bab-9785-e3a802d3737e";
@@ -71,8 +70,8 @@ public class ArchivalDestinationsServiceTest {
     public void setup() throws Exception {
         closeable = openMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user",
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID,
+                BxcEnvironmentHelper.DEFAULT_ENV_ID, MigrationProject.PROJECT_SOURCE_CDM);
         testHelper = new SipServiceHelper(project, tmpFolder);
         service = new ArchivalDestinationsService();
         service.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmExportServiceTest.java
@@ -6,6 +6,7 @@ import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo.CdmFieldEntry;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.options.CdmExportOptions;
 import edu.unc.lib.boxc.migration.cdm.services.export.ExportStateService;
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -53,8 +54,9 @@ public class CdmExportServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         closeable = openMocks(this);
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, "user",
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
         fieldService = new CdmFieldService();
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmFieldServiceTest.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpEntity;
@@ -56,8 +57,9 @@ public class CdmFieldServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         closeable = openMocks(this);
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, "user",
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
         service = new CdmFieldService();
         service.setHttpClient(httpClient);
         service.setCdmBaseUri(CDM_BASE_URL);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexServiceTest.java
@@ -5,11 +5,10 @@ import edu.unc.lib.boxc.migration.cdm.exceptions.StateAlreadyExistsException;
 import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 import org.apache.commons.io.FileUtils;
-import org.jdom2.output.Format;
-import org.jdom2.output.XMLOutputter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -48,8 +47,9 @@ public class CdmIndexServiceTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, "user",
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
         fieldService = new CdmFieldService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/DescriptionsServiceTest.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.jdom2.Document;
@@ -50,7 +51,8 @@ public class DescriptionsServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         basePath = tmpFolder;
-        project = MigrationProjectFactory.createMigrationProject(basePath, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(basePath, PROJECT_NAME, null,
+                "user", CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getDescriptionsPath());
         service = new DescriptionsService();
         service.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldAssessmentTemplateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldAssessmentTemplateServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,8 +36,9 @@ public class FieldAssessmentTemplateServiceTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, "user",
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
         fieldService = new CdmFieldService();
 
         service = new FieldAssessmentTemplateService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldUrlAssessmentServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FieldUrlAssessmentServiceTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import org.apache.commons.csv.CSVFormat;
@@ -52,8 +53,9 @@ public class FieldUrlAssessmentServiceTest {
 
     @BeforeEach
     public void setup(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, "user",
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
         var testHelper = new SipServiceHelper(project, tmpFolder);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,8 +30,9 @@ public class FindingAidServiceTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, "user",
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
 
         fieldService = new CdmFieldService();
         service = new FindingAidService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/GroupMappingServiceTest.java
@@ -9,6 +9,7 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
 import edu.unc.lib.boxc.migration.cdm.options.GroupMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.options.GroupMappingSyncOptions;
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.OutputHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
@@ -53,8 +54,9 @@ public class GroupMappingServiceTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, "user",
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
         fieldService = new CdmFieldService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/IndexFilteringServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/IndexFilteringServiceTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class IndexFilteringServiceTest {
     private static final String PROJECT_NAME = "proj";
     private static final String USERNAME = "migr_user";
+    private static final String PROJECT_SOURCE = "cdm";
     @TempDir
     public Path tmpFolder;
     private SipServiceHelper testHelper;
@@ -38,7 +39,7 @@ public class IndexFilteringServiceTest {
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
                 tmpFolder, PROJECT_NAME, null, USERNAME,
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
         testHelper = new SipServiceHelper(project, tmpFolder);
         service = new IndexFilteringService();
         service.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/IndexFilteringServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/IndexFilteringServiceTest.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class IndexFilteringServiceTest {
     private static final String PROJECT_NAME = "proj";
     private static final String USERNAME = "migr_user";
-    private static final String PROJECT_SOURCE = "cdm";
     @TempDir
     public Path tmpFolder;
     private SipServiceHelper testHelper;
@@ -38,8 +37,8 @@ public class IndexFilteringServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, USERNAME,
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
+                tmpFolder, PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID,
+                BxcEnvironmentHelper.DEFAULT_ENV_ID, MigrationProject.PROJECT_SOURCE_CDM);
         testHelper = new SipServiceHelper(project, tmpFolder);
         service = new IndexFilteringService();
         service.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactoryTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactoryTest.java
@@ -3,6 +3,7 @@ package edu.unc.lib.boxc.migration.cdm.services;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -196,6 +197,38 @@ public class MigrationProjectFactoryTest {
 
         assertReturnedPropertiesPopulated(projectLoaded, PROJ_NAME, COLL_ID);
         assertPropertiesFilePopulated(projectLoaded, PROJ_NAME, COLL_ID);
+
+        assertEquals(projectCreated.getProjectProperties().getCreatedDate(),
+                projectLoaded.getProjectProperties().getCreatedDate(),
+                "Expect created and loaded projects to have same timestamp");
+    }
+
+    @Test
+    public void createFilesMigrationTest() throws Exception {
+        Path projectPath = projectsBase.resolve(PROJ_NAME);
+        MigrationProject projectCreated = MigrationProjectFactory
+                .createFilesMigrationProject(projectsBase, PROJ_NAME, USERNAME, bxcTestEnv);
+
+        MigrationProject projectLoaded = MigrationProjectFactory.loadMigrationProject(projectPath);
+
+        assertNotNull(projectLoaded);
+        assertEquals(projectPath, projectLoaded.getProjectPath());
+
+        MigrationProjectProperties returnedProperties = projectLoaded.getProjectProperties();
+        assertEquals(USERNAME, returnedProperties.getCreator());
+        assertEquals(PROJ_NAME, returnedProperties.getName(), "Project name did not match expected value");
+        assertNull(returnedProperties.getCdmCollectionId());
+        assertNotNull(returnedProperties.getCreatedDate(), "Created date not set");
+        assertNull(returnedProperties.getCdmEnvironmentId());
+
+        Path propertiesPath = projectLoaded.getProjectPropertiesPath();
+        assertTrue(Files.exists(propertiesPath), "Properties object must exist");
+        MigrationProjectProperties propertiesFile = ProjectPropertiesSerialization.read(propertiesPath);
+        assertEquals(USERNAME, propertiesFile.getCreator());
+        assertEquals(PROJ_NAME, propertiesFile.getName(), "Project name did not match expected value");
+        assertNull(propertiesFile.getCdmCollectionId());
+        assertNotNull(propertiesFile.getCreatedDate(), "Created date not set");
+        assertNull(propertiesFile.getCdmEnvironmentId());
 
         assertEquals(projectCreated.getProjectProperties().getCreatedDate(),
                 projectLoaded.getProjectProperties().getCreatedDate(),

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactoryTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactoryTest.java
@@ -217,6 +217,7 @@ public class MigrationProjectFactoryTest {
         MigrationProjectProperties returnedProperties = projectLoaded.getProjectProperties();
         assertEquals(USERNAME, returnedProperties.getCreator());
         assertEquals(PROJ_NAME, returnedProperties.getName(), "Project name did not match expected value");
+        assertEquals(MigrationProject.PROJECT_SOURCE_FILES, returnedProperties.getProjectSource());
         assertNull(returnedProperties.getCdmCollectionId());
         assertNotNull(returnedProperties.getCreatedDate(), "Created date not set");
         assertNull(returnedProperties.getCdmEnvironmentId());
@@ -226,6 +227,7 @@ public class MigrationProjectFactoryTest {
         MigrationProjectProperties propertiesFile = ProjectPropertiesSerialization.read(propertiesPath);
         assertEquals(USERNAME, propertiesFile.getCreator());
         assertEquals(PROJ_NAME, propertiesFile.getName(), "Project name did not match expected value");
+        assertEquals(MigrationProject.PROJECT_SOURCE_FILES, propertiesFile.getProjectSource());
         assertNull(propertiesFile.getCdmCollectionId());
         assertNotNull(propertiesFile.getCreatedDate(), "Created date not set");
         assertNull(propertiesFile.getCdmEnvironmentId());

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactoryTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationProjectFactoryTest.java
@@ -11,6 +11,7 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,7 @@ public class MigrationProjectFactoryTest {
     public Path tmpFolder;
     private Path projectsBase;
     private String testEnv = CdmEnvironmentHelper.DEFAULT_ENV_ID;
+    private String bxcTestEnv = BxcEnvironmentHelper.DEFAULT_ENV_ID;
 
     @BeforeEach
     public void setup() throws Exception {
@@ -42,7 +44,8 @@ public class MigrationProjectFactoryTest {
     @Test
     public void createNoUserTest() throws Exception {
         try {
-            MigrationProjectFactory.createMigrationProject(projectsBase, null, null, null, testEnv);
+            MigrationProjectFactory.createCdmMigrationProject(projectsBase, null, null, null,
+                    testEnv, bxcTestEnv);
             fail();
         } catch (IllegalArgumentException e) {
             // Expected
@@ -53,7 +56,7 @@ public class MigrationProjectFactoryTest {
     @Test
     public void createWithNameTest() throws Exception {
         MigrationProject project = MigrationProjectFactory
-                .createMigrationProject(projectsBase, PROJ_NAME, null, USERNAME, testEnv);
+                .createCdmMigrationProject(projectsBase, PROJ_NAME, null, USERNAME, testEnv, bxcTestEnv);
 
         assertNotNull(project);
         assertEquals(projectsBase.resolve(PROJ_NAME), project.getProjectPath());
@@ -68,7 +71,7 @@ public class MigrationProjectFactoryTest {
         Files.createDirectory(projectsBase.resolve(PROJ_NAME));
 
         MigrationProject project = MigrationProjectFactory
-                .createMigrationProject(projectsBase, PROJ_NAME, null, USERNAME, testEnv);
+                .createCdmMigrationProject(projectsBase, PROJ_NAME, null, USERNAME, testEnv, bxcTestEnv);
 
         assertNotNull(project);
         assertEquals(projectsBase.resolve(PROJ_NAME), project.getProjectPath());
@@ -82,7 +85,7 @@ public class MigrationProjectFactoryTest {
         Files.createFile(projectsBase.resolve(PROJ_NAME));
         try {
             // Create file at expected project path
-            MigrationProjectFactory.createMigrationProject(projectsBase, PROJ_NAME, null, USERNAME, testEnv);
+            MigrationProjectFactory.createCdmMigrationProject(projectsBase, PROJ_NAME, null, USERNAME, testEnv, bxcTestEnv);
             fail();
         } catch (InvalidProjectStateException e) {
             assertTrue(e.getMessage().contains("already exists and is not a directory"));
@@ -92,7 +95,7 @@ public class MigrationProjectFactoryTest {
     @Test
     public void createWithNameAndCollectionTest() throws Exception {
         MigrationProject project = MigrationProjectFactory
-                .createMigrationProject(projectsBase, PROJ_NAME, COLL_ID, USERNAME, testEnv);
+                .createCdmMigrationProject(projectsBase, PROJ_NAME, COLL_ID, USERNAME, testEnv, bxcTestEnv);
 
         assertNotNull(project);
         assertEquals(projectsBase.resolve(PROJ_NAME), project.getProjectPath());
@@ -108,7 +111,7 @@ public class MigrationProjectFactoryTest {
         Files.createDirectory(projectPath);
 
         MigrationProject project = MigrationProjectFactory
-                .createMigrationProject(projectPath, null, null, USERNAME, testEnv);
+                .createCdmMigrationProject(projectPath, null, null, USERNAME, testEnv, bxcTestEnv);
 
         assertNotNull(project);
         assertEquals(projectPath, project.getProjectPath());
@@ -124,7 +127,7 @@ public class MigrationProjectFactoryTest {
         Files.createDirectory(projectPath);
 
         MigrationProject project = MigrationProjectFactory
-                .createMigrationProject(projectPath, null, COLL_ID, USERNAME, testEnv);
+                .createCdmMigrationProject(projectPath, null, COLL_ID, USERNAME, testEnv, bxcTestEnv);
 
         assertNotNull(project);
         assertEquals(projectPath, project.getProjectPath());
@@ -136,11 +139,11 @@ public class MigrationProjectFactoryTest {
     @Test
     public void createProjectAlreadyExistsTest() throws Exception {
         MigrationProject project = MigrationProjectFactory
-                .createMigrationProject(projectsBase, PROJ_NAME, null, USERNAME, testEnv);
+                .createCdmMigrationProject(projectsBase, PROJ_NAME, null, USERNAME, testEnv, bxcTestEnv);
 
         try {
             // Create file at expected project path
-            MigrationProjectFactory.createMigrationProject(projectsBase, PROJ_NAME, COLL_ID, USERNAME, testEnv);
+            MigrationProjectFactory.createCdmMigrationProject(projectsBase, PROJ_NAME, COLL_ID, USERNAME, testEnv, bxcTestEnv);
             fail();
         } catch (InvalidProjectStateException e) {
             assertTrue(e.getMessage().contains("directory already contains a migration project"));
@@ -184,7 +187,7 @@ public class MigrationProjectFactoryTest {
     public void loadValidProject() throws Exception {
         Path projectPath = projectsBase.resolve(PROJ_NAME);
         MigrationProject projectCreated = MigrationProjectFactory
-                .createMigrationProject(projectsBase, PROJ_NAME, COLL_ID, USERNAME, testEnv);
+                .createCdmMigrationProject(projectsBase, PROJ_NAME, COLL_ID, USERNAME, testEnv, bxcTestEnv);
 
         MigrationProject projectLoaded = MigrationProjectFactory.loadMigrationProject(projectPath);
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationTypeReportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationTypeReportServiceTest.java
@@ -38,8 +38,8 @@ public class MigrationTypeReportServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, "proj", null, "user",
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
+                tmpFolder, "proj", null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID,
+                BxcEnvironmentHelper.DEFAULT_ENV_ID, MigrationProject.PROJECT_SOURCE_CDM);
         testHelper = new SipServiceHelper(project, tmpFolder);
         reportGenerator = new PostMigrationReportService();
         reportGenerator.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationTypeReportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationTypeReportServiceTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author krwong
  */
 public class MigrationTypeReportServiceTest {
+    private static final String PROJECT_SOURCE = "cdm";
     private static final String BOXC_BASE_URL = "http://localhost:46887/bxc/record/";
     private static final String BOXC_ID_1 = "bb3b83d7-2962-4604-a7d0-9afcb4ec99b1";
     private static final String BOXC_ID_2 = "91c08272-260f-40f1-bb7c-78854d504368";
@@ -38,7 +39,7 @@ public class MigrationTypeReportServiceTest {
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
                 tmpFolder, "proj", null, "user",
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
         testHelper = new SipServiceHelper(project, tmpFolder);
         reportGenerator = new PostMigrationReportService();
         reportGenerator.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationTypeReportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/MigrationTypeReportServiceTest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author krwong
  */
 public class MigrationTypeReportServiceTest {
-    private static final String PROJECT_SOURCE = "cdm";
     private static final String BOXC_BASE_URL = "http://localhost:46887/bxc/record/";
     private static final String BOXC_ID_1 = "bb3b83d7-2962-4604-a7d0-9afcb4ec99b1";
     private static final String BOXC_ID_2 = "91c08272-260f-40f1-bb7c-78854d504368";

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -39,6 +39,7 @@ import static org.mockito.MockitoAnnotations.openMocks;
 
 public class PermissionsServiceTest {
     private static final String PROJECT_NAME = "proj";
+    private static final String PROJECT_SOURCE = "cdm";
 
     @TempDir
     public Path tmpFolder;
@@ -53,7 +54,7 @@ public class PermissionsServiceTest {
         closeable = openMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
                 tmpFolder, PROJECT_NAME, null, "user",
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
         testHelper = new SipServiceHelper(project, tmpFolder);
         service = new PermissionsService();
         service.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -39,7 +39,6 @@ import static org.mockito.MockitoAnnotations.openMocks;
 
 public class PermissionsServiceTest {
     private static final String PROJECT_NAME = "proj";
-    private static final String PROJECT_SOURCE = "cdm";
 
     @TempDir
     public Path tmpFolder;
@@ -53,8 +52,8 @@ public class PermissionsServiceTest {
     public void setup() throws Exception {
         closeable = openMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user",
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID,
+                BxcEnvironmentHelper.DEFAULT_ENV_ID, MigrationProject.PROJECT_SOURCE_CDM);
         testHelper = new SipServiceHelper(project, tmpFolder);
         service = new PermissionsService();
         service.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportServiceTest.java
@@ -26,7 +26,6 @@ import static org.mockito.MockitoAnnotations.openMocks;
  * @author bbpennel
  */
 public class PostMigrationReportServiceTest {
-    protected final static String PROJECT_SOURCE = "cdm";
     private static final String BOXC_BASE_URL = "http://localhost:46887/bxc/record/";
     private static final String BOXC_ID_1 = "bb3b83d7-2962-4604-a7d0-9afcb4ec99b1";
     private static final String BOXC_ID_2 = "91c08272-260f-40f1-bb7c-78854d504368";
@@ -48,8 +47,8 @@ public class PostMigrationReportServiceTest {
     public void setup() throws Exception {
         closeable = openMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, "proj", null, "user",
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
+                tmpFolder, "proj", null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID,
+                BxcEnvironmentHelper.DEFAULT_ENV_ID, MigrationProject.PROJECT_SOURCE_CDM);
         testHelper = new SipServiceHelper(project, tmpFolder);
         descriptionsService = testHelper.getDescriptionsService();
         sourceFileService = testHelper.getSourceFileService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportServiceTest.java
@@ -26,6 +26,7 @@ import static org.mockito.MockitoAnnotations.openMocks;
  * @author bbpennel
  */
 public class PostMigrationReportServiceTest {
+    protected final static String PROJECT_SOURCE = "cdm";
     private static final String BOXC_BASE_URL = "http://localhost:46887/bxc/record/";
     private static final String BOXC_ID_1 = "bb3b83d7-2962-4604-a7d0-9afcb4ec99b1";
     private static final String BOXC_ID_2 = "91c08272-260f-40f1-bb7c-78854d504368";
@@ -48,7 +49,7 @@ public class PostMigrationReportServiceTest {
         closeable = openMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
                 tmpFolder, "proj", null, "user",
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
         testHelper = new SipServiceHelper(project, tmpFolder);
         descriptionsService = testHelper.getDescriptionsService();
         sourceFileService = testHelper.getSourceFileService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportVerifierTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportVerifierTest.java
@@ -34,6 +34,7 @@ import static org.mockito.MockitoAnnotations.openMocks;
  * @author bbpennel
  */
 public class PostMigrationReportVerifierTest {
+    protected final static String PROJECT_SOURCE = "cdm";
     private static final String BOXC_URL_1 = "http://example.com/bxc/bb3b83d7-2962-4604-a7d0-9afcb4ec99b1";
     private static final String BOXC_URL_2 = "http://example.com/bxc/91c08272-260f-40f1-bb7c-78854d504368";
     private static final String CDM_URL_1 = "http://localhost/cdm/singleitem/collection/proj/id/25";
@@ -53,7 +54,7 @@ public class PostMigrationReportVerifierTest {
         closeable = openMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
                 tmpFolder, "proj", null, "user",
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
         testHelper = new SipServiceHelper(project, tmpFolder);
         reportGenerator = new PostMigrationReportService();
         reportGenerator.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportVerifierTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PostMigrationReportVerifierTest.java
@@ -34,7 +34,6 @@ import static org.mockito.MockitoAnnotations.openMocks;
  * @author bbpennel
  */
 public class PostMigrationReportVerifierTest {
-    protected final static String PROJECT_SOURCE = "cdm";
     private static final String BOXC_URL_1 = "http://example.com/bxc/bb3b83d7-2962-4604-a7d0-9afcb4ec99b1";
     private static final String BOXC_URL_2 = "http://example.com/bxc/91c08272-260f-40f1-bb7c-78854d504368";
     private static final String CDM_URL_1 = "http://localhost/cdm/singleitem/collection/proj/id/25";
@@ -53,8 +52,8 @@ public class PostMigrationReportVerifierTest {
     public void setup() throws Exception {
         closeable = openMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, "proj", null, "user",
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
+                tmpFolder, "proj", null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID,
+                BxcEnvironmentHelper.DEFAULT_ENV_ID, MigrationProject.PROJECT_SOURCE_CDM);
         testHelper = new SipServiceHelper(project, tmpFolder);
         reportGenerator = new PostMigrationReportService();
         reportGenerator.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ProjectPropertiesServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/ProjectPropertiesServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,8 +36,9 @@ public class ProjectPropertiesServiceTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, "user",
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
         service = new ProjectPropertiesService();
         service.setProject(project);
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingIndexServiceTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class RedirectMappingIndexServiceTest {
     private static final String PROJECT_NAME = "proj";
     private static final String DEST_UUID = "7a33f5e6-f0ca-461c-8df0-c76c62198b17";
+    protected final static String PROJECT_SOURCE = "cdm";
 
     @TempDir
     public Path tmpFolder;
@@ -49,7 +50,7 @@ public class RedirectMappingIndexServiceTest {
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
                 tmpFolder, PROJECT_NAME, null, "user",
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
         testHelper = new SipServiceHelper(project, tmpFolder);
         redirectMappingHelper = new RedirectMappingHelper(project);
         redirectMappingHelper.createRedirectMappingsTableInDb();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingIndexServiceTest.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class RedirectMappingIndexServiceTest {
     private static final String PROJECT_NAME = "proj";
     private static final String DEST_UUID = "7a33f5e6-f0ca-461c-8df0-c76c62198b17";
-    protected final static String PROJECT_SOURCE = "cdm";
 
     @TempDir
     public Path tmpFolder;

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingIndexServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/RedirectMappingIndexServiceTest.java
@@ -49,8 +49,8 @@ public class RedirectMappingIndexServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user",
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID,
+                BxcEnvironmentHelper.DEFAULT_ENV_ID, MigrationProject.PROJECT_SOURCE_CDM);
         testHelper = new SipServiceHelper(project, tmpFolder);
         redirectMappingHelper = new RedirectMappingHelper(project);
         redirectMappingHelper.createRedirectMappingsTableInDb();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -79,6 +79,7 @@ import static org.mockito.MockitoAnnotations.openMocks;
 public class SipServiceTest {
     private static final String PROJECT_NAME = "proj";
     private static final String USERNAME = "migr_user";
+    private static final String PROJECT_SOURCE = "cdm";
     private static final String DEST_UUID = "bfe93126-849a-43a5-b9d9-391e18ffacc6";
     private static final String DEST_UUID2 = "8ae56bbc-400e-496d-af4b-3c585e20dba1";
     private static final String DEST_UUID3 = "bdbd99af-36a5-4bab-9785-e3a802d3737e";
@@ -103,7 +104,7 @@ public class SipServiceTest {
         closeable = openMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
                 tmpFolder, PROJECT_NAME, null, USERNAME,
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
 
         testHelper = new SipServiceHelper(project, tmpFolder);
         service = testHelper.createSipsService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SipServiceTest.java
@@ -79,7 +79,6 @@ import static org.mockito.MockitoAnnotations.openMocks;
 public class SipServiceTest {
     private static final String PROJECT_NAME = "proj";
     private static final String USERNAME = "migr_user";
-    private static final String PROJECT_SOURCE = "cdm";
     private static final String DEST_UUID = "bfe93126-849a-43a5-b9d9-391e18ffacc6";
     private static final String DEST_UUID2 = "8ae56bbc-400e-496d-af4b-3c585e20dba1";
     private static final String DEST_UUID3 = "bdbd99af-36a5-4bab-9785-e3a802d3737e";
@@ -103,8 +102,8 @@ public class SipServiceTest {
     public void setup() throws Exception {
         closeable = openMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, USERNAME,
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
+                tmpFolder, PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID,
+                BxcEnvironmentHelper.DEFAULT_ENV_ID, MigrationProject.PROJECT_SOURCE_CDM);
 
         testHelper = new SipServiceHelper(project, tmpFolder);
         service = testHelper.createSipsService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
@@ -13,10 +13,8 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.List;
 
-import edu.unc.lib.boxc.migration.cdm.AbstractOutputTest;
-import edu.unc.lib.boxc.migration.cdm.status.SourceFilesSummaryService;
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
-import edu.unc.lib.boxc.migration.cdm.test.OutputHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,8 +48,9 @@ public class SourceFileServiceTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, "user",
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
         Files.createDirectories(project.getExportPath());
 
         basePath = tmpFolder.resolve("testFolder");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/StreamingMetadataServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/StreamingMetadataServiceTest.java
@@ -20,7 +20,6 @@ import static org.mockito.MockitoAnnotations.openMocks;
 
 public class StreamingMetadataServiceTest {
     private static final String PROJECT_NAME = "proj";
-    private static final String PROJECT_SOURCE = "cdm";
 
     @TempDir
     public Path tmpFolder;
@@ -34,8 +33,8 @@ public class StreamingMetadataServiceTest {
     public void setup() throws Exception {
         closeable = openMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user",
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID,
+                BxcEnvironmentHelper.DEFAULT_ENV_ID, MigrationProject.PROJECT_SOURCE_CDM);
         testHelper = new SipServiceHelper(project, tmpFolder);
         service = new StreamingMetadataService();
         service.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/StreamingMetadataServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/StreamingMetadataServiceTest.java
@@ -20,6 +20,7 @@ import static org.mockito.MockitoAnnotations.openMocks;
 
 public class StreamingMetadataServiceTest {
     private static final String PROJECT_NAME = "proj";
+    private static final String PROJECT_SOURCE = "cdm";
 
     @TempDir
     public Path tmpFolder;
@@ -34,7 +35,7 @@ public class StreamingMetadataServiceTest {
         closeable = openMocks(this);
         project = MigrationProjectFactory.createMigrationProject(
                 tmpFolder, PROJECT_NAME, null, "user",
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
         testHelper = new SipServiceHelper(project, tmpFolder);
         service = new StreamingMetadataService();
         service.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportProgressServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportProgressServiceTest.java
@@ -3,6 +3,7 @@ package edu.unc.lib.boxc.migration.cdm.services.export;
 import edu.unc.lib.boxc.migration.cdm.AbstractOutputTest;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,8 +22,9 @@ public class ExportProgressServiceTest extends AbstractOutputTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, "user",
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);
         exportProgressService = new ExportProgressService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class ExportStateServiceTest {
     private static final String PROJECT_NAME = "proj";
-    private static final String PROJECT_SOURCE = "cdm";
     @TempDir
     public Path tmpFolder;
 
@@ -38,8 +37,8 @@ public class ExportStateServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user",
-                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID,
+                BxcEnvironmentHelper.DEFAULT_ENV_ID, MigrationProject.PROJECT_SOURCE_CDM);
         Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
@@ -36,7 +36,7 @@ public class ExportStateServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID);
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID, null, null);
         Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/export/ExportStateServiceTest.java
@@ -4,6 +4,7 @@ import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class ExportStateServiceTest {
     private static final String PROJECT_NAME = "proj";
+    private static final String PROJECT_SOURCE = "cdm";
     @TempDir
     public Path tmpFolder;
 
@@ -36,7 +38,8 @@ public class ExportStateServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID, null, null);
+                tmpFolder, PROJECT_NAME, null, "user",
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID, PROJECT_SOURCE);
         Files.copy(Paths.get("src/test/resources/gilmer_fields.csv"), project.getFieldsPath());
         exportStateService = new ExportStateService();
         exportStateService.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/status/DestinationsStatusServiceTest.java
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
 
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,8 +36,9 @@ public class DestinationsStatusServiceTest extends AbstractOutputTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, USERNAME,
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
 
         testHelper = new SipServiceHelper(project, tmpFolder);
         statusService = new DestinationsStatusService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesStatusServiceTest.java
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
 
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,8 +36,9 @@ public class SourceFilesStatusServiceTest extends AbstractOutputTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, USERNAME,
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
 
         testHelper = new SipServiceHelper(project, tmpFolder);
         statusService = new SourceFilesStatusService();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesSummaryServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesSummaryServiceTest.java
@@ -6,6 +6,7 @@ import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo;
 import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.services.SourceFileService;
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
@@ -36,8 +37,9 @@ public class SourceFilesSummaryServiceTest extends AbstractOutputTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, USERNAME,
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
 
         basePath = tmpFolder.resolve("testFolder");
         Files.createDirectory(basePath);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DescriptionsValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DescriptionsValidatorTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.jdom2.Document;
@@ -38,8 +39,9 @@ public class DescriptionsValidatorTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, USERNAME,
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
 
         validator = new DescriptionsValidator();
         validator.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DestinationsValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/DestinationsValidatorTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Assertions;
@@ -38,8 +39,9 @@ public class DestinationsValidatorTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, USERNAME,
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
 
         validator = new DestinationsValidator();
         validator.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/PermissionsValidatorTest.java
@@ -5,6 +5,7 @@ import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.PermissionsInfo;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.services.PermissionsService;
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Assertions;
@@ -32,8 +33,9 @@ public class PermissionsValidatorTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, USERNAME,
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
 
         validator = new PermissionsValidator();
         validator.setProject(project);

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/SourceFilesValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/SourceFilesValidatorTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Assertions;
@@ -37,8 +38,9 @@ public class SourceFilesValidatorTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        project = MigrationProjectFactory.createMigrationProject(
-                tmpFolder, PROJECT_NAME, null, USERNAME, CdmEnvironmentHelper.DEFAULT_ENV_ID);
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, USERNAME,
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
 
         testHelper = new SipServiceHelper(project, tmpFolder);
         validator = new SourceFilesValidator();


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4635](https://unclibrary.atlassian.net/browse/BXC-4635)

- `InitializeProjectCommand`: add `-s, --source` option to init a new chompb project that doesn't need to be linked to a CDM collection
- `MigrationProjectFactory`: `CdmCollectionId` is `null` when `CdmEnvId` is `null`
- add test