### PR TITLE
BXC-5668 - Email on velocicroptor failure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# AGENTS.md — Chompb (CDM to Box-c Migration Utility)
+
+## Project Overview
+Java 21 CLI tool (picocli) that migrates collections from CONTENTdm (CDM) to the Box-c repository. Built as a fat JAR with Maven Shade. Depends on the `box-c` parent project (must be built locally first).
+
+## Build & Test
+```bash
+mvn clean package          # full build with tests
+mvn test                   # run unit tests only
+mvn verify                 # run all tests including integration
+```
+- Some ITs require external ActiveMQ (use Docker Compose from box-c project).
+- Parent POM is `edu.unc.lib.cdr:cdr` (box-c repo). Must be installed locally via `mvn clean install -DskipTests` in box-c before building chompb.
+- Artifact: `target/cdm2bxc.jar`; main class: `edu.unc.lib.boxc.migration.cdm.CLIMain`
+
+## Architecture & Data Flow
+```
+CDM server → export XMLs → cdm_index.db (SQLite) → CSV mappings → SIPs → Box-c deposit
+```
+1. **Init** – creates project directory with `.project.json`
+2. **Export** – fetches CDM XML records via `CdmExportService`/`CdmFileRetrievalService` (SSH or HTTP)
+3. **Index** – `CdmIndexService` parses XML into SQLite (`cdm_index.db`) with entry-type metadata
+4. **Map** – separate services produce CSV files: `destinations.csv`, `source_files.csv`, `access_files.csv`, `group_mappings.csv`
+5. **SIP generation** – `SipService` reads all CSVs + expanded MODS descriptions, emits RDF/N3 model (`model.n3`) + deposit layout under `sips/<uuid>/`
+6. **Submit** – `SipSubmissionService` sends SIPs to Box-c deposit ActiveMQ endpoint
+
+## Key Source Directories
+| Path | Purpose |
+|------|---------|
+| `src/main/java/.../migration/cdm/` | All commands, services, model, validators |
+| `src/main/java/.../migration/cdm/services/sips/` | SIP construction (`WorkGenerator`, `WorkGeneratorFactory`, `CdmToDestMapper`) |
+| `src/main/java/.../migration/cdm/model/MigrationProject.java` | Central file-path constants for every project artifact |
+| `src/test/java/.../migration/cdm/test/SipServiceHelper.java` | Test harness — wires all services; reference for service dependency graph |
+| `src/test/java/.../migration/cdm/AbstractCommandIT.java` | Base class for all command integration tests |
+
+## CDM Object Types (in SQLite `entry_type` column)
+Defined in `CdmIndexService`:
+- `cpd_object` — compound object parent
+- `cpd_child` — compound object child
+- `grouped_work` — manually grouped work
+- `doc_pdf` — document/PDF type
+
+## CSV Mapping Conventions
+All mapping CSVs use Apache Commons CSV. Headers are defined as constants in the corresponding `*Info` model class (e.g., `SourceFilesInfo`, `DestinationsInfo`). The first column is always the CDM object ID. A blank/missing value means unmapped.
+
+## Configuration
+`ChompbConfigService` reads a JSON config file (path passed via CLI `-c`) with `cdmEnvironments` and `bxcEnvironments` maps. See `CdmEnvironment` and `BxcEnvironment` for fields. Tests use `CdmEnvironmentHelper` / `BxcEnvironmentHelper` stubs.
+
+## Testing Patterns
+- Integration tests (`*IT.java`) extend `AbstractCommandIT` → `AbstractOutputTest`, which sets up a temp directory and a real `CommandLine(new CLIMain())` instance.
+- Use `SipServiceHelper` to bootstrap a full in-memory project state (index, descriptions, mappings) before asserting SIP contents.
+- Test descriptions live under `src/test/resources/descriptions/<collection>/`; CDM export fixtures under `src/test/resources/descriptions/` and `src/test/resources/files/`.
+- WireMock (`wiremock`) stubs CDM HTTP API calls in export tests.
+
+## Adding a New Command
+1. Create `FooCommand.java` (picocli `@Command`) in the commands package; inject services via setters.
+2. Register it in `CLIMain.java` `@Command(subcommands = {...})`.
+3. Create corresponding `FooService.java` in `services/`; accept a `MigrationProject` and call `getIndexPath()` / other path accessors.
+4. Add an IT extending `AbstractCommandIT`.
+
+## Checkstyle
+Checkstyle is enforced at build time: `checkstyle/checkstyle.xml` + `checkstyle/checkstyle-suppressions.xml` (inherited from box-c parent). Violations fail the build.
+

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,11 @@
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-client</artifactId>
         </dependency>
+        <!-- email -->
+        <dependency>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>jakarta.mail</artifactId>
+        </dependency>
         <!-- Testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/ProcessSourceFilesCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/ProcessSourceFilesCommand.java
@@ -6,6 +6,7 @@ import edu.unc.lib.boxc.migration.cdm.model.BxcEnvironment;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.options.ProcessSourceFilesOptions;
 import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
+import edu.unc.lib.boxc.migration.cdm.services.EmailService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.services.SourceFileService;
 import edu.unc.lib.boxc.migration.cdm.services.SourceFilesToRemoteService;
@@ -105,6 +106,7 @@ public class ProcessSourceFilesCommand implements Callable<Integer> {
         var sourceFilesToRemoteService = new SourceFilesToRemoteService();
         sourceFilesToRemoteService.setSourceFileService(sourceFileService);
         sourceFilesToRemoteService.setSshClientService(sshClientTransferService);
+        var emailService = new EmailService();
         velocicroptorRemoteJob = new VelocicroptorRemoteJob();
         velocicroptorRemoteJob.setProject(project);
         velocicroptorRemoteJob.setSshClientService(sshClientScriptService);
@@ -114,5 +116,6 @@ public class ProcessSourceFilesCommand implements Callable<Integer> {
         velocicroptorRemoteJob.setAdminEmail(boxcEnv.getBoxctronAdminEmail());
         velocicroptorRemoteJob.setRemoteJobScriptsPath(boxcEnv.getBoxctronRemoteJobScriptsPath());
         velocicroptorRemoteJob.setSourceFilesToRemoteService(sourceFilesToRemoteService);
+        velocicroptorRemoteJob.setEmailService(emailService);
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/ProcessSourceFilesCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/ProcessSourceFilesCommand.java
@@ -107,6 +107,7 @@ public class ProcessSourceFilesCommand implements Callable<Integer> {
         sourceFilesToRemoteService.setSourceFileService(sourceFileService);
         sourceFilesToRemoteService.setSshClientService(sshClientTransferService);
         var emailService = new EmailService();
+        emailService.setSmtpHost("localhost");
         velocicroptorRemoteJob = new VelocicroptorRemoteJob();
         velocicroptorRemoteJob.setProject(project);
         velocicroptorRemoteJob.setSshClientService(sshClientScriptService);

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/jobs/VelocicroptorRemoteJob.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/jobs/VelocicroptorRemoteJob.java
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.options.ProcessSourceFilesOptions;
+import edu.unc.lib.boxc.migration.cdm.services.EmailService;
 import edu.unc.lib.boxc.migration.cdm.services.SourceFilesToRemoteService;
 import edu.unc.lib.boxc.migration.cdm.util.SshClientService;
 import org.slf4j.Logger;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -36,6 +36,7 @@ public class VelocicroptorRemoteJob {
     private SshClientService sshClientService;
     private MigrationProject project;
     private SourceFilesToRemoteService sourceFilesToRemoteService;
+    private EmailService emailService;
     private Path remoteProjectsPath;
     private Path remoteJobScriptsPath;
     private String adminEmail;
@@ -73,7 +74,13 @@ public class VelocicroptorRemoteJob {
             log.info("Executing remote job with command: {}", sbatchCommand);
             var response = sshClientService.executeRemoteCommand("sbatch " + scriptPath + " '" + configJson + "'");
             log.info("Job submitted with response: {}", response);
-        } catch (IOException e) {
+        } catch (Exception e) {
+            log.error("Failed to submit velocicroptor job for project {}", project.getProjectName(), e);
+            var subject = "Velocicroptor job submission failure for project " + project.getProjectName();
+            var body = "A failure occurred while submitting a velocicroptor job for project '"
+                    + project.getProjectName() + "'.\n\n"
+                    + EmailService.formatException(e);
+            emailService.sendEmail(subject, body, adminEmail, adminEmail, options.getEmailAddress());
             throw new MigrationException(e);
         }
         return jobId;
@@ -106,6 +113,10 @@ public class VelocicroptorRemoteJob {
 
     public void setSourceFilesToRemoteService(SourceFilesToRemoteService sourceFilesToRemoteService) {
         this.sourceFilesToRemoteService = sourceFilesToRemoteService;
+    }
+
+    public void setEmailService(EmailService emailService) {
+        this.emailService = emailService;
     }
 
     public void setRemoteProjectsPath(Path remoteProjectsPath) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/EmailService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/EmailService.java
@@ -1,0 +1,75 @@
+package edu.unc.lib.boxc.migration.cdm.services;
+
+import org.slf4j.Logger;
+
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Properties;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Service for sending email notifications
+ * @author bbpennel
+ */
+public class EmailService {
+    private static final Logger log = getLogger(EmailService.class);
+
+    private String smtpHost;
+    private int smtpPort = 25;
+
+    /**
+     * Send a plain-text email to one or more recipients.
+     * @param subject email subject
+     * @param body email body
+     * @param fromAddress sender address
+     * @param toAddresses one or more recipient addresses
+     */
+    public void sendEmail(String subject, String body, String fromAddress, String... toAddresses) {
+        Properties props = new Properties();
+        props.put("mail.smtp.host", smtpHost);
+        props.put("mail.smtp.port", String.valueOf(smtpPort));
+
+        Session session = Session.getInstance(props);
+        try {
+            MimeMessage message = new MimeMessage(session);
+            message.setFrom(new InternetAddress(fromAddress));
+            for (String to : toAddresses) {
+                message.addRecipient(Message.RecipientType.TO, new InternetAddress(to));
+            }
+            message.setSubject(subject);
+            message.setText(body);
+            Transport.send(message);
+            log.info("Email sent: subject='{}' to={}", subject, toAddresses);
+        } catch (MessagingException e) {
+            log.error("Failed to send email with subject '{}': {}", subject, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Format a Throwable's message and full stack trace as a string
+     * @param t the throwable
+     * @return formatted string
+     */
+    public static String formatException(Throwable t) {
+        StringWriter sw = new StringWriter();
+        t.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
+    }
+
+    public void setSmtpHost(String smtpHost) {
+        this.smtpHost = smtpHost;
+    }
+
+    public void setSmtpPort(int smtpPort) {
+        this.smtpPort = smtpPort;
+    }
+}
+

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/EmailService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/EmailService.java
@@ -22,8 +22,11 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class EmailService {
     private static final Logger log = getLogger(EmailService.class);
 
+    private static final int DEFAULT_TIMEOUT_MS = 10000;
+
     private String smtpHost;
     private int smtpPort = 25;
+    private int timeoutMs = DEFAULT_TIMEOUT_MS;
 
     /**
      * Send a plain-text email to one or more recipients.
@@ -36,6 +39,9 @@ public class EmailService {
         Properties props = new Properties();
         props.put("mail.smtp.host", smtpHost);
         props.put("mail.smtp.port", String.valueOf(smtpPort));
+        props.put("mail.smtp.connectiontimeout", String.valueOf(timeoutMs));
+        props.put("mail.smtp.timeout", String.valueOf(timeoutMs));
+        props.put("mail.smtp.writetimeout", String.valueOf(timeoutMs));
 
         Session session = Session.getInstance(props);
         try {
@@ -70,6 +76,10 @@ public class EmailService {
 
     public void setSmtpPort(int smtpPort) {
         this.smtpPort = smtpPort;
+    }
+
+    public void setTimeoutMs(int timeoutMs) {
+        this.timeoutMs = timeoutMs;
     }
 }
 

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/jobs/VelocicroptorRemoteJobTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/jobs/VelocicroptorRemoteJobTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.options.ProcessSourceFilesOptions;
+import edu.unc.lib.boxc.migration.cdm.services.EmailService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.services.SourceFilesToRemoteService;
 import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
@@ -25,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -45,6 +47,8 @@ public class VelocicroptorRemoteJobTest {
     private MigrationProject project;
     @Mock
     private SourceFilesToRemoteService sourceFilesToRemoteService;
+    @Mock
+    private EmailService emailService;
     private Path remoteProjectsPath;
     private Path remoteJobScriptsPath;
     private Path projectPath;
@@ -77,6 +81,7 @@ public class VelocicroptorRemoteJobTest {
         job.setAdminEmail(ADMIN_EMAIL);
         job.setOutputServer(OUTPUT_SERVER);
         job.setOutputPath(outputPath);
+        job.setEmailService(emailService);
     }
 
     @AfterEach
@@ -128,5 +133,11 @@ public class VelocicroptorRemoteJobTest {
         doThrow(new IOException("Failed to transfer files")).when(sourceFilesToRemoteService).transferFiles(any());
 
         assertThrows(MigrationException.class, () -> job.run(options));
+        verify(emailService).sendEmail(
+                eq("Velocicroptor job submission failure for project proj"),
+                anyString(),
+                eq(ADMIN_EMAIL),
+                eq(ADMIN_EMAIL),
+                eq(USER_EMAIL));
     }
 }


### PR DESCRIPTION
Part of https://unclibrary.atlassian.net/browse/BXC-5668

* Send an email to the submitted and admin account when velocicroptor job fails to start
* Adds an AGENTS.md file, which was generated by github copilot to help agents understand the project.