### PR TITLE
BXC-4414 add file permissions by filename matching

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommand.java
@@ -4,8 +4,10 @@ import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.options.PermissionMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
+import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.services.PermissionsService;
+import edu.unc.lib.boxc.migration.cdm.services.SourceFileService;
 import edu.unc.lib.boxc.migration.cdm.validators.PermissionsValidator;
 import org.slf4j.Logger;
 import picocli.CommandLine.Mixin;
@@ -31,6 +33,7 @@ public class PermissionsCommand {
 
     private MigrationProject project;
     private PermissionsService permissionsService;
+    private SourceFileService sourceFileService;
 
     @Command(name = "generate",
             description = { "Generate the permissions mapping file for this project. " +
@@ -108,7 +111,13 @@ public class PermissionsCommand {
     private void initialize() throws IOException {
         Path currentPath = parentCommand.getWorkingDirectory();
         project = MigrationProjectFactory.loadMigrationProject(currentPath);
+        CdmIndexService indexService = new CdmIndexService();
+        indexService.setProject(project);
+        sourceFileService = new SourceFileService();
+        sourceFileService.setIndexService(indexService);
+        sourceFileService.setProject(project);
         permissionsService = new PermissionsService();
         permissionsService.setProject(project);
+        permissionsService.setSourceFileService(sourceFileService);
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/PermissionMappingOptions.java
@@ -25,6 +25,11 @@ public class PermissionMappingOptions {
             description = "Work or File to add or update, can be cdmId or group work identifier")
     private String cdmId;
 
+    @Option(names = {"-fp", "--file-name-pattern"},
+            description = "Generate file permission for all entries with filenames that match the pattern. " +
+                    "Case insensitive and supports wildcarding (e.g. *.pdf matches .pdf and .PDF extensions")
+    private String filenamePattern;
+
     @Option(names = {"-e", "--everyone"},
             description = "The patron access role assigned to the “everyone” group.")
     private UserRole everyone;
@@ -61,6 +66,10 @@ public class PermissionMappingOptions {
         return withFiles;
     }
 
+    public void setWithFiles(boolean withFiles) {
+        this.withFiles = withFiles;
+    }
+
     public String getCdmId() {
         return cdmId;
     }
@@ -69,8 +78,12 @@ public class PermissionMappingOptions {
         this.cdmId = cdmId;
     }
 
-    public void setWithFiles(boolean withFiles) {
-        this.withFiles = withFiles;
+    public String getFilenamePattern() {
+        return filenamePattern;
+    }
+
+    public void setFilenamePattern(String filenamePattern) {
+        this.filenamePattern = filenamePattern;
     }
 
     public UserRole getEveryone() {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
@@ -7,6 +7,7 @@ import edu.unc.lib.boxc.migration.cdm.exceptions.StateAlreadyExistsException;
 import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.PermissionsInfo;
+import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo;
 import edu.unc.lib.boxc.migration.cdm.options.PermissionMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 import org.apache.commons.csv.CSVFormat;
@@ -31,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.slf4j.LoggerFactory.getLogger;
@@ -53,6 +55,7 @@ public class PermissionsService {
 
     private MigrationProject project;
     private CdmIndexService indexService;
+    private SourceFileService sourceFileService;
     private List<String> patronRoles;
 
     /**
@@ -292,7 +295,51 @@ public class PermissionsService {
         }
     }
 
-    private List<List<String>> updateCsvRecords(PermissionMappingOptions options) {
+    private Set<String> getFilenamePatternIds(PermissionMappingOptions options) throws IOException {
+        String wildcardPattern = options.getFilenamePattern();
+        if (wildcardPattern == null || wildcardPattern.isBlank()) {
+            throw new IllegalArgumentException("Must provide filename pattern");
+        }
+        Pattern regex = Pattern.compile(wildcardToRegex(wildcardPattern), Pattern.CASE_INSENSITIVE);
+
+        SourceFilesInfo sourceFiles = sourceFileService.loadMappings();
+
+        return sourceFiles.getMappings().stream()
+                .filter(entry -> entry.getSourcePaths() != null &&
+                    entry.getSourcePaths().stream().map(Object::toString)
+                        .anyMatch(sourcePath -> regex.matcher(sourcePath).matches()))
+                .map(entry -> entry.getCdmId())
+                .collect(Collectors.toSet());
+    }
+
+    private String wildcardToRegex(String wildcardPattern) {
+        StringBuilder regex = new StringBuilder();
+        regex.append("^");
+
+        for (int i = 0; i < wildcardPattern.length(); i++) {
+            char c = wildcardPattern.charAt(i);
+
+            switch (c) {
+                case '*':
+                    regex.append(".*");
+                    break;
+                case '?':
+                    regex.append(".");
+                    break;
+                default:
+                    if ("\\.[]{}()+-^$|".indexOf(c) >= 0) {
+                        regex.append("\\");
+                    }
+                    regex.append(c);
+                    break;
+            }
+        }
+
+        regex.append("$");
+        return regex.toString();
+    }
+
+    private List<List<String>> updateCsvRecords(PermissionMappingOptions options) throws IOException {
         List<CSVRecord> previousRecords = getPermissions();
         List<Map.Entry<String, String>> workAndFileRecords = new ArrayList<>();
         List<List<String>> updatedRecords = new ArrayList<>();
@@ -310,6 +357,13 @@ public class PermissionsService {
             workAndFileRecords.addAll(queryForMappedIds(options));
             Set<String> workFileIds = workAndFileRecords.stream().map(Map.Entry::getKey).collect(Collectors.toSet());
             addedAndUpdatedIds.addAll(workFileIds);
+        }
+        if (options.getFilenamePattern() != null) {
+            var cdmIds = getFilenamePatternIds(options);
+            for (String cdmId : cdmIds) {
+                workAndFileRecords.add(new AbstractMap.SimpleEntry<>(cdmId, getObjectType(cdmId)));
+            }
+            addedAndUpdatedIds.addAll(cdmIds);
         }
 
         // update existing entries and add unchanged entries to updatedRecords, then remove updated ids from updateIds
@@ -331,9 +385,9 @@ public class PermissionsService {
             }
         }
 
-        updatedRecords.sort(Comparator.comparing(entry -> entry.get(0)));
+        updatedRecords.sort(Comparator.comparing(entry -> entry.getFirst()));
         // move default entry to top if it exists
-        List<String> updatedIds = updatedRecords.stream().map(entry -> entry.get(0)).collect(Collectors.toList());
+        List<String> updatedIds = updatedRecords.stream().map(entry -> entry.getFirst()).toList();
         if (updatedIds.contains(PermissionsInfo.DEFAULT_ID)) {
             List<String> defaultEntry = updatedRecords.remove(updatedIds.indexOf(PermissionsInfo.DEFAULT_ID));
             updatedRecords.add(0, defaultEntry);
@@ -373,5 +427,9 @@ public class PermissionsService {
 
     public void setIndexService(CdmIndexService indexService) {
         this.indexService = indexService;
+    }
+
+    public void setSourceFileService(SourceFileService sourceFileService) {
+        this.sourceFileService = sourceFileService;
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsService.java
@@ -14,6 +14,7 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 
 import java.io.BufferedWriter;
@@ -307,7 +308,7 @@ public class PermissionsService {
         return sourceFiles.getMappings().stream()
                 .filter(entry -> entry.getSourcePaths() != null &&
                     entry.getSourcePaths().stream().map(Object::toString)
-                        .anyMatch(sourcePath -> regex.matcher(sourcePath).matches()))
+                        .anyMatch(sourcePath -> regex.matcher(FilenameUtils.getName(sourcePath)).matches()))
                 .map(entry -> entry.getCdmId())
                 .collect(Collectors.toSet());
     }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
@@ -320,6 +320,48 @@ public class PermissionsCommandIT extends AbstractCommandIT {
     }
 
     @Test
+    public void setPermissionsFilenameMatchingNewEntry() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "generate",
+                "-wd",
+                "--everyone", "canViewOriginals",
+                "--authenticated", "canViewOriginals"};
+        executeExpectSuccess(args);
+
+        String[] args2 = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "set",
+                "-fp", "*.tif",
+                "-e", "canViewMetadata",
+                "-a", "canViewMetadata"};
+        executeExpectSuccess(args2);
+        assertMapping(0, "default", "canViewOriginals", "canViewOriginals");
+        assertMapping(1, "25", "canViewMetadata", "canViewMetadata");
+        assertMapping(2, "26", "canViewMetadata", "canViewMetadata");
+        assertMapping(3, "27", "canViewMetadata", "canViewMetadata");
+    }
+
+    @Test
+    public void setPermissionsFilenameMatchingExistingEntry() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
+        FileUtils.write(project.getPermissionsPath().toFile(),
+                "25,,canViewOriginals,canViewOriginals", StandardCharsets.UTF_8, true);
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "set",
+                "-fp", "*.tif",
+                "-e", "canViewMetadata",
+                "-a", "canViewMetadata"};
+        executeExpectSuccess(args);
+        assertMapping(0, "25", "canViewMetadata", "canViewMetadata");
+    }
+
+    @Test
     public void validateValidDefaultPermissions() throws Exception {
         String[] args = new String[] {
                 "-w", project.getProjectPath().toString(),

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
@@ -1,8 +1,10 @@
 package edu.unc.lib.boxc.migration.cdm;
 
+import edu.unc.lib.boxc.auth.api.UserRole;
 import edu.unc.lib.boxc.migration.cdm.model.PermissionsInfo;
 import edu.unc.lib.boxc.migration.cdm.options.GroupMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.options.GroupMappingSyncOptions;
+import edu.unc.lib.boxc.migration.cdm.options.PermissionMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.services.PermissionsService;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PermissionsCommandIT extends AbstractCommandIT {
     @BeforeEach
@@ -359,6 +362,42 @@ public class PermissionsCommandIT extends AbstractCommandIT {
                 "-a", "canViewMetadata"};
         executeExpectSuccess(args);
         assertMapping(0, "25", "canViewMetadata", "canViewMetadata");
+        assertMapping(1, "26", "canViewMetadata", "canViewMetadata");
+        assertMapping(2, "27", "canViewMetadata", "canViewMetadata");
+    }
+
+    @Test
+    public void setPermissionsFilenameMatchingNoMatches() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
+        FileUtils.write(project.getPermissionsPath().toFile(),
+                "25,,canViewOriginals,canViewOriginals", StandardCharsets.UTF_8, true);
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "set",
+                "-fp", "*.png",
+                "-e", "canViewMetadata",
+                "-a", "canViewMetadata"};
+        executeExpectSuccess(args);
+    }
+
+    @Test
+    public void setPermissionFilenameMatchingNoPattern() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
+        FileUtils.write(project.getPermissionsPath().toFile(),
+                "25,,canViewOriginals,canViewOriginals", StandardCharsets.UTF_8, true);
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "set",
+                "-fp", "",
+                "-e", "canViewMetadata",
+                "-a", "canViewMetadata"};
+
+        executeExpectFailure(args);
+        assertOutputContains("Must provide filename pattern");
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
@@ -370,16 +370,25 @@ public class PermissionsCommandIT extends AbstractCommandIT {
     public void setPermissionsFilenameMatchingNoMatches() throws Exception {
         testHelper.indexExportData("mini_gilmer");
         testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
-        FileUtils.write(project.getPermissionsPath().toFile(),
-                "25,,canViewOriginals,canViewOriginals", StandardCharsets.UTF_8, true);
 
-        String[] args = new String[] {
+        String[] args1 = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "permissions", "generate",
+                "-wd",
+                "--everyone", "canViewOriginals",
+                "--authenticated", "canViewOriginals",
+                "--force"};
+        executeExpectSuccess(args1);
+
+        String[] args2 = new String[] {
                 "-w", project.getProjectPath().toString(),
                 "permissions", "set",
                 "-fp", "*.png",
                 "-e", "canViewMetadata",
                 "-a", "canViewMetadata"};
-        executeExpectSuccess(args);
+        executeExpectSuccess(args2);
+        assertMapping(0, "default", "canViewOriginals", "canViewOriginals");
+        assertMappingCount(1);
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/PermissionsCommandIT.java
@@ -407,6 +407,7 @@ public class PermissionsCommandIT extends AbstractCommandIT {
 
         executeExpectFailure(args);
         assertOutputContains("Must provide filename pattern");
+        assertMappingCount(0);
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -566,7 +566,7 @@ public class PermissionsServiceTest {
     }
 
     @Test
-    public void setPermissionsFilenameMatchingNewIds() throws Exception{
+    public void setPermissionsFilenameMatchingExtensionNewIds() throws Exception{
         testHelper.indexExportData("mini_gilmer");
         testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
         writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata"));
@@ -587,7 +587,7 @@ public class PermissionsServiceTest {
     }
 
     @Test
-    public void setPermissionFilenameMatchingExistingIds() throws Exception {
+    public void setPermissionFilenameMatchingExtensionExistingIds() throws Exception {
         testHelper.indexExportData("mini_gilmer");
         testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
         writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "26,work,none,none"));
@@ -605,6 +605,127 @@ public class PermissionsServiceTest {
         assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
         assertIterableEquals(Arrays.asList("26", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
         assertIterableEquals(Arrays.asList("27", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
+    }
+
+    @Test
+    public void setPermissionFilenameMatchingFilenameExistingIds() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
+        writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "26,work,none,none"));
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setFilenamePattern("276_*");
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.setPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
+    }
+
+    @Test
+    public void setPermissionFilenameMatchingNoMatches() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
+        writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "26,work,none,none"));
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setFilenamePattern("*.pdf");
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.setPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("26", "work", "none", "none"), rows.get(1));
+    }
+
+    @Test
+    public void setPermissionFilenameMatchingWildcareInMiddleofMatcher() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
+        writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "26,work,none,none"));
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setFilenamePattern("276_*E.tif");
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.setPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
+    }
+
+    @Test
+    public void setPermissionFilenameMatchingPartialMatches() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
+        writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "26,work,none,none"));
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setFilenamePattern("*182_E*");
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.setPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "work", "none", "none"), rows.get(2));
+    }
+
+    @Test
+    public void setPermissionFilenameMatchingQuestionMarkInMatcher() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
+        writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "26,work,none,none"));
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setFilenamePattern("*_?.tif");
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.setPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
+    }
+
+    @Test
+    public void setPermissionFilenameMatchingNoPattern() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
+        writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "26,work,none,none"));
+        var options = new PermissionMappingOptions();
+        options.setFilenamePattern("");
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            service.setPermissions(options);
+        });
+
+        String expectedMessage = "Must provide filename pattern";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
     }
 
     private String mappingBody(String... rows) {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -57,6 +57,7 @@ public class PermissionsServiceTest {
         testHelper = new SipServiceHelper(project, tmpFolder);
         service = new PermissionsService();
         service.setProject(project);
+        service.setSourceFileService(testHelper.getSourceFileService());
     }
 
     @AfterEach
@@ -562,6 +563,48 @@ public class PermissionsServiceTest {
         assertIterableEquals(Arrays.asList("605", "file", "canViewMetadata", "canViewMetadata"), rows.get(5));
         assertIterableEquals(Arrays.asList("606", "file", "canViewMetadata", "canViewMetadata"), rows.get(6));
         assertIterableEquals(Arrays.asList("607", "work", "canViewMetadata", "canViewMetadata"), rows.get(7));
+    }
+
+    @Test
+    public void setPermissionsFilenameMatchingNewIds() throws Exception{
+        testHelper.indexExportData("mini_gilmer");
+        testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
+        writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata"));
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setFilenamePattern("*.tif");
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.setPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
+    }
+
+    @Test
+    public void setPermissionFilenameMatchingExistingIds() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
+        writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "26,work,none,none"));
+        Path permissionsMappingPath = project.getPermissionsPath();
+        var options = new PermissionMappingOptions();
+        options.setFilenamePattern("*.tif");
+        options.setEveryone(UserRole.canViewMetadata);
+        options.setAuthenticated(UserRole.canViewMetadata);
+
+        service.setPermissions(options);
+        assertTrue(Files.exists(permissionsMappingPath));
+
+        List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
+        assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
+        assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("26", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertIterableEquals(Arrays.asList("27", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
     }
 
     private String mappingBody(String... rows) {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -587,7 +587,7 @@ public class PermissionsServiceTest {
     }
 
     @Test
-    public void setPermissionFilenameMatchingExtensionExistingIds() throws Exception {
+    public void setPermissionFilenameMatchingExtension() throws Exception {
         testHelper.indexExportData("mini_gilmer");
         testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
         writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "26,work,none,none"));
@@ -608,13 +608,13 @@ public class PermissionsServiceTest {
     }
 
     @Test
-    public void setPermissionFilenameMatchingFilenameExistingIds() throws Exception {
+    public void setPermissionFilenameMatchingPrefix() throws Exception {
         testHelper.indexExportData("mini_gilmer");
         testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
         writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "26,work,none,none"));
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
-        options.setFilenamePattern("276_*");
+        options.setFilenamePattern("276_1*");
         options.setEveryone(UserRole.canViewMetadata);
         options.setAuthenticated(UserRole.canViewMetadata);
 
@@ -625,7 +625,6 @@ public class PermissionsServiceTest {
         assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
         assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
         assertIterableEquals(Arrays.asList("26", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
-        assertIterableEquals(Arrays.asList("27", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
     }
 
     @Test
@@ -654,7 +653,7 @@ public class PermissionsServiceTest {
         writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "26,work,none,none"));
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
-        options.setFilenamePattern("276_*E.tif");
+        options.setFilenamePattern("276_1*E.tif");
         options.setEveryone(UserRole.canViewMetadata);
         options.setAuthenticated(UserRole.canViewMetadata);
 
@@ -665,7 +664,6 @@ public class PermissionsServiceTest {
         assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
         assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
         assertIterableEquals(Arrays.asList("26", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
-        assertIterableEquals(Arrays.asList("27", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
     }
 
     @Test
@@ -695,7 +693,7 @@ public class PermissionsServiceTest {
         writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata", "26,work,none,none"));
         Path permissionsMappingPath = project.getPermissionsPath();
         var options = new PermissionMappingOptions();
-        options.setFilenamePattern("*_?.tif");
+        options.setFilenamePattern("276_??3_E.tif");
         options.setEveryone(UserRole.canViewMetadata);
         options.setAuthenticated(UserRole.canViewMetadata);
 
@@ -704,9 +702,8 @@ public class PermissionsServiceTest {
 
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
         assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
-        assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
-        assertIterableEquals(Arrays.asList("26", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
-        assertIterableEquals(Arrays.asList("27", "work", "canViewMetadata", "canViewMetadata"), rows.get(3));
+        assertIterableEquals(Arrays.asList("26", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
+        assertIterableEquals(Arrays.asList("27", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/PermissionsServiceTest.java
@@ -566,7 +566,7 @@ public class PermissionsServiceTest {
     }
 
     @Test
-    public void setPermissionsFilenameMatchingExtensionNewIds() throws Exception{
+    public void setPermissionsFilenameMatchingExtension() throws Exception{
         testHelper.indexExportData("mini_gilmer");
         testHelper.populateSourceFiles("276_182_E.tif", "276_183_E.tif", "276_203_E.tif");
         writeCsv(mappingBody("default,,canViewMetadata,canViewMetadata"));
@@ -625,6 +625,7 @@ public class PermissionsServiceTest {
         assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
         assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
         assertIterableEquals(Arrays.asList("26", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertEquals(3, rows.size());
     }
 
     @Test
@@ -644,6 +645,7 @@ public class PermissionsServiceTest {
         List<CSVRecord> rows = listCsvRecords(permissionsMappingPath);
         assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
         assertIterableEquals(Arrays.asList("26", "work", "none", "none"), rows.get(1));
+        assertEquals(2, rows.size());
     }
 
     @Test
@@ -664,6 +666,7 @@ public class PermissionsServiceTest {
         assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
         assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
         assertIterableEquals(Arrays.asList("26", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertEquals(3, rows.size());
     }
 
     @Test
@@ -684,6 +687,7 @@ public class PermissionsServiceTest {
         assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
         assertIterableEquals(Arrays.asList("25", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
         assertIterableEquals(Arrays.asList("26", "work", "none", "none"), rows.get(2));
+        assertEquals(3, rows.size());
     }
 
     @Test
@@ -704,6 +708,7 @@ public class PermissionsServiceTest {
         assertIterableEquals(Arrays.asList("default", "", "canViewMetadata", "canViewMetadata"), rows.get(0));
         assertIterableEquals(Arrays.asList("26", "work", "canViewMetadata", "canViewMetadata"), rows.get(1));
         assertIterableEquals(Arrays.asList("27", "work", "canViewMetadata", "canViewMetadata"), rows.get(2));
+        assertEquals(3, rows.size());
     }
 
     @Test

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
@@ -38,7 +38,6 @@ import edu.unc.lib.boxc.migration.cdm.services.FindingAidReportService;
 import edu.unc.lib.boxc.migration.cdm.services.GroupMappingService;
 import edu.unc.lib.boxc.migration.cdm.services.PermissionsService;
 import edu.unc.lib.boxc.migration.cdm.services.StreamingMetadataService;
-import jakarta.ws.rs.HEAD;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
@@ -166,6 +165,7 @@ public class SipServiceHelper {
         findingAidReportService.setIndexService(cdmIndexService);
         permissionsService = new PermissionsService();
         permissionsService.setProject(project);
+        permissionsService.setSourceFileService(sourceFileService);
 
         Files.createDirectories(project.getExportPath());
     }


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4414](https://unclibrary.atlassian.net/browse/BXC-4414)

- add `--file-name-pattern` option that accepts a <pattern> and supports wildcarding
- initialize `SourceFileService` in `PermissionsCommand` and add setter to `Permissions Service`
- add `getFilenamePatternIds` and `wildcardToRegex` methods to `PermissionsService` to retrieve all ids with filenames that match the pattern
- add tests and update test helper