### PR TITLE
BXC-4728 update source files reporting

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/status/ProjectStatusService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/status/ProjectStatusService.java
@@ -85,7 +85,9 @@ public class ProjectStatusService extends AbstractStatusService {
         sectionDivider();
 
         outputLogger.info("Source File Mappings");
-        reportSourceMappings(totalObjects);
+        // exclude group/compound objects since they don't have source files
+        int totalObjectsOnlyFileObjects = getQueryService().countIndexedFileObjects();
+        reportSourceMappings(totalObjectsOnlyFileObjects);
         sectionDivider();
 
         outputLogger.info("Access File Mappings");

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/StatusCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/StatusCommandIT.java
@@ -356,7 +356,7 @@ public class StatusCommandIT extends AbstractCommandIT {
         assertOutputMatches(".*Destinations: +1\n.*");
 
         assertOutputMatches(".*Source File Mappings\n +Last Updated: +[0-9\\-T:]+.*");
-        assertOutputMatches(".*Source File Mappings\n.*\n +Objects Mapped: +5 \\(71.4%\\).*");
+        assertOutputMatches(".*Source File Mappings\n.*\n +Objects Mapped: +5 \\(100.0%\\).*");
 
         assertOutputMatches(".*Access File Mappings\n +Last Updated: +Not completed.*");
         assertOutputMatches(".*Submission Information Packages\n +Last Generated: +[0-9\\-T:]+.*");


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4728](https://unclibrary.atlassian.net/browse/BXC-4728)

- exclude group/compound objects from `totalObjects` in `chompb status` source files reporting