### PR TITLE
BXC-4621 - Divide by zero in source_file generate status

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesSummaryService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/SourceFilesSummaryService.java
@@ -147,8 +147,12 @@ public class SourceFilesSummaryService extends AbstractStatusService {
         List<CSVRecord> sampleListNewFiles;
 
         // select every nth file
-        int interval = completeListNewFiles.size() / sampleSize;
-
+        int interval;
+        if (completeListNewFiles.size() <= sampleSize) {
+            interval = 1;
+        } else {
+            interval = completeListNewFiles.size() / sampleSize;
+        }
         sampleListNewFiles = IntStream.range(0, completeListNewFiles.size())
                 .filter(n -> n % interval == 0)
                 .mapToObj(completeListNewFiles::get)


### PR DESCRIPTION
The issue was that when the number of newly mapped files was less than the sample_size, we would end up with an interval of 0, which produced a divide by zero when selecting every Nth result to display. 

For example, if there was one new file mapped, and the sample size was 20, then we would calculate the interval of results to display by doing 1/20, which comes out to 0 since the values are integers.

https://unclibrary.atlassian.net/browse/BXC-4621

* Add test to replicate divide by zero during reporting error, and set minimum interval to 1