### PR TITLE
BXC-5682 generate ref id mappings from indexed ead to cdm metadata file

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/AspaceRefIdCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/AspaceRefIdCommand.java
@@ -83,6 +83,30 @@ public class AspaceRefIdCommand {
         }
     }
 
+    @Command(name = "generate_from_index",
+            description = {"Generate the optional aspace ref id mapping file for this project " +
+                    "using the indexed ead to cdm metadata file, cdm_index.db.",
+                    "A ref_id_mapping.csv template will be created for this project, " +
+                            "with record ids, hook ids, and aspace ref ids populated."})
+    public int generateFromIndex() throws Exception {
+        long start = System.nanoTime();
+
+        try {
+            initialize();
+            aspaceRefIdService.generateAspaceRefIdMappingFromCdmIndexDb();
+            outputLogger.info("Aspace ref id mapping generated for {} in {}s", project.getProjectName(),
+                    (System.nanoTime() - start) / 1e9);
+            return 0;
+        } catch (MigrationException | IllegalArgumentException e) {
+            outputLogger.info("Cannot generate aspace ref id mapping: {}", e.getMessage());
+            return 1;
+        } catch (Exception e) {
+            log.error("Failed to generate aspace ref id template", e);
+            outputLogger.info("Failed to generate aspace ref id template: {}", e.getMessage(), e);
+            return 1;
+        }
+    }
+
     @Command(name = "validate",
             description = {"Validate the aspace ref id mappings for this project"})
     public int validate(@Option(names = { "-f", "--force"},

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdService.java
@@ -110,7 +110,7 @@ public class AspaceRefIdService {
 
         if (!hasProjectContriDescriAspaceRefIdFields()) {
             throw new InvalidProjectStateException("Project has no contri field named hook id, " +
-                    "and/or descri field named collection number, and/or refid field named aspace ref id");
+                    "and/or descri field named collection number, and/or ref_id field named ref_id");
         }
 
         try (BufferedWriter writer = Files.newBufferedWriter(getMappingPath());
@@ -296,7 +296,7 @@ public class AspaceRefIdService {
                         && value.equalsIgnoreCase(FindingAidService.COLLECTION_NUMBER_FIELD_DESC)) {
                     hasDescri = true;
                 } else if (key.equalsIgnoreCase(REF_ID_FIELD)
-                    && value.equalsIgnoreCase("aspace ref id")) {
+                    && value.equalsIgnoreCase("ref_id")) {
                     hasAspaceRefId = true;
                 }
             }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdService.java
@@ -40,7 +40,9 @@ public class AspaceRefIdService {
     private CdmIndexService indexService;
     private Path hookIdRefIdMapPath;
     private Boolean projectHasContriAndDescri = null;
+    private Boolean projectHasContriDescriAspaceRefId = null;
 
+    public static final String REF_ID_FIELD = "refid";
     public static final String[] HOOKID_REFID_CSV_HEADERS = {"cache_hookid", "normalized_cache_hookid", "collid",
             "ref_id", "ao_title", "tc_type", "tc_indicator", "sc_type", "sc_indicator", "gc_type", "gc_indicator",
             "aspace_hookid", "cdm_alias"};
@@ -92,6 +94,57 @@ public class AspaceRefIdService {
                 } else {
                     csvPrinter.printRecord(recordId, hookId, null);
                 }
+            }
+        }
+
+        setUpdatedDate(Instant.now());
+    }
+
+    /**
+     * Generate the aspace ref id mapping using the indexed ead to cdm metadata file (cdm_index.db)
+     * Record ids, hook ids, and ref ids populated
+     * @throws Exception
+     */
+    public void generateAspaceRefIdMappingFromCdmIndexDb() throws IOException {
+        assertProjectStateValid();
+
+        if (!hasProjectContriDescriAspaceRefIdFields()) {
+            throw new InvalidProjectStateException("Project has no contri field named hook id, " +
+                    "and/or descri field named collection number, and/or refid field named aspace ref id");
+        }
+
+        try (BufferedWriter writer = Files.newBufferedWriter(getMappingPath());
+             var csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.withHeader(AspaceRefIdInfo.CSV_HEADERS))) {
+            String query = "select " + CdmFieldInfo.CDM_ID + "," + FindingAidService.DESCRI_FIELD + ","
+                    + FindingAidService.CONTRI_FIELD + "," + REF_ID_FIELD
+                    + " from " + CdmIndexService.TB_NAME
+                    + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_GROUPED_WORK + "'"
+                    + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_COMPOUND_OBJECT + "'"
+                    + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_DOCUMENT_PDF + "'"
+                    + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " is null"
+                    + " and " + CdmIndexService.PARENT_ID_FIELD + " is null"
+                    + " and " + FindingAidService.DESCRI_FIELD + " is not null"
+                    + " and " + FindingAidService.CONTRI_FIELD + " is not null";
+
+            getIndexService();
+            try (Connection conn = indexService.openDbConnection()) {
+                var stmt = conn.createStatement();
+                var rs = stmt.executeQuery(query);
+                while (rs.next()) {
+                    // if dmrecord, descri, contri, and ref_id fields are not blank,
+                    // add dmrecord, descri_contri (hook id when combined), and ref_id to aspace ref id mapping
+                    var dmrecord = rs.getString(1);
+                    var descri = rs.getString(2);
+                    var contri = rs.getString(3);
+                    var refId = rs.getString(4);
+                    if (!dmrecord.isBlank() && !descri.isBlank() && !contri.isBlank() & !refId.isBlank()) {
+                        // remove -v from descri for matching purposes
+                        csvPrinter.printRecord(dmrecord,
+                            descri.replace("-z", "") + "_" + contri, refId);
+                    }
+                }
+            } catch (SQLException e) {
+                throw new MigrationException("Error interacting with export index", e);
             }
         }
 
@@ -217,6 +270,40 @@ public class AspaceRefIdService {
             projectHasContriAndDescri = hasContri && hasDescri;
         }
         return projectHasContriAndDescri;
+    }
+
+    private boolean hasProjectContriDescriAspaceRefIdFields() {
+        if (projectHasContriDescriAspaceRefId == null) {
+            // check if project has contri field named hook id, descri field named collection number,
+            // and refid field named aspace ref id
+            boolean hasContri = false;
+            boolean hasDescri = false;
+            boolean hasAspaceRefId = false;
+            fieldService.validateFieldsFile(project);
+            CdmFieldInfo fieldInfo = fieldService.loadFieldsFromProject(project);
+            Map<String, String> fields = fieldInfo.getFields().stream()
+                    .filter(f -> !f.getSkipExport())
+                    .collect(Collectors.toMap(CdmFieldInfo.CdmFieldEntry::getNickName,
+                            CdmFieldInfo.CdmFieldEntry::getDescription));
+
+            for (Map.Entry<String, String> entry : fields.entrySet()) {
+                String key = entry.getKey();
+                String value = entry.getValue();
+                if (key.equalsIgnoreCase(FindingAidService.CONTRI_FIELD)
+                        && value.equalsIgnoreCase(FindingAidService.HOOK_ID_FIELD_DESC)) {
+                    hasContri = true;
+                } else if (key.equalsIgnoreCase(FindingAidService.DESCRI_FIELD)
+                        && value.equalsIgnoreCase(FindingAidService.COLLECTION_NUMBER_FIELD_DESC)) {
+                    hasDescri = true;
+                } else if (key.equalsIgnoreCase(REF_ID_FIELD)
+                    && value.equalsIgnoreCase("aspace ref id")) {
+                    hasAspaceRefId = true;
+                }
+            }
+
+            projectHasContriDescriAspaceRefId = hasContri && hasDescri && hasAspaceRefId;
+        }
+        return projectHasContriDescriAspaceRefId;
     }
 
     /**

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdService.java
@@ -42,7 +42,7 @@ public class AspaceRefIdService {
     private Boolean projectHasContriAndDescri = null;
     private Boolean projectHasContriDescriAspaceRefId = null;
 
-    public static final String REF_ID_FIELD = "refid";
+    public static final String REF_ID_FIELD = "ref_id";
     public static final String[] HOOKID_REFID_CSV_HEADERS = {"cache_hookid", "normalized_cache_hookid", "collid",
             "ref_id", "ao_title", "tc_type", "tc_indicator", "sc_type", "sc_indicator", "gc_type", "gc_indicator",
             "aspace_hookid", "cdm_alias"};
@@ -275,7 +275,7 @@ public class AspaceRefIdService {
     private boolean hasProjectContriDescriAspaceRefIdFields() {
         if (projectHasContriDescriAspaceRefId == null) {
             // check if project has contri field named hook id, descri field named collection number,
-            // and refid field named aspace ref id
+            // and ref_id field named aspace ref id
             boolean hasContri = false;
             boolean hasDescri = false;
             boolean hasAspaceRefId = false;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdService.java
@@ -40,8 +40,9 @@ public class AspaceRefIdService {
     private CdmIndexService indexService;
     private Path hookIdRefIdMapPath;
     private Boolean projectHasContriAndDescri = null;
-    private Boolean projectHasContriDescriAspaceRefId = null;
+    private Boolean projectHasHookIdRefId = null;
 
+    public static final String HOOK_ID_FIELD = "hook_id";
     public static final String REF_ID_FIELD = "ref_id";
     public static final String[] HOOKID_REFID_CSV_HEADERS = {"cache_hookid", "normalized_cache_hookid", "collid",
             "ref_id", "ao_title", "tc_type", "tc_indicator", "sc_type", "sc_indicator", "gc_type", "gc_indicator",
@@ -108,15 +109,14 @@ public class AspaceRefIdService {
     public void generateAspaceRefIdMappingFromCdmIndexDb() throws IOException {
         assertProjectStateValid();
 
-        if (!hasProjectContriDescriAspaceRefIdFields()) {
-            throw new InvalidProjectStateException("Project has no contri field named hook id, " +
-                    "and/or descri field named collection number, and/or ref_id field named ref_id");
+        if (!hasProjectHookIdRefIdFields()) {
+            throw new InvalidProjectStateException("Project has no hook_id field named hook_id " +
+                    "and/or ref_id field named ref_id");
         }
 
         try (BufferedWriter writer = Files.newBufferedWriter(getMappingPath());
              var csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.withHeader(AspaceRefIdInfo.CSV_HEADERS))) {
-            String query = "select " + CdmFieldInfo.CDM_ID + "," + FindingAidService.DESCRI_FIELD + ","
-                    + FindingAidService.CONTRI_FIELD + "," + REF_ID_FIELD
+            String query = "select " + CdmFieldInfo.CDM_ID + "," + HOOK_ID_FIELD + "," + REF_ID_FIELD
                     + " from " + CdmIndexService.TB_NAME
                     + " where (" + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_GROUPED_WORK + "'"
                     + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_COMPOUND_OBJECT + "'"
@@ -131,16 +131,13 @@ public class AspaceRefIdService {
                 var stmt = conn.createStatement();
                 var rs = stmt.executeQuery(query);
                 while (rs.next()) {
-                    // if dmrecord, descri, contri, and ref_id fields are not blank,
-                    // add dmrecord, descri_contri (hook id when combined), and ref_id to aspace ref id mapping
+                    // if dmrecord, hook_id, and ref_id fields are not blank,
+                    // add dmrecord, hook_id, and ref_id to aspace ref id mapping
                     var dmrecord = rs.getString(1);
-                    var descri = rs.getString(2);
-                    var contri = rs.getString(3);
-                    var refId = rs.getString(4);
-                    if (!dmrecord.isBlank() && !descri.isBlank() && !contri.isBlank() & !refId.isBlank()) {
-                        // remove -v from descri for matching purposes
-                        csvPrinter.printRecord(dmrecord,
-                            descri.replace("-z", "") + "_" + contri, refId);
+                    var hookId = rs.getString(2);
+                    var refId = rs.getString(3);
+                    if (!dmrecord.isBlank() && !hookId.isBlank() & !refId.isBlank()) {
+                        csvPrinter.printRecord(dmrecord, hookId, refId);
                     }
                 }
             } catch (SQLException e) {
@@ -272,13 +269,11 @@ public class AspaceRefIdService {
         return projectHasContriAndDescri;
     }
 
-    private boolean hasProjectContriDescriAspaceRefIdFields() {
-        if (projectHasContriDescriAspaceRefId == null) {
-            // check if project has contri field named hook id, descri field named collection number,
-            // and ref_id field named aspace ref id
-            boolean hasContri = false;
-            boolean hasDescri = false;
-            boolean hasAspaceRefId = false;
+    private boolean hasProjectHookIdRefIdFields() {
+        if (projectHasHookIdRefId == null) {
+            // check if project has hook_id field named hook_id and ref_id field named ref_id
+            boolean hasHookId = false;
+            boolean hasRefId = false;
             fieldService.validateFieldsFile(project);
             CdmFieldInfo fieldInfo = fieldService.loadFieldsFromProject(project);
             Map<String, String> fields = fieldInfo.getFields().stream()
@@ -289,21 +284,18 @@ public class AspaceRefIdService {
             for (Map.Entry<String, String> entry : fields.entrySet()) {
                 String key = entry.getKey();
                 String value = entry.getValue();
-                if (key.equalsIgnoreCase(FindingAidService.CONTRI_FIELD)
-                        && value.equalsIgnoreCase(FindingAidService.HOOK_ID_FIELD_DESC)) {
-                    hasContri = true;
-                } else if (key.equalsIgnoreCase(FindingAidService.DESCRI_FIELD)
-                        && value.equalsIgnoreCase(FindingAidService.COLLECTION_NUMBER_FIELD_DESC)) {
-                    hasDescri = true;
+                if (key.equalsIgnoreCase(HOOK_ID_FIELD)
+                        && value.equalsIgnoreCase(HOOK_ID_FIELD)) {
+                    hasHookId = true;
                 } else if (key.equalsIgnoreCase(REF_ID_FIELD)
                     && value.equalsIgnoreCase("ref_id")) {
-                    hasAspaceRefId = true;
+                    hasRefId = true;
                 }
             }
 
-            projectHasContriDescriAspaceRefId = hasContri && hasDescri && hasAspaceRefId;
+            projectHasHookIdRefId = hasHookId && hasRefId;
         }
-        return projectHasContriDescriAspaceRefId;
+        return projectHasHookIdRefId;
     }
 
     /**

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdService.java
@@ -118,10 +118,10 @@ public class AspaceRefIdService {
             String query = "select " + CdmFieldInfo.CDM_ID + "," + FindingAidService.DESCRI_FIELD + ","
                     + FindingAidService.CONTRI_FIELD + "," + REF_ID_FIELD
                     + " from " + CdmIndexService.TB_NAME
-                    + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_GROUPED_WORK + "'"
+                    + " where (" + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_GROUPED_WORK + "'"
                     + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_COMPOUND_OBJECT + "'"
                     + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_DOCUMENT_PDF + "'"
-                    + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " is null"
+                    + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " is null )"
                     + " and " + CdmIndexService.PARENT_ID_FIELD + " is null"
                     + " and " + FindingAidService.DESCRI_FIELD + " is not null"
                     + " and " + FindingAidService.CONTRI_FIELD + " is not null";
@@ -164,10 +164,10 @@ public class AspaceRefIdService {
         List<String> ids = new ArrayList<>();
         // for all work objects in the project (grouped works, compound objects, and single file works)
         String query = "select " + CdmFieldInfo.CDM_ID + " from " + CdmIndexService.TB_NAME
-                + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_GROUPED_WORK + "'"
+                + " where (" + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_GROUPED_WORK + "'"
                 + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_COMPOUND_OBJECT + "'"
                 + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_DOCUMENT_PDF + "'"
-                + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " is null"
+                + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " is null )"
                 + " and " + CdmIndexService.PARENT_ID_FIELD + " is null";
 
         getIndexService();
@@ -193,10 +193,10 @@ public class AspaceRefIdService {
         String query = "select " + CdmFieldInfo.CDM_ID + "," + FindingAidService.DESCRI_FIELD + ","
                 + FindingAidService.CONTRI_FIELD
                 + " from " + CdmIndexService.TB_NAME
-                + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_GROUPED_WORK + "'"
+                + " where (" + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_GROUPED_WORK + "'"
                 + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_COMPOUND_OBJECT + "'"
                 + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_DOCUMENT_PDF + "'"
-                + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " is null"
+                + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " is null )"
                 + " and " + CdmIndexService.PARENT_ID_FIELD + " is null"
                 + " and " + FindingAidService.DESCRI_FIELD + " is not null"
                 + " and " + FindingAidService.CONTRI_FIELD + " is not null";

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdService.java
@@ -123,8 +123,8 @@ public class AspaceRefIdService {
                     + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_DOCUMENT_PDF + "'"
                     + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " is null )"
                     + " and " + CdmIndexService.PARENT_ID_FIELD + " is null"
-                    + " and " + FindingAidService.DESCRI_FIELD + " is not null"
-                    + " and " + FindingAidService.CONTRI_FIELD + " is not null";
+                    + " and " + HOOK_ID_FIELD + " is not null"
+                    + " and " + REF_ID_FIELD + " is not null";
 
             getIndexService();
             try (Connection conn = indexService.openDbConnection()) {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AspaceRefIdCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AspaceRefIdCommandIT.java
@@ -98,6 +98,21 @@ public class AspaceRefIdCommandIT extends AbstractCommandIT {
     }
 
     @Test
+    public void generateFromIndexAspaceRefIdMappingSucceedsTest() throws Exception {
+        indexExportSamples();
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "--env-config", chompbConfigPath,
+                "aspace_ref_id", "generate_from_index"};
+        executeExpectSuccess(args);
+
+        assertTrue(Files.exists(project.getAspaceRefIdMappingPath()));
+
+        assertUpdatedDatePresent();
+    }
+
+    @Test
     public void validateValidTest() throws Exception {
         indexExportSamples();
         writeCsv(mappingBody("25,03883_folder_9,fcee5fc2bb61effc8836498a8117b05d"));

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdServiceTest.java
@@ -223,7 +223,7 @@ public class AspaceRefIdServiceTest {
             service.generateAspaceRefIdMappingFromCdmIndexDb();
         });
         String expectedMessage = "Project has no contri field named hook id, " +
-            "and/or descri field named collection number, and/or refid field named aspace ref id";
+            "and/or descri field named collection number, and/or ref_id field named ref_id";
         String actualMessage = exception.getMessage();
 
         assertTrue(actualMessage.contains(expectedMessage));

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdServiceTest.java
@@ -222,8 +222,7 @@ public class AspaceRefIdServiceTest {
         Exception exception = assertThrows(InvalidProjectStateException.class, () -> {
             service.generateAspaceRefIdMappingFromCdmIndexDb();
         });
-        String expectedMessage = "Project has no contri field named hook id, " +
-            "and/or descri field named collection number, and/or ref_id field named ref_id";
+        String expectedMessage = "Project has no hook_id field named hook_id, and/or ref_id field named ref_id";
         String actualMessage = exception.getMessage();
 
         assertTrue(actualMessage.contains(expectedMessage));

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdServiceTest.java
@@ -222,7 +222,7 @@ public class AspaceRefIdServiceTest {
         Exception exception = assertThrows(InvalidProjectStateException.class, () -> {
             service.generateAspaceRefIdMappingFromCdmIndexDb();
         });
-        String expectedMessage = "Project has no hook_id field named hook_id, and/or ref_id field named ref_id";
+        String expectedMessage = "Project has no hook_id field named hook_id and/or ref_id field named ref_id";
         String actualMessage = exception.getMessage();
 
         assertTrue(actualMessage.contains(expectedMessage));

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdServiceTest.java
@@ -194,6 +194,41 @@ public class AspaceRefIdServiceTest {
         assertTrue(actualMessage.contains(expectedMessage));
     }
 
+    @Test
+    public void generateFromCdmIndexDbTest() throws Exception {
+        testHelper.indexExportData(Paths.get("src/test/resources/findingaid_fields.csv"), "03883");
+        service.generateAspaceRefIdMappingFromCdmIndexDb();
+
+        assertTrue(Files.exists(project.getAspaceRefIdMappingPath()));
+        try (CSVParser csvParser = parser()) {
+            List<CSVRecord> rows = csvParser.getRecords();
+            assertEquals("0", rows.get(0).get(AspaceRefIdInfo.RECORD_ID_FIELD));
+            assertEquals("03883_folder_5", rows.get(0).get(AspaceRefIdInfo.HOOK_ID_FIELD));
+            assertEquals("8578708eda77e378b3a844a2166b815b", rows.get(0).get(AspaceRefIdInfo.REF_ID_FIELD));
+            assertEquals("548", rows.get(1).get(AspaceRefIdInfo.RECORD_ID_FIELD));
+            assertEquals("03883_folder_9", rows.get(1).get(AspaceRefIdInfo.HOOK_ID_FIELD));
+            assertEquals("4c1196b46a06b21b1184fba0de1e84bd", rows.get(1).get(AspaceRefIdInfo.REF_ID_FIELD));
+            assertEquals("549", rows.get(2).get(AspaceRefIdInfo.RECORD_ID_FIELD));
+            assertEquals("03883_folder_9", rows.get(2).get(AspaceRefIdInfo.HOOK_ID_FIELD));
+            assertEquals("4c1196b46a06b21b1184fba0de1e84bd", rows.get(2).get(AspaceRefIdInfo.REF_ID_FIELD));
+            assertEquals(3, rows.size());
+        }
+    }
+
+    @Test
+    public void generateFromCdmIndexDbNoAspaceRefIdTest() throws Exception {
+        testHelper.indexExportData(Paths.get("src/test/resources/monograph_fields.csv"), "monograph");
+
+        Exception exception = assertThrows(InvalidProjectStateException.class, () -> {
+            service.generateAspaceRefIdMappingFromCdmIndexDb();
+        });
+        String expectedMessage = "Project has no contri field named hook id, " +
+            "and/or descri field named collection number, and/or refid field named aspace ref id";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
     private CSVParser parser() throws IOException {
         Reader reader = Files.newBufferedReader(project.getAspaceRefIdMappingPath());
         CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT

--- a/src/test/resources/descriptions/03883/index/description/desc.all
+++ b/src/test/resources/descriptions/03883/index/description/desc.all
@@ -65,7 +65,7 @@
 <duracl></duracl>
 <fullrs>Volume1/03883_0005_0025.tif</fullrs>
 <find>231.jp2</find>
-<refid>8578708eda77e378b3a844a2166b815b</refid>
+<ref_id>8578708eda77e378b3a844a2166b815b</ref_id>
 <dmaccess></dmaccess>
 <dmimage></dmimage>
 <dmad1></dmad1>
@@ -141,7 +141,7 @@
 <duracl></duracl>
 <fullrs>Volume1/03883_0009_0051.tif</fullrs>
 <find>711.jp2</find>
-<refid>4c1196b46a06b21b1184fba0de1e84bd</refid>
+<ref_id>4c1196b46a06b21b1184fba0de1e84bd</ref_id>
 <dmaccess></dmaccess>
 <dmimage></dmimage>
 <dmad1></dmad1>
@@ -217,7 +217,7 @@
 <duracl></duracl>
 <fullrs>Volume1/03883_0009_0051.tif</fullrs>
 <find>711.jp2</find>
-<refid>4c1196b46a06b21b1184fba0de1e84bd</refid>
+<ref_id>4c1196b46a06b21b1184fba0de1e84bd</ref_id>
 <dmaccess></dmaccess>
 <dmimage></dmimage>
 <dmad1></dmad1>

--- a/src/test/resources/descriptions/03883/index/description/desc.all
+++ b/src/test/resources/descriptions/03883/index/description/desc.all
@@ -65,6 +65,7 @@
 <duracl></duracl>
 <fullrs>Volume1/03883_0005_0025.tif</fullrs>
 <find>231.jp2</find>
+<refid>8578708eda77e378b3a844a2166b815b</refid>
 <dmaccess></dmaccess>
 <dmimage></dmimage>
 <dmad1></dmad1>
@@ -140,6 +141,7 @@
 <duracl></duracl>
 <fullrs>Volume1/03883_0009_0051.tif</fullrs>
 <find>711.jp2</find>
+<refid>4c1196b46a06b21b1184fba0de1e84bd</refid>
 <dmaccess></dmaccess>
 <dmimage></dmimage>
 <dmad1></dmad1>
@@ -215,6 +217,7 @@
 <duracl></duracl>
 <fullrs>Volume1/03883_0009_0051.tif</fullrs>
 <find>711.jp2</find>
+<refid>4c1196b46a06b21b1184fba0de1e84bd</refid>
 <dmaccess></dmaccess>
 <dmimage></dmimage>
 <dmad1></dmad1>

--- a/src/test/resources/descriptions/03883/index/description/desc.all
+++ b/src/test/resources/descriptions/03883/index/description/desc.all
@@ -65,6 +65,7 @@
 <duracl></duracl>
 <fullrs>Volume1/03883_0005_0025.tif</fullrs>
 <find>231.jp2</find>
+<hook_id>03883_folder_5</hook_id>
 <ref_id>8578708eda77e378b3a844a2166b815b</ref_id>
 <dmaccess></dmaccess>
 <dmimage></dmimage>
@@ -141,6 +142,7 @@
 <duracl></duracl>
 <fullrs>Volume1/03883_0009_0051.tif</fullrs>
 <find>711.jp2</find>
+<hook_id>03883_folder_9</hook_id>
 <ref_id>4c1196b46a06b21b1184fba0de1e84bd</ref_id>
 <dmaccess></dmaccess>
 <dmimage></dmimage>
@@ -217,6 +219,7 @@
 <duracl></duracl>
 <fullrs>Volume1/03883_0009_0051.tif</fullrs>
 <find>711.jp2</find>
+<hook_id>03883_folder_9</hook_id>
 <ref_id>4c1196b46a06b21b1184fba0de1e84bd</ref_id>
 <dmaccess></dmaccess>
 <dmimage></dmimage>

--- a/src/test/resources/findingaid_fields.csv
+++ b/src/test/resources/findingaid_fields.csv
@@ -60,4 +60,4 @@ dmmodified,dmmodified,Date modified,false,y,n,y,n,
 dmrecord,dmrecord,CONTENTdm number,false,y,n,y,n,
 find,find,CONTENTdm file name,false,y,n,y,n,
 groupa,groupa,Group A,false,n,y,n,n,descri
-refid,refid,Aspace Ref Id,false,n,y,n,n,
+ref_id,ref_id,Aspace Ref Id,false,n,y,n,n,

--- a/src/test/resources/findingaid_fields.csv
+++ b/src/test/resources/findingaid_fields.csv
@@ -60,4 +60,4 @@ dmmodified,dmmodified,Date modified,false,y,n,y,n,
 dmrecord,dmrecord,CONTENTdm number,false,y,n,y,n,
 find,find,CONTENTdm file name,false,y,n,y,n,
 groupa,groupa,Group A,false,n,y,n,n,descri
-ref_id,ref_id,Aspace Ref Id,false,n,y,n,n,
+ref_id,ref_id,ref_id,false,n,y,n,n,

--- a/src/test/resources/findingaid_fields.csv
+++ b/src/test/resources/findingaid_fields.csv
@@ -60,3 +60,4 @@ dmmodified,dmmodified,Date modified,false,y,n,y,n,
 dmrecord,dmrecord,CONTENTdm number,false,y,n,y,n,
 find,find,CONTENTdm file name,false,y,n,y,n,
 groupa,groupa,Group A,false,n,y,n,n,descri
+refid,refid,Aspace Ref Id,false,n,y,n,n,

--- a/src/test/resources/findingaid_fields.csv
+++ b/src/test/resources/findingaid_fields.csv
@@ -60,4 +60,5 @@ dmmodified,dmmodified,Date modified,false,y,n,y,n,
 dmrecord,dmrecord,CONTENTdm number,false,y,n,y,n,
 find,find,CONTENTdm file name,false,y,n,y,n,
 groupa,groupa,Group A,false,n,y,n,n,descri
+hook_id,hook_id,hook_id,false,n,y,n,y,
 ref_id,ref_id,ref_id,false,n,y,n,n,


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-5682](https://unclibrary.atlassian.net/browse/BXC-5682)

- add `aspace_ref_id generate_from_index` command
- add `generateAspaceRefIdMappingFromCdmIndexDb` and `hasProjectContriDescriAspaceRefIdFields` methods to `AspaceRefIdService`
- update tests and test resources